### PR TITLE
77: Report Code Coverage to Sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: ./gradlew spotlessCheck
 
       - name: Sonar
-        run: ./gradlew app:build app:sonar --info
+        run: ./gradlew app:build app:jacocoTestReport app:sonar --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,10 @@ jacocoTestCoverageVerification {
 }
 
 jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, excludes: test.jacoco.excludes)


### PR DESCRIPTION
# AReport Code Coverage to Sonar

We need to enable JaCoCo's XML report so we can send it to Sonar.

## Issue

#77.