### PR TITLE
79: Fix Some SonarCloud Smells

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
@@ -1,9 +1,5 @@
 package gov.hhs.cdc.trustedintermediary.external.apache;
-/**
- * This class implements Httpclient and is a "humble object" for the Apache Client 5 library. Using
- * Apache Client 5 Fluent facade, we are able to perform CRUD operations such as POST, in a generic
- * way.
- */
+
 import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
 import java.io.IOException;
 import java.util.Map;
@@ -13,6 +9,11 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * This class implements HttpClient and is a "humble object" for the Apache Client 5 library. Using
+ * Apache Client 5 Fluent facade, we are able to perform CRUD operations such as POST, in a generic
+ * way.
+ */
 public class ApacheClient implements HttpClient {
 
     private static final ApacheClient INSTANCE = new ApacheClient();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java
@@ -1,10 +1,8 @@
 package gov.hhs.cdc.trustedintermediary.external.jjwt;
-/**
- * This class implements the AuthEngine and is a "humble object" for the Jjwt library. It's main
- * purpose is to deal with all jwt related transactions such as creating a jwt (json web token).
- */
+
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
@@ -15,6 +13,10 @@ import java.util.Date;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * This class implements the AuthEngine and is a "humble object" for the Jjwt library. It's main
+ * purpose is to deal with all jwt related transactions such as creating a jwt (json web token).
+ */
 public class JjwtEngine implements AuthEngine {
 
     private static final JjwtEngine INSTANCE = new JjwtEngine();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
@@ -22,42 +22,42 @@ public class Slf4jLogger implements Logger {
 
     private Slf4jLogger() {}
 
+    public static Slf4jLogger getLogger() {
+        return new Slf4jLogger();
+    }
+
     @Override
     public void logInfo(String infoMessage) {
-        LOGGER.info(ANSI_GREEN + infoMessage + ANSI_RESET);
+        LOGGER.atInfo().log(() -> ANSI_GREEN + infoMessage + ANSI_RESET);
     }
 
     @Override
     public void logWarning(String warningMessage) {
-        LOGGER.warn(ANSI_YELLOW + warningMessage + ANSI_RESET);
+        LOGGER.atWarn().log(() -> ANSI_YELLOW + warningMessage + ANSI_RESET);
     }
 
     @Override
     public void logTrace(String traceMessage) {
-        LOGGER.trace(ANSI_PURPLE + traceMessage + ANSI_RESET);
+        LOGGER.atTrace().log(() -> ANSI_PURPLE + traceMessage + ANSI_RESET);
     }
 
     @Override
     public void logDebug(String debugMessage) {
-        LOGGER.debug(ANSI_CYAN + debugMessage + ANSI_RESET);
+        LOGGER.atDebug().log(() -> ANSI_CYAN + debugMessage + ANSI_RESET);
     }
 
     @Override
     public void logError(String errorMessage) {
-        LOGGER.error(ANSI_RED + errorMessage + ANSI_RESET);
+        LOGGER.atError().log(() -> ANSI_RED + errorMessage + ANSI_RESET);
     }
 
     @Override
     public void logDebug(String debugMessage, Throwable e) {
-        LOGGER.debug(ANSI_CYAN + debugMessage + ANSI_RESET, e);
+        LOGGER.atDebug().setMessage(() -> ANSI_CYAN + debugMessage + ANSI_RESET).setCause(e).log();
     }
 
     @Override
     public void logError(String errorMessage, Throwable e) {
-        LOGGER.error(ANSI_RED + errorMessage + ANSI_RESET, e);
-    }
-
-    public static Slf4jLogger getLogger() {
-        return new Slf4jLogger();
+        LOGGER.atError().setMessage(() -> ANSI_RED + errorMessage + ANSI_RESET).setCause(e).log();
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/AuthEngine.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/AuthEngine.java
@@ -1,10 +1,11 @@
 package gov.hhs.cdc.trustedintermediary.wrappers;
+
+import org.jetbrains.annotations.NotNull;
+
 /**
  * This interface provides a blueprint for all auth. related transactions. For example,
  * generateSenderToken() generates a token using ETOR's private key.
  */
-import org.jetbrains.annotations.NotNull;
-
 public interface AuthEngine {
     @NotNull
     String generateSenderToken(

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HapiFhir.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HapiFhir.java
@@ -4,6 +4,11 @@ import java.util.Optional;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+/**
+ * An interface that wraps around the Hapi FHIR library. It is Hapi-specific because making it
+ * library-agnostic was going to greatly complicate its use. It was decided to be more pragmatic to
+ * keep the complication down.
+ */
 public interface HapiFhir {
     <T extends IBase> Optional<T> fhirPathEvaluateFirst(
             IBase fhirResource, String fhirPath, Class<T> clazz);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClient.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClient.java
@@ -1,8 +1,9 @@
 package gov.hhs.cdc.trustedintermediary.wrappers;
-/** This interface provides a generic blueprint for CRUD operations */
+
 import java.io.IOException;
 import java.util.Map;
 
+/** This interface provides a generic blueprint for HTTP operations */
 public interface HttpClient {
     String post(String path, Map<String, String> headerMap, String body) throws IOException;
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/YamlCombiner.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/YamlCombiner.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.wrappers;
 
 import java.util.Set;
 
+/** Combines YAML strings into one monolithic YAML string. */
 public interface YamlCombiner {
     String combineYaml(Set<String> yamlStrings) throws YamlCombinerException;
 }


### PR DESCRIPTION
# Fix Some SonarCloud Smells

- Move some JavaDocs to be above the class.
- Add some JavaDocs to some classes where they were missing.
- Make the logging string concatenation be "lazy" so the concatenation only happens if the logging level is enabled.

## Issue

#79.