### PR TITLE
13: No need to construct ApplicationContext through singleton

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
@@ -1,8 +1,6 @@
 /**
  * ApplicationContext class works similar to a factory. The idea is to use this class in conjunction
- * with annotations that will be used to inject the implementations. There is the option of using
- * the getImplementation method to get an implementation of a class. This is a double checked
- * locking singleton class.
+ * with annotations that will be used to inject the implementations.
  */
 package gov.hhs.cdc.trustedintermediary.context;
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
@@ -23,15 +23,4 @@ public class ApplicationContext {
     public static <T> T getImplementation(Class<T> clazz) {
         return (T) OBJECT_MAP.get(clazz);
     }
-
-    public static ApplicationContext getInstance() {
-        if (applicationContext == null) {
-            synchronized (ApplicationContext.class) {
-                if (applicationContext == null) {
-                    applicationContext = new ApplicationContext();
-                }
-            }
-        }
-        return applicationContext;
-    }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
@@ -4,12 +4,12 @@
  */
 package gov.hhs.cdc.trustedintermediary.context;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ApplicationContext {
 
-    private static final Map<Class<?>, Object> OBJECT_MAP = new HashMap<>();
+    private static final Map<Class<?>, Object> OBJECT_MAP = new ConcurrentHashMap<>();
 
     private ApplicationContext() {}
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/context/ApplicationContext.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 public class ApplicationContext {
 
-    private static volatile ApplicationContext applicationContext = null;
     private static final Map<Class<?>, Object> OBJECT_MAP = new HashMap<>();
 
     private ApplicationContext() {}

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/ApplicationContextTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/ApplicationContextTest.groovy
@@ -3,25 +3,13 @@ package gov.hhs.cdc.trustedintermediary.context
 import spock.lang.Specification
 
 class ApplicationContextTest extends Specification {
-    def "singleton object test"() {
-        setup:
-        def contextA = ApplicationContext.getInstance()
-        def contextB = ApplicationContext.getInstance()
-
-        when:
-        def result = contextA == contextB
-
-        then:
-        result == true
-    }
 
     def "implementation retrieval test"() {
         setup:
-        def context = ApplicationContext.getInstance()
         def result = "DogCow"
-        context.register(String.class, "DogCow")
+        ApplicationContext.register(String.class, "DogCow")
 
         expect:
-        result == context.getImplementation(String.class)
+        result == ApplicationContext.getImplementation(String.class)
     }
 }


### PR DESCRIPTION
# No need to construct ApplicationContext through singleton

We actually don't need to construct the `ApplicationContext`.  All of its fields and methods are `static`.

## Issue

#13.
