### PR TITLE
Updated output path for dora metrics

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -43,4 +43,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: dora-metrics
-          path: devops-deployment-metrics/*.csv
+          path: devops-deployment-metrics/data/*.csv


### PR DESCRIPTION
# Updated output path for dora metrics

Based on this change: https://github.com/basiliskus/devops-deployment-metrics/pull/1

## Issue

#198 
