### PR TITLE
79: Make the Key Vault Name Globally Unique

### DIFF
--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault" "key_storage" {
-  name = "key-vault-${var.environment}"
+  name = "ti-key-vault-${var.environment}"
 
   resource_group_name = azurerm_resource_group.group.name
   location            = azurerm_resource_group.group.location


### PR DESCRIPTION
# Make the Key Vault Name Globally Unique

The Azure Key Vault name needs to be globally unique.  Unsurprisingly, someone else already has `key-vault-staging`.  So we are making the name slightly more unique.

## Issue

#79.