### PR TITLE
79: Convert @NotNull to @Nonnull Annotation

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
@@ -7,7 +7,6 @@ import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This class implements HttpClient and is a "humble object" for the Apache Client 5 library. Using
@@ -25,9 +24,7 @@ public class ApacheClient implements HttpClient {
     }
 
     @Override
-    public String post(
-            @NotNull String url, @NotNull Map<String, String> headerMap, @NotNull String body)
-            throws IOException {
+    public String post(String url, Map<String, String> headerMap, String body) throws IOException {
         Header[] headers = convertMapToHeader(headerMap);
 
         return Request.post(url)

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java
@@ -11,7 +11,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * This class implements the AuthEngine and is a "humble object" for the Jjwt library. It's main
@@ -28,12 +28,12 @@ public class JjwtEngine implements AuthEngine {
     }
 
     @Override
-    @NotNull
+    @Nonnull
     public String generateSenderToken(
-            @NotNull String sender,
-            @NotNull String baseUrl,
-            @NotNull String pemKey,
-            @NotNull String keyId,
+            @Nonnull String sender,
+            @Nonnull String baseUrl,
+            @Nonnull String pemKey,
+            @Nonnull String keyId,
             int expirationSecondsFromNow)
             throws InvalidKeySpecException, NoSuchAlgorithmException {
 
@@ -54,7 +54,7 @@ public class JjwtEngine implements AuthEngine {
         return jwsObj.compact();
     }
 
-    protected RSAPrivateKey readPrivateKey(@NotNull String pemKey)
+    protected RSAPrivateKey readPrivateKey(@Nonnull String pemKey)
             throws NoSuchAlgorithmException, InvalidKeySpecException {
         String privatePemKey =
                 pemKey.replace("-----BEGIN PRIVATE KEY-----", "")

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -11,8 +11,8 @@ import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import org.jetbrains.annotations.NotNull;
 
 /** Accepts a {@link LabOrder} and sends it to ReportStream. */
 public class ReportStreamLabOrderSender implements LabOrderSender {
@@ -43,7 +43,7 @@ public class ReportStreamLabOrderSender implements LabOrderSender {
         sendRequestBody(json, bearerToken);
     }
 
-    protected String sendRequestBody(@NotNull String json, @NotNull String bearerToken) {
+    protected String sendRequestBody(@Nonnull String json, @Nonnull String bearerToken) {
         String res = "";
         Map<String, String> headers =
                 Map.of(

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/AuthEngine.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/AuthEngine.java
@@ -1,18 +1,18 @@
 package gov.hhs.cdc.trustedintermediary.wrappers;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * This interface provides a blueprint for all auth. related transactions. For example,
  * generateSenderToken() generates a token using ETOR's private key.
  */
 public interface AuthEngine {
-    @NotNull
+    @Nonnull
     String generateSenderToken(
-            @NotNull String sender,
-            @NotNull String baseUrl,
-            @NotNull String pemKey,
-            @NotNull String keyId,
+            @Nonnull String sender,
+            @Nonnull String baseUrl,
+            @Nonnull String pemKey,
+            @Nonnull String keyId,
             int expirationSecondsFromNow)
             throws Exception; // TODO dedicated exception instead of generic
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/ReflectionTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/ReflectionTest.groovy
@@ -1,6 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.context
 
-import org.jetbrains.annotations.NotNull
+
 import spock.lang.Specification
 
 class ReflectionTest extends Specification {
@@ -14,7 +14,7 @@ class ReflectionTest extends Specification {
 
     static class DogCow implements Comparable {
         @Override
-        int compareTo(@NotNull final Object o) {
+        int compareTo(final Object o) {
             return 0
         }
     }


### PR DESCRIPTION
# Convert `@NotNull` to `@Nonnull` Annotation

The `@Nonnull` is the "official" annotation to annotate a thing that it doesn't support `null`.  `@NotNull` is something JetBrains specific.  I also removed the annotation from the `ApacheClient` because the `HttpClient` interface it was implementing didn't have the annotations.

## Issue

#79.
