### PR TITLE
End-To-End Runs Using JAR File

### DIFF
--- a/e2e-execute.sh
+++ b/e2e-execute.sh
@@ -2,15 +2,18 @@
 set -e
 
 start_api() {
+  DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  SUB_DIR="app/build/libs"
+  JAR_NAME="app-all.jar"
     echo 'Starting API'
-    ./gradlew --no-daemon app:clean app:run &
+    java -jar "${DIR}"/"${SUB_DIR}"/"${JAR_NAME}" > /dev/null &
     export API_PID="${!}"
     echo "API starting at PID ${API_PID}"
 }
 
 wait_for_api() {
     attempt_counter=0
-    max_attempts=36
+    max_attempts=5
 
     until curl --output /dev/null --silent --head --fail http://localhost:8080/health; do
         if [ "${attempt_counter}" -eq "${max_attempts}" ];then

--- a/e2e-execute.sh
+++ b/e2e-execute.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
+shadowJar() {
+  echo "Running shadowJar..."
+  ./gradlew shadowJar
+}
+
 start_api() {
-  DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  SUB_DIR="app/build/libs"
-  JAR_NAME="app-all.jar"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SUB_DIR="app/build/libs"
+    JAR_NAME="app-all.jar"
     echo 'Starting API'
     java -jar "${DIR}"/"${SUB_DIR}"/"${JAR_NAME}" > /dev/null &
     export API_PID="${!}"
@@ -39,6 +44,7 @@ cleanup() {
 }
 
 trap cleanup EXIT  # Run the cleanup function on exit
+shadowJar
 start_api
 wait_for_api
 run_tests


### PR DESCRIPTION
# E2E Test Runs Using JAR

This PR addresses the issue where the app would work correctly while performing data retrieval (File Stream), running in gradle, but it would fail when running in a container or from a JAR file. This was due to the data having different formats (zip) at time of access. 

Gradle come with tools that decode these formats so it would automatically use them, that's why it was not failing when using gradle to run the app. On the other hand, changes were made such as using output streams instead of file stream, in order to prevent the data from getting serialized with a different format.

In order to prevent this from happening in the future, it is a good choice to run the application using the JAR file. Running the application using the JAR file will ensure that the same bug doesn't happen again.

## Testing
1. run `e2e-execute.sh`
2. make sure the test passes

You can go into the e2e-execute.sh file and add `-x` for debugging, at the top, in the `set` command. 
It should look like this: `set -e -x`

## Issue
#77.

