### PR TITLE
FHIR Utility Dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,10 @@
         "groupName": "patch dependencies",
         "groupSlug": "all-patch",
         "stabilityDays": 0
-    }
+    },
+    "packageRules": [{
+            "matchPackageNames": ["ca.uhn.hapi.fhir:org.hl7.fhir.utilities"],
+            "allowedVersions": "!/5\\.6\\.881/"
+        }
+    ]
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.2.5'
     implementation 'org.fhir:ucum:1.0.3'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.2'
+    implementation 'ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.93'
 
     testImplementation 'org.apache.groovy:groovy:4.0.8'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,6 @@ dependencies {
 
     //fhir
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:6.2.5'
-    implementation 'ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.93'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.2.5'
     implementation 'org.fhir:ucum:1.0.3'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.2'


### PR DESCRIPTION
# FHIR Utility Dependency

`ca.uhn.hapi.fhir:org.hl7.fhir.utilities` released a `5.6.881` release which broke the semantic versioning schema.  They probably meant `5.6.88.1`.  So, now to get the latest version, we need to tell Renovatebot to ignore `5.6.881`.

## Issue

#77.