### PR TITLE
Remove the IDE-specific Folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "cSpell.words": [
-        "ATSDR",
-        "CFPB",
-        "ISSO",
-        "cybersecurity"
-    ]
-}


### PR DESCRIPTION
# Remove the IDE-specific Folder

Removed the directory associated with VS Code.  We shouldn't have IDE-specific directories in our code.  We are agnostic and support any IDE a developer wants to use.

## Issue

_No issue._