### PR TITLE
Implementation Guide Docs Terraform

### DIFF
--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_linux_web_app" "api" {
 
 resource "azurerm_storage_account" "docs" {
   name                     = "cdcti${var.environment}docs"
-  resource_group_name = azurerm_resource_group.group.name
+  resource_group_name      = azurerm_resource_group.group.name
 
   location                 = azurerm_resource_group.group.location
   account_tier             = "Standard"

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -55,3 +55,17 @@ resource "azurerm_linux_web_app" "api" {
     type = "SystemAssigned"
   }
 }
+
+resource "azurerm_storage_account" "docs" {
+  name                     = "cdcti${var.environment}docs"
+  resource_group_name = azurerm_resource_group.group.name
+
+  location                 = azurerm_resource_group.group.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  account_kind             = "StorageV2"
+
+  static_website {
+    index_document = "index.html"
+  }
+}

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -59,7 +59,6 @@ resource "azurerm_linux_web_app" "api" {
 resource "azurerm_storage_account" "docs" {
   name                     = "cdcti${var.environment}docs"
   resource_group_name      = azurerm_resource_group.group.name
-
   location                 = azurerm_resource_group.group.location
   account_tier             = "Standard"
   account_replication_type = "GRS"


### PR DESCRIPTION
# Implementation Guide Docs Terraform

Adding terraform provisioning of the infrastructure hosting our implementation guide documentation. This uses just a single Azure storage account with a static site configuration.

## Issue
#178 
