### PR TITLE
77: Set the Project Name in Sonar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,7 @@ spotless {
     }
 }
 
-sonarqube {
+sonar {
     properties {
         property "sonar.projectName", "Trusted Intermediary"
         property "sonar.projectKey", "trusted-intermediary"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,7 @@ spotless {
 
 sonarqube {
     properties {
+        property "sonar.projectName", "Trusted Intermediary"
         property "sonar.projectKey", "trusted-intermediary"
         property "sonar.organization", "cdcgov"
         property "sonar.host.url", "https://sonarcloud.io"


### PR DESCRIPTION
# Set the Project Name in Sonar

The Sonar Gradle plugin decides to rename the project in SonarCloud to `app`.  That's dumb.  So we are going to force Sonar to use the real name.

## Issue

#77.