### PR TITLE
Removing FHIR Utilities as a Dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.4.0'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-caching-caffeine:6.4.0'
     implementation 'org.fhir:ucum:1.0.3'
-    implementation 'ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.99'
+    //implementation 'ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.99'
 
     testImplementation 'org.apache.groovy:groovy:4.0.9'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.4.0'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-caching-caffeine:6.4.0'
     implementation 'org.fhir:ucum:1.0.3'
-    //implementation 'ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.6.99'
 
     testImplementation 'org.apache.groovy:groovy:4.0.9'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'


### PR DESCRIPTION
# Removing FHIR Utilities as a Dependency

The explicit FHIR Utilities dependency was added to remove a vulnerability.  It seems the latest version of the other FHIR dependencies depend on a newer version of FHIR Utilities that doesn't have the vulnerability.