### PR TITLE
Work Around for Bad Docker Compose Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,25 @@ jobs:
     name: Docker Build Test
     runs-on: ubuntu-latest
     steps:
+
       - uses: actions/checkout@v3
+
       - uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: corretto
           cache: gradle
+
       - name: ShadowJar
         run: ./gradlew shadowJar
+
+      - name: Install Latest Version of Docker Compose v2
+        run: |
+          COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq '.tag_name' -r)
+          INSTALL_LOCATION=/usr/libexec/docker/cli-plugins/docker-compose
+          sudo curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o ${INSTALL_LOCATION}
+          sudo chmod +x ${INSTALL_LOCATION}
+          docker compose version
 
       - name: Run Container
         run: docker compose up --build -d

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -26,6 +26,14 @@ jobs:
       - name: ShadowJar
         run: ./gradlew clean shadowJar
 
+      - name: Install Latest Version of Docker Compose v2
+        run: |
+          COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq '.tag_name' -r)
+          INSTALL_LOCATION=/usr/libexec/docker/cli-plugins/docker-compose
+          sudo curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o ${INSTALL_LOCATION}
+          sudo chmod +x ${INSTALL_LOCATION}
+          docker compose version
+
       - name: Run App in Container
         run: docker compose up --build -d
 


### PR DESCRIPTION
# Work Around for Bad Docker Compose Version

Lately, our Docker Compose builds have been failing.  This is due to an [issue](https://github.com/docker/compose/issues/10574) introduced in version 2.18.0.  This was subsequently fixed in [version 2.18.1](https://github.com/docker/compose/releases/tag/v2.18.1), but it seems the GitHub Action runners have not updated yet.

We should remove this change at a later point in time.  I created #368 to remind us.

## Issue

_None_.

## Checklist

- [x] _None are applicable_.

**Note**: You may remove items that are not applicable
