### PR TITLE
77: Stop Trusted Intermediary On Bootstrap Failure

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -24,6 +24,7 @@ public class App {
             registerDomains(app);
             ApplicationContext.injectRegisteredImplementations();
         } catch (Exception exception) {
+            // Not using the logger because boostrapping has failed.
             System.err.println(
                     "Exception occurred during bootstrap of Trusted Intermediary!  Exiting!");
             exception.printStackTrace();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -17,11 +17,18 @@ public class App {
     public static void main(String[] args) {
         var app = Javalin.create().start(8080);
 
-        app.get("/health", ctx -> ctx.result("Operational"));
+        try {
+            app.get("/health", ctx -> ctx.result("Operational"));
 
-        registerClasses();
-        registerDomains(app);
-        ApplicationContext.injectRegisteredImplementations();
+            registerClasses();
+            registerDomains(app);
+            ApplicationContext.injectRegisteredImplementations();
+        } catch (Exception exception) {
+            System.err.println(
+                    "Exception occurred during bootstrap of Trusted Intermediary!  Exiting!");
+            exception.printStackTrace();
+            System.exit(1);
+        }
     }
 
     private static void registerDomains(Javalin app) {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -25,7 +25,7 @@ public class App {
             ApplicationContext.injectRegisteredImplementations();
         } catch (Exception exception) {
             // Not using the logger because boostrapping has failed.
-            System.err.println(
+            System.out.println(
                     "Exception occurred during bootstrap of Trusted Intermediary!  Exiting!");
             exception.printStackTrace(System.out);
             System.exit(1);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -27,7 +27,7 @@ public class App {
             // Not using the logger because boostrapping has failed.
             System.err.println(
                     "Exception occurred during bootstrap of Trusted Intermediary!  Exiting!");
-            exception.printStackTrace();
+            exception.printStackTrace(System.out);
             System.exit(1);
         }
     }


### PR DESCRIPTION
# Stop Trusted Intermediary On Bootstrap Failure

Exit the application if there is a failure on bootstrap of TI.  Depending on the orchestration deployment tool, it will roll back the deployment because TI will fail the health check due to it not running.

## Issue

#77.