### PR TITLE
Skip the PR Deployment Another Way

### DIFF
--- a/.github/workflows/deploy_reusable-skip.yml
+++ b/.github/workflows/deploy_reusable-skip.yml
@@ -13,6 +13,5 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - run: echo 'Nothing'

--- a/.github/workflows/deploy_reusable-skip.yml
+++ b/.github/workflows/deploy_reusable-skip.yml
@@ -1,0 +1,18 @@
+name: 'Container Build & Deploy'
+
+on:
+  workflow_call:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:

--- a/.github/workflows/deploy_reusable-skip.yml
+++ b/.github/workflows/deploy_reusable-skip.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+      - run: echo 'Nothing'
 
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
-
     steps:
+      - run: echo 'Nothing'

--- a/.github/workflows/deploy_reusable-skip.yml
+++ b/.github/workflows/deploy_reusable-skip.yml
@@ -1,3 +1,6 @@
+# Used when a PR doesn't have any changes that require the PR deploy.
+# The jobs' keys/names must align with the `deploy_reusable.yml` jobs' keys/names.
+
 name: 'Container Build & Deploy'
 
 on:

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -15,6 +15,10 @@ on:
       APP:
         required: true
         type: string
+      SKIP:
+        type: boolean
+        required: false
+        default: false
     secrets:
       ACR_USERNAME:
         required: true
@@ -30,7 +34,8 @@ on:
 
 jobs:
   build:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
+    if: ${{ inputs.SKIP }}
 
     steps:
     - uses: actions/checkout@v3
@@ -65,15 +70,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ inputs.SKIP }}
     environment:
-      name: '${{ inputs.ENVIRONMENT }}'
-      url: '${{ steps.deploy-to-webapp.outputs.webapp-url }}'
+      name: ${{ inputs.ENVIRONMENT }}
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
     permissions:
       id-token: write
       contents: read
 
     steps:
-    - name: 'Login via Azure CLI'
+    - name: Login via Azure CLI
       uses: azure/login@v1
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -84,6 +90,6 @@ jobs:
       id: deploy-to-webapp
       uses: azure/webapps-deploy@v2
       with:
-        app-name: '${{ inputs.APP }}'
-        slot-name: 'production'
+        app-name: ${{ inputs.APP }}
+        slot-name: production
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -15,10 +15,6 @@ on:
       APP:
         required: true
         type: string
-      SKIP:
-        type: boolean
-        required: false
-        default: false
     secrets:
       ACR_USERNAME:
         required: true
@@ -35,7 +31,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !inputs.SKIP }}
 
     steps:
     - uses: actions/checkout@v3
@@ -70,7 +65,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ !inputs.SKIP }}
     environment:
       name: ${{ inputs.ENVIRONMENT }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ inputs.SKIP }}
+    if: ${{ !inputs.SKIP }}
 
     steps:
     - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ inputs.SKIP }}
+    if: ${{ !inputs.SKIP }}
     environment:
       name: ${{ inputs.ENVIRONMENT }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       TERRAFORM_DIRECTORY: operations/environments/pr
       TERRAFORM_INIT_PARAMETERS: -backend-config="key=pr_${{ github.event.number }}.tfstate"
       TERRAFORM_APPLY_PARAMETERS: -var="pr_number=${{ github.event.number }}"
-      SKIP: ${{ needs.paths-filter.outputs.operations == 'true' }}
+      SKIP: ${{ needs.paths-filter.outputs.operations != 'true' }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -50,7 +50,7 @@ jobs:
       REPO: trusted-intermediary-router
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
-      SKIP: ${{ needs.paths-filter.outputs.operations == 'true' }}
+      SKIP: ${{ needs.paths-filter.outputs.operations != 'true' }}
     secrets:
       ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
       ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -29,6 +29,7 @@ jobs:
     name: PR Infrastructure Deploy
     needs: paths-filter
     uses: ./.github/workflows/terraform-deploy_reusable.yml
+    if: needs.paths-filter.outputs.operations == 'true'
     with:
       TERRAFORM_DIRECTORY: operations/environments/pr
       TERRAFORM_INIT_PARAMETERS: -backend-config="key=pr_${{ github.event.number }}.tfstate"
@@ -39,12 +40,20 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+
+  terraform-deploy-skip:
+    name: PR Infrastructure Deploy
+    needs: paths-filter
+    uses: ./.github/workflows/terraform-deploy_reusable-skip.yml
+    if: needs.paths-filter.outputs.operations != 'true'
+
   pr-deploy:
     name: PR Application Deploy
     needs:
       - terraform-deploy
       - paths-filter
     uses: ./.github/workflows/deploy_reusable.yml
+    if: needs.paths-filter.outputs.operations == 'true'
     with:
       ENVIRONMENT: pr
       REPO: trusted-intermediary-router
@@ -57,6 +66,14 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  pr-deploy-skip:
+    name: PR Application Deploy
+    needs:
+      - terraform-deploy-skip
+      - paths-filter
+    uses: ./.github/workflows/deploy_reusable-skip.yml
+    if: needs.paths-filter.outputs.operations != 'true'
 
   destroy-environment:
     name: Destroy PR Environment

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -34,7 +34,6 @@ jobs:
       TERRAFORM_DIRECTORY: operations/environments/pr
       TERRAFORM_INIT_PARAMETERS: -backend-config="key=pr_${{ github.event.number }}.tfstate"
       TERRAFORM_APPLY_PARAMETERS: -var="pr_number=${{ github.event.number }}"
-      SKIP: ${{ needs.paths-filter.outputs.operations != 'true' }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -59,7 +58,6 @@ jobs:
       REPO: trusted-intermediary-router
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
-      SKIP: ${{ needs.paths-filter.outputs.operations != 'true' }}
     secrets:
       ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
       ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -29,11 +29,11 @@ jobs:
     name: PR Infrastructure Deploy
     needs: paths-filter
     uses: ./.github/workflows/terraform-deploy_reusable.yml
-    if: needs.paths-filter.outputs.operations == 'true'
     with:
       TERRAFORM_DIRECTORY: operations/environments/pr
       TERRAFORM_INIT_PARAMETERS: -backend-config="key=pr_${{ github.event.number }}.tfstate"
       TERRAFORM_APPLY_PARAMETERS: -var="pr_number=${{ github.event.number }}"
+      SKIP: ${{ needs.paths-filter.outputs.operations == 'true' }}
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -45,12 +45,12 @@ jobs:
       - terraform-deploy
       - paths-filter
     uses: ./.github/workflows/deploy_reusable.yml
-    if: needs.paths-filter.outputs.operations == 'true'
     with:
       ENVIRONMENT: pr
       REPO: trusted-intermediary-router
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
+      SKIP: ${{ needs.paths-filter.outputs.operations == 'true' }}
     secrets:
       ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
       ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -68,7 +68,6 @@ jobs:
   pr-deploy-skip:
     name: PR Application Deploy
     needs:
-      - terraform-deploy-skip
       - paths-filter
     uses: ./.github/workflows/deploy_reusable-skip.yml
     if: needs.paths-filter.outputs.operations != 'true'

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -40,11 +40,12 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
 
-  terraform-deploy-skip:
+  terraform-deploy-skip:  # runs when the PR doesn't have any changes that require the PR deploy; this ensures we get the appropriate required PR checks
     name: PR Infrastructure Deploy
     needs: paths-filter
     uses: ./.github/workflows/terraform-deploy_reusable-skip.yml
     if: needs.paths-filter.outputs.operations != 'true'
+
 
   pr-deploy:
     name: PR Application Deploy
@@ -65,12 +66,14 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-  pr-deploy-skip:
+
+  pr-deploy-skip:  # runs when the PR doesn't have any changes that require the PR deploy; this ensures we get the appropriate required PR checks
     name: PR Application Deploy
     needs:
       - paths-filter
     uses: ./.github/workflows/deploy_reusable-skip.yml
     if: needs.paths-filter.outputs.operations != 'true'
+
 
   destroy-environment:
     name: Destroy PR Environment

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
 
   terraform-deploy-skip:  # runs when the PR doesn't have any changes that require the PR deploy; this ensures we get the appropriate required PR checks
-    name: PR Infrastructure Deploy
+    name: PR Infrastructure Deploy  # this name must match the above `terraform-deploy` job's name
     needs: paths-filter
     uses: ./.github/workflows/terraform-deploy_reusable-skip.yml
     if: needs.paths-filter.outputs.operations != 'true'
@@ -68,7 +68,7 @@ jobs:
 
 
   pr-deploy-skip:  # runs when the PR doesn't have any changes that require the PR deploy; this ensures we get the appropriate required PR checks
-    name: PR Application Deploy
+    name: PR Application Deploy  # this name must match the above `pr-deploy` job's name
     needs:
       - paths-filter
     uses: ./.github/workflows/deploy_reusable-skip.yml

--- a/.github/workflows/terraform-deploy_reusable-skip.yml
+++ b/.github/workflows/terraform-deploy_reusable-skip.yml
@@ -1,0 +1,11 @@
+name: Terraform Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  terraform-deploy:
+    name: Terraform Deploy
+    runs-on: ubuntu-latest
+
+    steps:

--- a/.github/workflows/terraform-deploy_reusable-skip.yml
+++ b/.github/workflows/terraform-deploy_reusable-skip.yml
@@ -7,5 +7,5 @@ jobs:
   terraform-deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
-
     steps:
+      - run: echo 'Nothing'

--- a/.github/workflows/terraform-deploy_reusable-skip.yml
+++ b/.github/workflows/terraform-deploy_reusable-skip.yml
@@ -1,3 +1,6 @@
+# Used when a PR doesn't have any changes that require the PR deploy.
+# The job's keys/names must align with the `terraform-deploy_reusable.yml` job's keys/names.
+
 name: Terraform Deploy
 
 on:

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -14,6 +14,10 @@ on:
         type: string
         required: false
         default: ""
+      SKIP:
+        type: boolean
+        required: false
+        default: false
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -39,6 +43,7 @@ jobs:
   terraform-deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
+    if: ${{ inputs.SKIP }}
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -14,10 +14,6 @@ on:
         type: string
         required: false
         default: ""
-      SKIP:
-        type: boolean
-        required: false
-        default: false
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -43,7 +39,6 @@ jobs:
   terraform-deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
-    if: ${{ !inputs.SKIP }}
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -43,7 +43,7 @@ jobs:
   terraform-deploy:
     name: Terraform Deploy
     runs-on: ubuntu-latest
-    if: ${{ inputs.SKIP }}
+    if: ${{ !inputs.SKIP }}
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
# Skip the PR Deployment Another Way

We have a required PR deployment check.  It ensures that nothing is broken when the Terraform code changes.  But we don't want to deploy something when the PR doesn't include any changes to the Terraform code.  I tried to skip the workflows that would deploy the PR environment while also making the required PR check pass, but the job names weren't aligning correctly between PRs that would run the PR deployment and the PRs that wouldn't need to run the PR deployment.  Therefore, this PR adds some dummy workflows that have jobs that align with the real jobs so we get the correct PR checks.

## Issue

_N/A_.