### PR TITLE
Lab Order Exception Handling

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -10,6 +10,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsController;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResponse;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.UnableToSendLabOrderException;
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiLabOrderConverter;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalFileLabOrderSender;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamLabOrderSender;
@@ -66,7 +67,12 @@ public class EtorDomainRegistration implements DomainConnector {
 
         var demographics = patientDemographicsController.parseDemographics(request);
 
-        convertAndSendLabOrderUsecase.convertAndSend(demographics);
+        try {
+            convertAndSendLabOrderUsecase.convertAndSend(demographics);
+        } catch (UnableToSendLabOrderException e) {
+            logger.logError("Unable to send lab order", e);
+            return patientDemographicsController.constructResponse(400, e);
+        }
 
         PatientDemographicsResponse patientDemographicsResponse =
                 new PatientDemographicsResponse(demographics);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/ConvertAndSendLabOrderUsecase.java
@@ -21,7 +21,7 @@ public class ConvertAndSendLabOrderUsecase {
 
     private ConvertAndSendLabOrderUsecase() {}
 
-    public void convertAndSend(Demographics<?> demographics) {
+    public void convertAndSend(Demographics<?> demographics) throws UnableToSendLabOrderException {
         LabOrder<?> labOrder = converter.convertToOrder(demographics);
         sender.sendOrder(labOrder);
     }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/LabOrderSender.java
@@ -2,5 +2,5 @@ package gov.hhs.cdc.trustedintermediary.etor.demographics;
 
 /** Interface for sending a lab order. */
 public interface LabOrderSender {
-    void sendOrder(LabOrder<?> order);
+    void sendOrder(LabOrder<?> order) throws UnableToSendLabOrderException;
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/PatientDemographicsController.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/PatientDemographicsController.java
@@ -55,4 +55,19 @@ public class PatientDemographicsController {
 
         return response;
     }
+
+    public DomainResponse constructResponse(int httpStatus, Exception exception) {
+        var domainResponse = new DomainResponse(httpStatus);
+
+        try {
+            var responseBody = formatter.convertToString(Map.of("error", exception.getMessage()));
+            domainResponse.setBody(responseBody);
+        } catch (FormatterProcessingException e) {
+            logger.logError("Error constructing demographics response", e);
+            throw new RuntimeException(e);
+        }
+        domainResponse.setHeaders(Map.of(CONTENT_TYPE_LITERAL, APPLICATION_JSON_LITERAL));
+
+        return domainResponse;
+    }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/UnableToSendLabOrderException.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/demographics/UnableToSendLabOrderException.java
@@ -1,0 +1,7 @@
+package gov.hhs.cdc.trustedintermediary.etor.demographics;
+
+public class UnableToSendLabOrderException extends Exception {
+    public UnableToSendLabOrderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSender.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.localfile;
 
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrderSender;
+import gov.hhs.cdc.trustedintermediary.etor.demographics.UnableToSendLabOrderException;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import java.nio.charset.StandardCharsets;
@@ -25,7 +26,7 @@ public class LocalFileLabOrderSender implements LabOrderSender {
     private LocalFileLabOrderSender() {}
 
     @Override
-    public void sendOrder(final LabOrder<?> order) {
+    public void sendOrder(final LabOrder<?> order) throws UnableToSendLabOrderException {
         var fileLocation = Paths.get(LOCAL_FILE_NAME);
         logger.logInfo("Sending the order to the hard drive at {}", fileLocation.toAbsolutePath());
 
@@ -33,8 +34,7 @@ public class LocalFileLabOrderSender implements LabOrderSender {
             String serialized = fhir.encodeResourceToJson(order.getUnderlyingOrder());
             Files.writeString(fileLocation, serialized, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            logger.logError("Error writing the lab order", e);
-            throw new RuntimeException(e);
+            throw new UnableToSendLabOrderException("Error writing the lab order", e);
         }
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSender.java
@@ -97,8 +97,6 @@ public class ReportStreamLabOrderSender implements LabOrderSender {
                             300);
             body = composeRequestBody(senderToken);
             String rsResponse = client.post(RS_AUTH_API_URL, headers, body);
-            // TODO response handling for good structure of response, else it will fail to extract
-            // the key
             token = extractToken(rsResponse);
         } catch (Exception e) {
             throw new UnableToSendLabOrderException(

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClientException.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClientException.java
@@ -1,9 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.wrappers;
 
-import java.io.IOException;
-
 /** Custom exception class use to catch any exception coming from an HTTP request */
-public class HttpClientException extends IOException {
+public class HttpClientException extends Exception {
 
     public HttpClientException(String message, Throwable cause) {
         super(message, cause);

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSenderTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileLabOrderSenderTest.groovy
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.localfile
 
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.demographics.LabOrder
+import gov.hhs.cdc.trustedintermediary.etor.demographics.UnableToSendLabOrderException
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir
 import spock.lang.Specification
 
@@ -64,7 +65,7 @@ class LocalFileLabOrderSenderTest extends Specification{
         LocalFileLabOrderSender.getInstance().sendOrder(mockOrder)
 
         then:
-        def exception = thrown(RuntimeException)
+        def exception = thrown(UnableToSendLabOrderException)
         exception.getCause() == nullException
     }
 }


### PR DESCRIPTION
# Lab Order Exception Handling (UnableToSendLabOrderException)

This PR adds exception handling for lab orders.  The `UnableToSendLabOrderException` gets triggered by multiple exceptions ranging from format, IO, and runtime exceptions. All these exceptions can happen during the process of sending a lab order.

## Issue
#84 

