### PR TITLE
79: Date and Time for the Logger

### DIFF
--- a/app/src/main/resources/simplelogger.properties
+++ b/app/src/main/resources/simplelogger.properties
@@ -13,13 +13,14 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Set to true if you want the current date and time to be included in output messages.
 # Default is false, and will output the number of milliseconds elapsed since startup.
-org.slf4j.simpleLogger.showDateTime=false
+org.slf4j.simpleLogger.showDateTime=true
 
 # The date and time format to be used in the output messages.
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
 # If the format is not specified or is invalid, the default format is used.
 # The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+# Currently set to ISO8601 format.
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd'T'HH:mm:ss:SSSZ
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.
@@ -27,7 +28,7 @@ org.slf4j.simpleLogger.showThreadName=true
 
 # Set to true if you want the Logger instance name to be included in output messages.
 # Defaults to true.
-org.slf4j.simpleLogger.showLogName=true
+org.slf4j.simpleLogger.showLogName=false
 
 # Set to true if you want the last component of the name to be included in output messages.
 # Defaults to false.


### PR DESCRIPTION
# Date and Time for the Logger

Add the date and time to the logger in ISO8601 format.  Also remove the logger name since it was always `tilogger`.

What it looks like now...

```
2023-03-14T16:39:30:122-0500 [main] INFO Info
2023-03-14T16:39:30:123-0500 [main] WARN Warning
2023-03-14T16:39:30:123-0500 [main] ERROR Error
2023-03-14T16:39:30:125-0500 [main] INFO Registering: 
2023-03-14T16:39:30:127-0500 [main] INFO verb: POST, endpoint: /v1/etor/demographics
2023-03-14T16:45:48:547-0500 [JettyServerThreadPool-35] INFO POST http://localhost:8080/v1/etor/demographics
2023-03-14T16:45:48:558-0500 [JettyServerThreadPool-35] INFO Parsing request...
2023-03-14T16:45:48:558-0500 [JettyServerThreadPool-35] INFO Parsing patient demographics
2023-03-14T16:45:49:122-0500 [JettyServerThreadPool-35] INFO Constructing response...
2023-03-14T16:45:49:122-0500 [JettyServerThreadPool-35] INFO Constructing the response
2023-03-14T16:45:49:146-0500 [JettyServerThreadPool-35] INFO Handler complete
```

## Issue

#79.