### PR TITLE
79: Move to `authoredOn` from `occurrence`

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverter.java
@@ -155,7 +155,7 @@ public class HapiLabOrderConverter implements LabOrderConverter {
 
         serviceRequest.setSubject(new Reference(patient));
 
-        serviceRequest.setOccurrence(new DateTimeType(Date.from(Instant.now())));
+        serviceRequest.setAuthoredOn(Date.from(Instant.now()));
 
         return serviceRequest;
     }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiLabOrderConverterTest.groovy
@@ -96,5 +96,6 @@ class HapiLabOrderConverterTest extends Specification {
         serviceRequest.getCode().getCodingFirstRep().getCode() == "54089-8"
         serviceRequest.getCategoryFirstRep().getCodingFirstRep().getCode() == "108252007"
         serviceRequest.getSubject().getResource() == labOrderBundle.getEntry().get(1).getResource()
+        serviceRequest.getAuthoredOn() != null
     }
 }

--- a/examples/fhir/lab_order.json
+++ b/examples/fhir/lab_order.json
@@ -1,16 +1,16 @@
 {
   "resourceType": "Bundle",
-  "id": "fd03c4b6-0ad4-4cdd-832f-28b18cd94ee9",
+  "id": "969bcbb3-cd34-49be-ac4f-e1b8479b8219",
   "identifier": {
-    "value": "fd03c4b6-0ad4-4cdd-832f-28b18cd94ee9"
+    "value": "969bcbb3-cd34-49be-ac4f-e1b8479b8219"
   },
   "type": "message",
-  "timestamp": "2023-03-13T09:57:49.536-05:00",
+  "timestamp": "2023-03-20T10:00:37.103-05:00",
   "entry": [
     {
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "665fe0e7-5681-48cc-9953-366c0712650e",
+        "id": "3b5e0ea5-f204-4cb1-8027-7adf07d8065b",
         "eventCoding": {
           "system": "http://terminology.hl7.org/CodeSystem/v2-0003",
           "code": "O21",
@@ -103,7 +103,7 @@
     {
       "resource": {
         "resourceType": "ServiceRequest",
-        "id": "7df300be-3b89-4c18-b454-b72036555855",
+        "id": "0beae7d1-7b3a-4a80-a3d3-7c2ae5e61e15",
         "status": "active",
         "intent": "order",
         "category": [
@@ -129,7 +129,7 @@
         "subject": {
           "reference": "Patient/infant-twin-1"
         },
-        "occurrenceDateTime": "2023-03-13T09:57:49-05:00"
+        "authoredOn": "2023-03-20T10:00:37-05:00"
       }
     }
   ]


### PR DESCRIPTION
# Move to `authoredOn` from `occurrence`

Changed to use `authoredOn` instead of `occurrence` in the `ServiceRequest`.  This is because of the FHIR -> HL7v2 conversion rules.

## Issue

#79.