### PR TITLE
79: Inject the ReportStream Domain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   router:
     build: .
+    environment:
+      REPORT_STREAM_URL_PREFIX: http://localhost:7071
     ports:
       - "8080:8080" # default api endpoint port
       - "5005:5005" # Java debug port

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -1,3 +1,12 @@
+locals {
+  environment_to_rs_environment_prefix_mapping = {
+    dev = "staging"
+    staging = "staging"
+    prod = ""
+  }
+  rs_domain_prefix = "${local.environment_to_rs_environment_prefix_mapping[var.environment]}${length(local.environment_to_rs_environment_prefix_mapping[var.environment]) == 0 ? "" : "."}"
+}
+
 # Create the staging resource group
 resource "azurerm_resource_group" "group" {
   name     = "cdcti-${var.environment}"
@@ -35,6 +44,7 @@ resource "azurerm_linux_web_app" "api" {
     DOCKER_REGISTRY_SERVER_URL      = "https://${azurerm_container_registry.registry.login_server}"
     DOCKER_REGISTRY_SERVER_USERNAME = azurerm_container_registry.registry.admin_username
     DOCKER_REGISTRY_SERVER_PASSWORD = azurerm_container_registry.registry.admin_password
+    REPORT_STREAM_URL_PREFIX = "https://${local.rs_domain_prefix}prime.cdc.gov"
   }
 
   identity {

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -4,7 +4,8 @@ locals {
     staging = "staging"
     prod = ""
   }
-  rs_domain_prefix = "${local.environment_to_rs_environment_prefix_mapping[var.environment]}${length(local.environment_to_rs_environment_prefix_mapping[var.environment]) == 0 ? "" : "."}"
+  selected_rs_environment_prefix = lookup(local.environment_to_rs_environment_prefix_mapping, var.environment, "staging")
+  rs_domain_prefix = "${local.selected_rs_environment_prefix}${length(local.selected_rs_environment_prefix) == 0 ? "" : "."}"
 }
 
 # Create the staging resource group

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -1,11 +1,11 @@
 locals {
   environment_to_rs_environment_prefix_mapping = {
-    dev = "staging"
+    dev     = "staging"
     staging = "staging"
-    prod = ""
+    prod    = ""
   }
   selected_rs_environment_prefix = lookup(local.environment_to_rs_environment_prefix_mapping, var.environment, "staging")
-  rs_domain_prefix = "${local.selected_rs_environment_prefix}${length(local.selected_rs_environment_prefix) == 0 ? "" : "."}"
+  rs_domain_prefix               = "${local.selected_rs_environment_prefix}${length(local.selected_rs_environment_prefix) == 0 ? "" : "."}"
 }
 
 # Create the staging resource group
@@ -45,7 +45,7 @@ resource "azurerm_linux_web_app" "api" {
     DOCKER_REGISTRY_SERVER_URL      = "https://${azurerm_container_registry.registry.login_server}"
     DOCKER_REGISTRY_SERVER_USERNAME = azurerm_container_registry.registry.admin_username
     DOCKER_REGISTRY_SERVER_PASSWORD = azurerm_container_registry.registry.admin_password
-    REPORT_STREAM_URL_PREFIX = "https://${local.rs_domain_prefix}prime.cdc.gov"
+    REPORT_STREAM_URL_PREFIX        = "https://${local.rs_domain_prefix}prime.cdc.gov"
   }
 
   identity {


### PR DESCRIPTION
# Inject the ReportStream Domain

Pass the ReportStream domain we should be using to our application through the `REPORT_STREAM_URL_PREFIX` environment variable.

Construct this environment variable in Terraform so we use a real version when running in our deployed environment.

## Issue

#79.