### PR TITLE
Removed github username as it is not required

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run DORA metrics application
         working-directory: devops-deployment-metrics
         env:
-          GITHUB_USERNAME: JohnNKing
+          GITHUB_USERNAME: None
           GITHUB_PASSWORD: ${{ secrets.DORA_METRICS_ACCESS_TOKEN_JOHNNKING }}
         run: poetry run devops-deployment-metrics -c config.toml
 


### PR DESCRIPTION
Removed the github username as it's not required by `devops-deployment-metrics`. Only the token is required

## Checklist

N/A
