### PR TITLE
79: Bundle Identifier in Addition to the ID

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -40,7 +40,9 @@ public class HapiLabOrderConverter implements LabOrderConverter {
     @Override
     public LabOrder<Bundle> convertToOrder(final PatientDemographics demographics) {
         var labOrder = new Bundle();
-        labOrder.setId(UUID.randomUUID().toString());
+        var labOrderId = UUID.randomUUID().toString();
+        labOrder.setId(labOrderId);
+        labOrder.setIdentifier(new Identifier().setValue(labOrderId));
         labOrder.setType(Bundle.BundleType.MESSAGE);
         labOrder.setTimestamp(Date.from(Instant.now()));
 

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.hapi
 
 import gov.hhs.cdc.trustedintermediary.etor.demographics.NextOfKin
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographics
+import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.DateTimeType
 import org.hl7.fhir.r4.model.MessageHeader
 import org.hl7.fhir.r4.model.Patient
@@ -35,6 +36,17 @@ class HapiLabOrderConverterTest extends Specification {
     race,
     nextOfKin
     )
+
+    def "the demographics correctly constructs the overall bundle in the lab order"() {
+
+        when:
+        def labOrderBundle = HapiLabOrderConverter.getInstance().convertToOrder(demographics).getUnderlyingOrder()
+
+        then:
+        !labOrderBundle.getId().isEmpty()
+        labOrderBundle.getId() == labOrderBundle.getIdentifier().getValue()
+        labOrderBundle.getType() == Bundle.BundleType.MESSAGE
+    }
 
     def "the demographics correctly constructs a message header in the lab order"() {
 

--- a/examples/fhir/lab_order.json
+++ b/examples/fhir/lab_order.json
@@ -1,13 +1,16 @@
 {
   "resourceType": "Bundle",
-  "id": "82f56714-2d67-4e9e-94c3-67d0747f5a99",
+  "id": "fd03c4b6-0ad4-4cdd-832f-28b18cd94ee9",
+  "identifier": {
+    "value": "fd03c4b6-0ad4-4cdd-832f-28b18cd94ee9"
+  },
   "type": "message",
-  "timestamp": "2023-03-03T09:14:36.501-06:00",
+  "timestamp": "2023-03-13T09:57:49.536-05:00",
   "entry": [
     {
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "f245e7fd-0b77-447b-824f-fe836be30373",
+        "id": "665fe0e7-5681-48cc-9953-366c0712650e",
         "eventCoding": {
           "system": "http://terminology.hl7.org/CodeSystem/v2-0003",
           "code": "O21",
@@ -100,7 +103,7 @@
     {
       "resource": {
         "resourceType": "ServiceRequest",
-        "id": "227cb0b3-899c-4ac7-89c5-d52ca347a48f",
+        "id": "7df300be-3b89-4c18-b454-b72036555855",
         "status": "active",
         "intent": "order",
         "category": [
@@ -126,7 +129,7 @@
         "subject": {
           "reference": "Patient/infant-twin-1"
         },
-        "occurrenceDateTime": "2023-03-03T09:14:36-06:00"
+        "occurrenceDateTime": "2023-03-13T09:57:49-05:00"
       }
     }
   ]


### PR DESCRIPTION
# Bundle Identifier in Addition to the ID

We now also set the `Bundle` identifier in addition to the `Bundle`'s ID.  This allows us to correctly convert to an HL7 message according to HL7's official spreadsheets.

## Issue

#79.