### PR TITLE
Adding public key storage for trusted orgs

### DIFF
--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -34,6 +34,30 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
+resource "azurerm_key_vault_secret" "trusted_intermediary_public_key" {
+  name  = "organization-trusted-intermediary-public-key-${var.environment}"
+  value = "dogcow"
+
+  key_vault_id = azurerm_key_vault.key_storage.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+  depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
+}
+
+resource "azurerm_key_vault_secret" "report_stream_public_key" {
+  name  = "organization-report-stream-public-key-${var.environment}"
+  value = "dogcow"
+
+  key_vault_id = azurerm_key_vault.key_storage.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+  depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
+}
+
 resource "azurerm_key_vault_secret" "report_stream_sender_private_key" {
   name  = "report-stream-sender-private-key-${var.environment}"
   value = "dogcow"


### PR DESCRIPTION
# Adding Public Key Storage for Trusted Orgs

This provides terraform provisioning for the RS & TI public keys. Only placeholder values for the keys are actually are added.

## Issue

#148 

## Checklist

n/a

**Note**: You may remove items that are not applicable
