### PR TITLE
79: Pass in just the RS domain name for the JWT

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -11,6 +11,7 @@ import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,9 +25,9 @@ public class ReportStreamLabOrderSender implements LabOrderSender {
     private static final String RS_AUTH_API_URL =
             ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX") + "/api/token";
     private static final String RS_DOMAIN_NAME =
-            ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX")
-                    .replace("https://", "")
-                    .replace("http://", "");
+            Optional.ofNullable(ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX"))
+                    .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
+                    .orElse("");
     private static final String CLIENT_NAME = "flexion.etor-service-sender";
 
     @Inject private HttpClient client;

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -35,7 +35,6 @@ public class ReportStreamLabOrderSender implements LabOrderSender {
     @Inject private HapiFhir fhir;
 
     public static ReportStreamLabOrderSender getInstance() {
-        System.out.println("RS_DOMAIN_NAME=" + RS_DOMAIN_NAME);
         return INSTANCE;
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -20,14 +20,16 @@ public class ReportStreamLabOrderSender implements LabOrderSender {
 
     private static final ReportStreamLabOrderSender INSTANCE = new ReportStreamLabOrderSender();
 
+    private static final String RS_URL_PREFIX_PROPERTY = "REPORT_STREAM_URL_PREFIX";
     private static final String RS_WATERS_API_URL =
-            ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX") + "/api/waters";
+            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/waters";
     private static final String RS_AUTH_API_URL =
-            ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX") + "/api/token";
+            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/token";
     private static final String RS_DOMAIN_NAME =
-            Optional.ofNullable(ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX"))
+            Optional.ofNullable(ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY))
                     .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
                     .orElse("");
+
     private static final String CLIENT_NAME = "flexion.etor-service-sender";
 
     @Inject private HttpClient client;


### PR DESCRIPTION
# Pass in just the RS domain name for the JWT

- Appended `RS` to the constants.
- Generate the domain name from the passed in URL prefix environment variable so we can use it in generating the JWT.  The JWT should have just the domain name instead of the entire URL.

## Issue

#79.