### PR TITLE
Cache Synchronization Fails Occasionally

### DIFF
--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSenderTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamLabOrderSenderTest.groovy
@@ -19,6 +19,8 @@ import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import spock.lang.Specification
 
+import java.util.concurrent.ConcurrentHashMap
+
 class ReportStreamLabOrderSenderTest extends Specification {
 
     def setup() {
@@ -255,7 +257,7 @@ class ReportStreamLabOrderSenderTest extends Specification {
         def labOrderSender = ReportStreamLabOrderSender.getInstance()
         def threadNums = 5
         def iterations = 25
-        def table = new HashMap<String, Integer>()
+        def table = new ConcurrentHashMap<String, Integer>()
 
         when:
         List<Thread> threads = []


### PR DESCRIPTION
# rsTokenCache Synchronization Fails Occasionally

The synchronization test for the rsTokenCache tends to fail occasionally. Since the cache is only a string variable, we needed a way to verify that each thread was firing to the last iteration. A hashmap was created to house the thread number as the key and the iteration as the value. The issue with this was that the hashmap is not thread-safe. 

In order to address this issue, the hashmap was changed to a concurrent hashmap.

## Issue
Bug hot-fix


## Checklist

- [x] I have added tests to cover my changes
