### PR TITLE
77: Sonar to Ignore Coverage the Same as JaCoCo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,5 +128,6 @@ sonarqube {
         property "sonar.projectKey", "trusted-intermediary"
         property "sonar.organization", "cdcgov"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.exclusions", test.jacoco.excludes
     }
 }


### PR DESCRIPTION
# Sonar to Ignore Coverage the Same as JaCoCo

Want the code coverage in Sonar to stay the same as JaCoCo.

## Issue

#77.
