### PR TITLE
Adding a new issue template for non-story related backlog tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/backlog_task.md
+++ b/.github/ISSUE_TEMPLATE/backlog_task.md
@@ -1,0 +1,24 @@
+---
+name: Backlog Task
+about: Non-story related task, typically foundational.  Can be used for both research and engineering tasks.
+title: ''
+labels: foundational
+assignees: ''
+
+---
+
+# Backlog Task
+
+Add a title and description here
+
+## Completion Criteria
+
+- [ ] What is the criteria for calling this task complete?
+
+## Tasks
+
+- [ ] What tasks need to be done to fulfill the completion criteria?
+
+### Other notes
+
+- Any other notes to help clarify this task for the team


### PR DESCRIPTION
# Backlog task template

A new github issue template has been created for non-story related backlog tasks

## Issue

N/A
