### PR TITLE
79: Skeleton

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ tasks.named('test') {
             '**/javalin/App*',
             '**/jackson/Jackson*',
             '**/slf4j/Slf4jLogger*',
-            '**/hapi/HapiFhirImplementation'
+            '**/hapi/HapiFhirImplementation*'
         ]
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,6 +118,7 @@ tasks.named('test') {
             '**/javalin/App*',
             '**/jackson/Jackson*',
             '**/slf4j/Slf4jLogger*',
+            '**/hapi/HapiFhirImplementation'
         ]
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -5,6 +5,7 @@ import gov.hhs.cdc.trustedintermediary.domainconnector.DomainConnector;
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainRequest;
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainResponse;
 import gov.hhs.cdc.trustedintermediary.domainconnector.HttpEndpoint;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.ConvertAndSendLabOrderUsecase;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsController;
@@ -35,6 +36,8 @@ public class EtorDomainRegistration implements DomainConnector {
 
         ApplicationContext.register(
                 PatientDemographicsController.class, PatientDemographicsController.getInstance());
+        ApplicationContext.register(
+                ConvertAndSendLabOrderUsecase.class, ConvertAndSendLabOrderUsecase.getInstance());
         ApplicationContext.register(LabOrderConverter.class, HapiLabOrderConverter.getInstance());
         ApplicationContext.register(LabOrderSender.class, LocalFileLabOrderSender.getInstance());
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 public class EtorDomainRegistration implements DomainConnector {
 
     @Inject PatientDemographicsController patientDemographicsController;
+    @Inject ConvertAndSendLabOrderUsecase convertAndSendLabOrderUsecase;
     @Inject Logger logger;
 
     private final Map<HttpEndpoint, Function<DomainRequest, DomainResponse>> endpoints =
@@ -57,10 +58,12 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleOrder(DomainRequest request) {
 
         logger.logInfo("Parsing request...");
-        var order = patientDemographicsController.parseDemographics(request);
+        var demographics = patientDemographicsController.parseDemographics(request);
+
+        convertAndSendLabOrderUsecase.convertAndSend(demographics);
 
         PatientDemographicsResponse patientDemographicsResponse =
-                new PatientDemographicsResponse(order);
+                new PatientDemographicsResponse(demographics);
 
         logger.logInfo("Constructing response...");
         return patientDemographicsController.constructResponse(patientDemographicsResponse);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -5,8 +5,12 @@ import gov.hhs.cdc.trustedintermediary.domainconnector.DomainConnector;
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainRequest;
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainResponse;
 import gov.hhs.cdc.trustedintermediary.domainconnector.HttpEndpoint;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsController;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResponse;
+import gov.hhs.cdc.trustedintermediary.external.hapi.HapiLabOrderConverter;
+import gov.hhs.cdc.trustedintermediary.external.localfile.LocalFileLabOrderSender;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +32,12 @@ public class EtorDomainRegistration implements DomainConnector {
 
     @Override
     public Map<HttpEndpoint, Function<DomainRequest, DomainResponse>> domainRegistration() {
+
         ApplicationContext.register(
                 PatientDemographicsController.class, PatientDemographicsController.getInstance());
+        ApplicationContext.register(LabOrderConverter.class, HapiLabOrderConverter.getInstance());
+        ApplicationContext.register(LabOrderSender.class, LocalFileLabOrderSender.getInstance());
+
         return endpoints;
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
@@ -1,0 +1,15 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics;
+
+import javax.inject.Inject;
+
+public class ConvertAndSendLabOrderUsecase {
+
+    @Inject LabOrderConverter converter;
+
+    @Inject LabOrderSender sender;
+
+    public void convertAndSend(PatientDemographics demographics) {
+        LabOrder<?> labOrder = converter.convertToOrder(demographics);
+        sender.sendOrder(labOrder);
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
@@ -16,7 +16,6 @@ public class ConvertAndSendLabOrderUsecase {
     }
 
     private ConvertAndSendLabOrderUsecase() {}
-    ;
 
     public void convertAndSend(PatientDemographics demographics) {
         LabOrder<?> labOrder = converter.convertToOrder(demographics);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
@@ -2,6 +2,10 @@ package gov.hhs.cdc.trustedintermediary.etor.demographics;
 
 import javax.inject.Inject;
 
+/**
+ * The overall logic that handles receiving patient demographics, converting it to a lab order, and
+ * sending it on its way.
+ */
 public class ConvertAndSendLabOrderUsecase {
 
     private static final ConvertAndSendLabOrderUsecase INSTANCE =

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
@@ -4,9 +4,19 @@ import javax.inject.Inject;
 
 public class ConvertAndSendLabOrderUsecase {
 
+    private static final ConvertAndSendLabOrderUsecase INSTANCE =
+            new ConvertAndSendLabOrderUsecase();
+
     @Inject LabOrderConverter converter;
 
     @Inject LabOrderSender sender;
+
+    public static ConvertAndSendLabOrderUsecase getInstance() {
+        return INSTANCE;
+    }
+
+    private ConvertAndSendLabOrderUsecase() {}
+    ;
 
     public void convertAndSend(PatientDemographics demographics) {
         LabOrder<?> labOrder = converter.convertToOrder(demographics);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
@@ -1,0 +1,5 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics;
+
+public interface LabOrder<T> {
+    T getUnderlyingOrder();
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
@@ -1,7 +1,10 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-/*
-   Interface to wrap a third-party lab order class (Ex: Hapi FHIR Bundle)
-*/
+
+/**
+ * Interface to wrap a third-party lab order class (Ex: Hapi FHIR Bundle)
+ *
+ * @param <T> The underlying FHIR lab order type.
+ */
 public interface LabOrder<T> {
     T getUnderlyingOrder();
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrder.java
@@ -1,5 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-
+/*
+   Interface to wrap a third-party lab order class (Ex: Hapi FHIR Bundle)
+*/
 public interface LabOrder<T> {
     T getUnderlyingOrder();
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
@@ -1,0 +1,5 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics;
+
+public interface LabOrderConverter {
+    LabOrder<?> convertToOrder(PatientDemographics demographics);
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-/*
-   Interface for converting a demographics object into a lab order
-*/
+
+/** Interface for converting a demographics object into a lab order. */
 public interface LabOrderConverter {
     LabOrder<?> convertToOrder(PatientDemographics demographics);
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderConverter.java
@@ -1,5 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-
+/*
+   Interface for converting a demographics object into a lab order
+*/
 public interface LabOrderConverter {
     LabOrder<?> convertToOrder(PatientDemographics demographics);
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-/*
-   Interface for sending a lab order
-*/
+
+/** Interface for sending a lab order. */
 public interface LabOrderSender {
     void sendOrder(LabOrder<?> order);
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
@@ -1,0 +1,5 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics;
+
+public interface LabOrderSender {
+    void sendOrder(LabOrder<?> order);
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
@@ -1,5 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.etor.demographics;
-
+/*
+   Interface for sending a lab order
+*/
 public interface LabOrderSender {
     void sendOrder(LabOrder<?> order);
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiFhirImplementation.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiFhirImplementation.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+/** Concrete implementation that calls the Hapi FHIR library. */
 public class HapiFhirImplementation implements HapiFhir {
 
     private static final HapiFhirImplementation INSTANCE = new HapiFhirImplementation();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrder.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrder.java
@@ -3,6 +3,10 @@ package gov.hhs.cdc.trustedintermediary.external.hapi;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import org.hl7.fhir.r4.model.Bundle;
 
+/**
+ * A concrete implementation of a {@link LabOrder} that uses the Hapi FHIR bundle as its underlying
+ * type.
+ */
 public class HapiLabOrder implements LabOrder<Bundle> {
 
     private final Bundle innerLabOrder;

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrder.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrder.java
@@ -1,0 +1,18 @@
+package gov.hhs.cdc.trustedintermediary.external.hapi;
+
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
+import org.hl7.fhir.r4.model.Bundle;
+
+public class HapiLabOrder implements LabOrder<Bundle> {
+
+    private final Bundle innerLabOrder;
+
+    public HapiLabOrder(Bundle innerLabOrder) {
+        this.innerLabOrder = innerLabOrder;
+    }
+
+    @Override
+    public Bundle getUnderlyingOrder() {
+        return innerLabOrder;
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -6,6 +6,14 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
 import org.hl7.fhir.r4.model.Bundle;
 
 public class HapiLabOrderConverter implements LabOrderConverter {
+    private static final HapiLabOrderConverter INSTANCE = new HapiLabOrderConverter();
+
+    public static HapiLabOrderConverter getInstance() {
+        return INSTANCE;
+    }
+
+    private HapiLabOrderConverter() {}
+
     @Override
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -5,6 +5,10 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
 import org.hl7.fhir.r4.model.Bundle;
 
+/**
+ * Converts {@link PatientDemographics} to a Hapi-specific FHIR lab order ({@link HapiLabOrder} or
+ * {@link LabOrder<Bundle>}).
+ */
 public class HapiLabOrderConverter implements LabOrderConverter {
     private static final HapiLabOrderConverter INSTANCE = new HapiLabOrderConverter();
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -1,0 +1,17 @@
+package gov.hhs.cdc.trustedintermediary.external.hapi;
+
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
+import org.hl7.fhir.r4.model.Bundle;
+
+public class HapiLabOrderConverter implements LabOrderConverter {
+    @Override
+    public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
+        var labOrder = new Bundle();
+        labOrder.setId(demographics.getFhirResourceId());
+        // other conversions to create the FHIR service request
+
+        return new HapiLabOrder(labOrder);
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
@@ -3,6 +3,10 @@ package gov.hhs.cdc.trustedintermediary.external.localfile;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
+/*
+   Accepts a LabOrder and writes it to a local file.
+*/
+
 public class LocalFileLabOrderSender implements LabOrderSender {
     private static final LocalFileLabOrderSender INSTANCE = new LocalFileLabOrderSender();
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
@@ -4,6 +4,14 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
 public class LocalFileLabOrderSender implements LabOrderSender {
+    private static final LocalFileLabOrderSender INSTANCE = new LocalFileLabOrderSender();
+
+    public static LocalFileLabOrderSender getInstance() {
+        return INSTANCE;
+    }
+
+    private LocalFileLabOrderSender() {}
+
     @Override
     public void sendOrder(final LabOrder<?> order) {
         // convert the order to JSON?

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
@@ -1,0 +1,12 @@
+package gov.hhs.cdc.trustedintermediary.external.localfile;
+
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
+
+public class LocalFileLabOrderSender implements LabOrderSender {
+    @Override
+    public void sendOrder(final LabOrder<?> order) {
+        // convert the order to JSON?
+        // save JSON? to a local file
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
@@ -3,10 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.localfile;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
-/*
-   Accepts a LabOrder and writes it to a local file.
-*/
-
+/** Accepts a {@link LabOrder} and writes it to a local file. */
 public class LocalFileLabOrderSender implements LabOrderSender {
     private static final LocalFileLabOrderSender INSTANCE = new LocalFileLabOrderSender();
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -3,9 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.reportstream;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
-/*
-    Sends a converted LabOrder to ReportStream
-*/
+/** Accepts a {@link LabOrder} and sends it to ReportStream. */
 public class ReportStreamLabOrderSender implements LabOrderSender {
 
     private static final ReportStreamLabOrderSender INSTANCE = new ReportStreamLabOrderSender();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -1,0 +1,12 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream;
+
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
+
+public class ReportStreamLabOrderSender implements LabOrderSender {
+    @Override
+    public void sendOrder(final LabOrder<?> order) {
+        // String json = FHIR.stringify(order.getUnderlyingOrder())
+        // reportStream.sendRequestBody(json)
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -4,6 +4,15 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
 public class ReportStreamLabOrderSender implements LabOrderSender {
+
+    private static final ReportStreamLabOrderSender INSTANCE = new ReportStreamLabOrderSender();
+
+    public static ReportStreamLabOrderSender getInstance() {
+        return INSTANCE;
+    }
+
+    private ReportStreamLabOrderSender() {}
+
     @Override
     public void sendOrder(final LabOrder<?> order) {
         // String json = FHIR.stringify(order.getUnderlyingOrder())

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -3,6 +3,9 @@ package gov.hhs.cdc.trustedintermediary.external.reportstream;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 
+/*
+    Sends a converted LabOrder to ReportStream
+*/
 public class ReportStreamLabOrderSender implements LabOrderSender {
 
     private static final ReportStreamLabOrderSender INSTANCE = new ReportStreamLabOrderSender();

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -4,6 +4,7 @@ import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainRequest
 import gov.hhs.cdc.trustedintermediary.domainconnector.DomainResponse
 import gov.hhs.cdc.trustedintermediary.domainconnector.HttpEndpoint
+import gov.hhs.cdc.trustedintermediary.etor.demographics.ConvertAndSendLabOrderUsecase
 import gov.hhs.cdc.trustedintermediary.etor.demographics.NextOfKin
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsController
@@ -56,11 +57,14 @@ class EtorDomainRegistrationTest extends Specification {
         mockDemographicsController.parseDemographics(_ as DomainRequest) >> new PatientDemographics(mockRequestId, "a patient ID", "George", "Washington", "male", ZonedDateTime.now(), 1, "Asian", new NextOfKin("King", "George", "555-867-5309"))
         mockDemographicsController.constructResponse(_ as PatientDemographicsResponse) >> new DomainResponse(418)
 
-        def domainRequest = new DomainRequest()
+        def mockUsecase = Mock(ConvertAndSendLabOrderUsecase)
 
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
         TestApplicationContext.register(PatientDemographicsController, mockDemographicsController)
+        TestApplicationContext.register(ConvertAndSendLabOrderUsecase, mockUsecase)
         TestApplicationContext.injectRegisteredImplementations()
+
+        def domainRequest = new DomainRequest()
 
         when:
         def response = domainRegistration.handleOrder(domainRequest)

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -73,5 +73,6 @@ class EtorDomainRegistrationTest extends Specification {
         1 * mockDemographicsController.constructResponse(_ as PatientDemographicsResponse) >> { PatientDemographicsResponse demographicsResponse ->
             assert demographicsResponse.fhirResourceId == mockRequestId
         }
+        1 * mockUsecase.convertAndSend(_ as PatientDemographics)
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecaseTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecaseTest.groovy
@@ -1,0 +1,39 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics
+
+import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
+import spock.lang.Specification
+
+class ConvertAndSendLabOrderUsecaseTest extends Specification {
+
+    def setup() {
+        TestApplicationContext.reset()
+        TestApplicationContext.init()
+        TestApplicationContext.register(ConvertAndSendLabOrderUsecase, ConvertAndSendLabOrderUsecase.getInstance())
+    }
+
+    def "ConvertAndSend"() {
+        given:
+        LabOrder<?> mockOrder = new LabOrder<String>() {
+                    @Override
+                    String getUnderlyingOrder() {
+                        return "This is a mock inner order"
+                    }
+                }
+
+        def mockConverter = Mock(LabOrderConverter)
+        def mockSender = Mock(LabOrderSender)
+
+        TestApplicationContext.register(LabOrderConverter, mockConverter)
+        TestApplicationContext.register(LabOrderSender, mockSender)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        def demographics = new PatientDemographics()
+
+        when:
+        ConvertAndSendLabOrderUsecase.getInstance().convertAndSend(demographics)
+
+        then:
+        1 * mockConverter.convertToOrder(_ as PatientDemographics) >> mockOrder
+        1 * mockSender.sendOrder(mockOrder)
+    }
+}

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -1,0 +1,17 @@
+package gov.hhs.cdc.trustedintermediary.external.hapi
+
+import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics
+import spock.lang.Specification
+
+class HapiLabOrderConverterTest extends Specification {
+    def "conversion between demographics and the LabOrder is correct"() {
+        given:
+        def demographics = new PatientDemographics()
+
+        when:
+        def labOrder = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
+
+        then:
+        labOrder.getId() == demographics.getFhirResourceId()
+    }
+}

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -6,7 +6,17 @@ import spock.lang.Specification
 class HapiLabOrderConverterTest extends Specification {
     def "conversion between demographics and the LabOrder is correct"() {
         given:
-        def demographics = new PatientDemographics()
+        def demographics = new PatientDemographics(
+                'fhir123id',
+                'patient123id',
+                'John',
+                'Doe',
+                'M',
+                null,
+                null,
+                null,
+                null
+                )
 
         when:
         def labOrder = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderTest.groovy
@@ -1,0 +1,18 @@
+package gov.hhs.cdc.trustedintermediary.external.hapi
+
+import org.hl7.fhir.r4.model.Bundle
+import spock.lang.Specification
+
+class HapiLabOrderTest extends Specification {
+    def "getUnderlyingOrder Works"() {
+        given:
+        def expectedInnerLabOrder = new Bundle()
+        def labOrder = new HapiLabOrder(expectedInnerLabOrder)
+
+        when:
+        def actualInnerLabOrder = labOrder.getUnderlyingOrder()
+
+        then:
+        actualInnerLabOrder == expectedInnerLabOrder
+    }
+}

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSenderTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSenderTest.groovy
@@ -1,9 +1,9 @@
-package gov.hhs.cdc.trustedintermediary.external.reportstream
+package gov.hhs.cdc.trustedintermediary.external.localfile
 
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder
 import spock.lang.Specification
 
-class ReportStreamLabOrderSenderTest extends Specification{
+class LocalFileLabOrderSenderTest extends Specification{
 
 
     def "send order works"() {
@@ -19,7 +19,7 @@ class ReportStreamLabOrderSenderTest extends Specification{
 
         when:
 
-        ReportStreamLabOrderSender.getInstance().sendOrder(mockOrder)
+        LocalFileLabOrderSender.getInstance().sendOrder(mockOrder)
 
         then:
 

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSenderTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSenderTest.groovy
@@ -1,0 +1,34 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream
+
+import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
+import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder
+import spock.lang.Specification
+
+class ReportStreamLabOrderSenderTest extends Specification{
+
+    def setup() {
+        TestApplicationContext.reset()
+        TestApplicationContext.init()
+        TestApplicationContext.register(ReportStreamLabOrderSender, ReportStreamLabOrderSender.getInstance())
+    }
+
+    def "send order works"() {
+
+        given:
+        LabOrder<?> mockOrder = new LabOrder<String>() {
+
+                    @Override
+                    String getUnderlyingOrder() {
+                        return "Mock order"
+                    }
+                }
+
+        when:
+
+        ReportStreamLabOrderSender.getInstance().sendOrder(mockOrder)
+
+        then:
+
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
# Skeleton

We created the usecase that handles the basics that this story is about: converting and sending.

For converting, we have an interface, `LabOrderConverter`, that can have different concrete implementations.  This is abstracted because there can be different third-party FHIR classes we could use.  We don't want the Hapi, Linux4Health, or whatever else dependencies spreading through all of our code.  To this end, we also have a `LabOrder` interface that "wraps" a concrete FHIR dependency lab order.  This allows our usecase to not know the concrete implementation being used behind the `LabOrder`.  So, one of our concrete convert implementations, `HapiLabOrderConverter`, creates a `LabOrder` for the Hapi FHIR `Bundle` class.

For sending, we have an interface, `LabOrderSender`, that can have different concrete implementations.  We created two implementations that will be fleshed out in future PRs.  One is for ReportStream, `ReportStreamLabOrderSender`, which will handle all the work associated with communicating with RS (JWT handling, ReST calls, etc.).  This implementation will be used when we're deployed in an actual environment.  Another implementation, `LocalFileLabOrderSender`, will be used when we run our application locally.  This implementation will write out the order to the local hard drive.

## Issue

#79.