### PR TITLE
79: Convert to Create a Lab Order

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -3,15 +3,21 @@ package gov.hhs.cdc.trustedintermediary.external.hapi;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
+import java.util.Date;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.ContactPoint;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
 
 /**
  * Converts {@link PatientDemographics} to a Hapi-specific FHIR lab order ({@link HapiLabOrder} or
@@ -29,7 +35,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     @Override
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();
-        labOrder.setId(demographics.getFhirResourceId());
+
         labOrder.addEntry(
                 new Bundle.BundleEntryComponent().setResource(createPatientResource(demographics)));
 
@@ -58,17 +64,42 @@ public class HapiLabOrderConverter implements LabOrderConverter {
 
         patient.setGender(Enumerations.AdministrativeGender.fromCode(demographics.getSex()));
 
-        // birth date
-        //        patient.setBirthDateElement(new
-        // DateType().addExtension("http://hl7.org/fhir/StructureDefinition/patient-birthTime", new
-        // DateTimeType(demographics.getBirthDateTime().to)))
+        // birth date and time
+        var birthDate = new DateType(Date.from(demographics.getBirthDateTime().toInstant()));
+        birthDate.addExtension(
+                "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                new DateTimeType(Date.from(demographics.getBirthDateTime().toInstant())));
+        patient.setBirthDateElement(birthDate);
 
         patient.setMultipleBirth(new IntegerType(demographics.getBirthOrder()));
 
         // race
-        //        patient.
+        var raceExtension =
+                new Extension()
+                        .setUrl("http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+        raceExtension.addExtension("text", new StringType(demographics.getRace()));
+        patient.addExtension(raceExtension);
 
-        // next of kind
+        // next of kin
+        var nextOfKinRelationship =
+                new CodeableConcept(
+                        new Coding(
+                                "http://terminology.hl7.org/CodeSystem/v2-0131",
+                                "N",
+                                "Next of kin"));
+        var nextOfKinName =
+                new HumanName()
+                        .setFamily(demographics.getNextOfKin().getLastName())
+                        .addGiven(demographics.getNextOfKin().getFirstName());
+        var nextOfKinTelecom =
+                new ContactPoint()
+                        .setSystem(ContactPoint.ContactPointSystem.PHONE)
+                        .setValue(demographics.getNextOfKin().getPhoneNumber());
+        patient.addContact(
+                new Patient.ContactComponent()
+                        .addRelationship(nextOfKinRelationship)
+                        .setName(nextOfKinName)
+                        .addTelecom(nextOfKinTelecom));
 
         return patient;
     }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -17,6 +17,7 @@ import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.StringType;
 
@@ -121,7 +122,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
                 new CodeableConcept(
                         new Coding("http://loinc.org", "54089-8", "Newborn Screening Panel")));
 
-        serviceRequest.setSubjectTarget(patient);
+        serviceRequest.setSubject(new Reference(patient));
 
         serviceRequest.setOccurrence(new DateTimeType(Date.from(Instant.now())));
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.MessageHeader;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ServiceRequest;
@@ -37,14 +38,32 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     @Override
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();
+        labOrder.setId("as23479824357234879df");
+        labOrder.setType(Bundle.BundleType.MESSAGE);
+        labOrder.setTimestamp(Date.from(Instant.now()));
 
         var patient = createPatientResource(demographics);
         var serviceRequest = createServiceRequest(patient);
+        var messageHeader = createMessageHeader();
 
+        labOrder.addEntry(new Bundle.BundleEntryComponent().setResource(messageHeader));
         labOrder.addEntry(new Bundle.BundleEntryComponent().setResource(patient));
         labOrder.addEntry(new Bundle.BundleEntryComponent().setResource(serviceRequest));
 
         return new HapiLabOrder(labOrder);
+    }
+
+    private MessageHeader createMessageHeader() {
+        var messageHeader = new MessageHeader();
+
+        messageHeader.setId("adljasdljasgjlasfjlg");
+        messageHeader.setEvent(
+                new Coding(
+                        "http://terminology.hl7.org/CodeSystem/v2-0003",
+                        "O21",
+                        "OML - Laboratory order"));
+
+        return messageHeader;
     }
 
     private Patient createPatientResource(final PatientDemographics demographics) {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -5,6 +5,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
 import java.time.Instant;
 import java.util.Date;
+import java.util.UUID;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -38,7 +39,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     @Override
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();
-        labOrder.setId("as23479824357234879df");
+        labOrder.setId(UUID.randomUUID().toString());
         labOrder.setType(Bundle.BundleType.MESSAGE);
         labOrder.setTimestamp(Date.from(Instant.now()));
 
@@ -56,7 +57,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     private MessageHeader createMessageHeader() {
         var messageHeader = new MessageHeader();
 
-        messageHeader.setId("adljasdljasgjlasfjlg");
+        messageHeader.setId(UUID.randomUUID().toString());
         messageHeader.setEvent(
                 new Coding(
                         "http://terminology.hl7.org/CodeSystem/v2-0003",
@@ -131,7 +132,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     private ServiceRequest createServiceRequest(final Patient patient) {
         var serviceRequest = new ServiceRequest();
 
-        serviceRequest.setId("123456789");
+        serviceRequest.setId(UUID.randomUUID().toString());
 
         serviceRequest.setStatus(ServiceRequest.ServiceRequestStatus.ACTIVE);
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -4,6 +4,14 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.HumanName;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
 
 /**
  * Converts {@link PatientDemographics} to a Hapi-specific FHIR lab order ({@link HapiLabOrder} or
@@ -22,8 +30,46 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();
         labOrder.setId(demographics.getFhirResourceId());
-        // other conversions to create the FHIR service request
+        labOrder.addEntry(
+                new Bundle.BundleEntryComponent().setResource(createPatientResource(demographics)));
 
         return new HapiLabOrder(labOrder);
+    }
+
+    private Resource createPatientResource(final PatientDemographics demographics) {
+        var patient = new Patient();
+
+        patient.setId(demographics.getFhirResourceId());
+        patient.addIdentifier(
+                new Identifier()
+                        .setType(
+                                new CodeableConcept(
+                                        new Coding(
+                                                "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                                "MR",
+                                                "Medical Record Number")))
+                        .setValue(demographics.getPatientId()));
+
+        patient.addName(
+                new HumanName()
+                        .setFamily(demographics.getLastName())
+                        .addGiven(demographics.getFirstName())
+                        .setUse(HumanName.NameUse.OFFICIAL));
+
+        patient.setGender(Enumerations.AdministrativeGender.fromCode(demographics.getSex()));
+
+        // birth date
+        //        patient.setBirthDateElement(new
+        // DateType().addExtension("http://hl7.org/fhir/StructureDefinition/patient-birthTime", new
+        // DateTimeType(demographics.getBirthDateTime().to)))
+
+        patient.setMultipleBirth(new IntegerType(demographics.getBirthOrder()));
+
+        // race
+        //        patient.
+
+        // next of kind
+
+        return patient;
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -1,27 +1,56 @@
 package gov.hhs.cdc.trustedintermediary.external.hapi
 
+import gov.hhs.cdc.trustedintermediary.etor.demographics.NextOfKin
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics
+import org.hl7.fhir.r4.model.DateTimeType
+import org.hl7.fhir.r4.model.Patient
 import spock.lang.Specification
 
+import java.time.ZonedDateTime
+
 class HapiLabOrderConverterTest extends Specification {
-    def "conversion between demographics and the LabOrder is correct"() {
+    def "the demographics correctly constructs a patient in the lab order"() {
         given:
+        def fhirResourceId = "fhir123id"
+        def patientId = "patient123id"
+        def firstName = "John"
+        def lastName = "Doe"
+        def sex = "male"
+        def birthDateTime = ZonedDateTime.now()
+        def birthOrder = 1
+        def race = "Asian"
+        def nextOfKinFirstName = "Jaina"
+        def nextOfKinLastName = "Solo"
+        def nextOfKinPhoneNumber = "555-555-5555"
+        def nextOfKin = new NextOfKin(nextOfKinFirstName, nextOfKinLastName, nextOfKinPhoneNumber)
         def demographics = new PatientDemographics(
-                'fhir123id',
-                'patient123id',
-                'John',
-                'Doe',
-                'M',
-                null,
-                null,
-                null,
-                null
+                fhirResourceId,
+                patientId,
+                firstName,
+                lastName,
+                sex,
+                birthDateTime,
+                birthOrder,
+                race,
+                nextOfKin
                 )
 
         when:
-        def labOrder = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
+        def labOrderBundle = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
 
         then:
-        labOrder.getId() == demographics.getFhirResourceId()
+        def patient = labOrderBundle.getEntry().get(0).getResource() as Patient
+
+        patient.getId() == fhirResourceId
+        patient.getIdentifierFirstRep().getValue() == patientId
+        patient.getNameFirstRep().getFamily() == lastName
+        patient.getNameFirstRep().getGiven().get(0).getValue() == firstName
+        patient.getGender().toCode() == sex
+        patient.getBirthDateElement().getExtensionByUrl("http://hl7.org/fhir/StructureDefinition/patient-birthTime").getValue().toString() == new DateTimeType(Date.from(birthDateTime.toInstant())).toString()
+        patient.getMultipleBirthIntegerType().getValue() == birthOrder
+        patient.getExtensionByUrl("http://hl7.org/fhir/us/core/StructureDefinition/us-core-race").getExtensionByUrl("text").getValue().toString() == race
+        patient.getContactFirstRep().getName().getFamily() == nextOfKinLastName
+        patient.getContactFirstRep().getName().getGiven().get(0).getValue() == nextOfKinFirstName
+        patient.getContactFirstRep().getTelecomFirstRep().getValue() == nextOfKinPhoneNumber
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -66,6 +66,6 @@ class HapiLabOrderConverterTest extends Specification {
 
         !serviceRequest.getId().isEmpty()
         serviceRequest.getCode().getCodingFirstRep().getCode() == "54089-8"
-        serviceRequest.getSubject().getResource() == labOrderBundle.getEntry().get(0).getResource()
+        serviceRequest.getSubject().getResource() == labOrderBundle.getEntry().get(1).getResource()
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -66,6 +66,6 @@ class HapiLabOrderConverterTest extends Specification {
 
         !serviceRequest.getId().isEmpty()
         serviceRequest.getCode().getCodingFirstRep().getCode() == "54089-8"
-        serviceRequest.getSubjectTarget() == labOrderBundle.getEntry().get(0).getResource()
+        serviceRequest.getSubject().getResource() == labOrderBundle.getEntry().get(0).getResource()
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -41,7 +41,7 @@ class HapiLabOrderConverterTest extends Specification {
         def labOrderBundle = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
 
         then:
-        def patient = labOrderBundle.getEntry().get(0).getResource() as Patient
+        def patient = labOrderBundle.getEntry().get(1).getResource() as Patient
 
         patient.getId() == fhirResourceId
         patient.getIdentifierFirstRep().getValue() == patientId
@@ -62,7 +62,7 @@ class HapiLabOrderConverterTest extends Specification {
         def labOrderBundle = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
 
         then:
-        def serviceRequest = labOrderBundle.getEntry().get(1).getResource() as ServiceRequest
+        def serviceRequest = labOrderBundle.getEntry().get(2).getResource() as ServiceRequest
 
         !serviceRequest.getId().isEmpty()
         serviceRequest.getCode().getCodingFirstRep().getCode() == "54089-8"

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -3,6 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.hapi
 import gov.hhs.cdc.trustedintermediary.etor.demographics.NextOfKin
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics
 import org.hl7.fhir.r4.model.DateTimeType
+import org.hl7.fhir.r4.model.MessageHeader
 import org.hl7.fhir.r4.model.Patient
 import org.hl7.fhir.r4.model.ServiceRequest
 import spock.lang.Specification
@@ -34,6 +35,19 @@ class HapiLabOrderConverterTest extends Specification {
     race,
     nextOfKin
     )
+
+    def "the demographics correctly constructs a message header in the lab order"() {
+
+        when:
+        def labOrderBundle = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
+
+        then:
+        def messageHeader = labOrderBundle.getEntry().get(0).getResource() as MessageHeader
+
+        !messageHeader.getId().isEmpty()
+        messageHeader.getEventCoding().getSystem() == "http://terminology.hl7.org/CodeSystem/v2-0003"
+        messageHeader.getEventCoding().getCode() == "O21"
+    }
 
     def "the demographics correctly constructs a patient in the lab order"() {
 


### PR DESCRIPTION
# Convert to Create a Lab Order

Converts the patient demographics to a lab order by creating a `Bundle` that contains...
- A `MessageHeader` resource containing the event for a `O21` which is an OML - Laboratory order.
- A re-created `Patient` resource filled in from the details of the patient demographics.
- A `ServiceRequest` resource that contains the LOINC code `54089-8` which is a Newborn Screening Panel.

## Issue

#79.