### PR TITLE
Bug Fix - JWT Unit Test

### DIFF
--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngineTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngineTest.groovy
@@ -75,14 +75,14 @@ class JjwtEngineTest extends Specification {
         def date = new Date(
                 System.currentTimeMillis()
                 + (300 * 1000L))
-        def expected = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).truncatedTo(ChronoUnit.SECONDS)
+        def expected = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()).truncatedTo(ChronoUnit.MINUTES)
 
         when:
         def jwt = jwtEngine.getInstance().generateSenderToken("DogCow", "fake_URL", pemKey, "Dogcow", 300)
         def actual = jwtEngine.getExpirationDate(jwt)
 
         then:
-        actual == expected
+        actual.truncatedTo(ChronoUnit.MINUTES) == expected
     }
 
     def "getExpirationDate works bad path"() {


### PR DESCRIPTION
# JWT Check Expiration Date Happy Path

This PR addresses the bug where the happy path for checking a jwt expiration date would occasionally fail do to time precision. To fix this issue, the precision was lowered to minutes.

## Issue
#312 

