### PR TITLE
Update github workflow for devops-deployment-metrics repo

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up config file
         uses: DamianReeves/write-file-action@master
         with:
-          path: config.toml
+          path: devops-deployment-metrics/config.toml
           write-mode: overwrite
           contents: |
             [general]

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -29,8 +29,24 @@ jobs:
         run: poetry install
 
       - name: Set up config file
-        working-directory: devops-deployment-metrics
-        run: sed -e '14,18d' -e 's/my_github_owner/CDCgov/' -e 's/my_github_repository/trusted-intermediary/' -e 's/12345678/42635194/' sample-config.toml > config.toml
+        uses: DamianReeves/write-file-action@master
+        with:
+          path: config.toml
+          write-mode: overwrite
+          contents: |
+            [general]
+            time-slice-days = 7
+            start-date = 2022-12-01T00:01:00
+            date-format = "%Y-%m-%d"
+
+            [[repositories]]
+            owner = "CDCgov"
+            repo = "trusted-intermediary"
+            id = "42635194"
+            deployment-frequency = "df"
+            change-fail-rate = "cf"
+            mean-time-to-recover = "mttrs"
+            deployment-log = "deployments"
 
       - name: Run DORA metrics application
         working-directory: devops-deployment-metrics

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: devops-deployment-metrics
         env:
           GITHUB_USERNAME: None
-          GITHUB_PASSWORD: ${{ secrets.DORA_METRICS_ACCESS_TOKEN_JOHNNKING }}
+          GITHUB_TOKEN: ${{ secrets.DORA_METRICS_ACCESS_TOKEN_JOHNNKING }}
         run: poetry run devops-deployment-metrics -c config.toml
 
       - name: Upload output metric files

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run DORA metrics application
         working-directory: devops-deployment-metrics
         env:
-          GITHUB_USERNAME: JohnNKing
+          GITHUB_USERNAME: None
           GITHUB_PASSWORD: ${{ secrets.DORA_METRICS_ACCESS_TOKEN_JOHNNKING }}
         run: poetry run devops-deployment-metrics -c config.toml
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout devops-deployment-metrics code
         uses: actions/checkout@v3
         with:
-          repository: basiliskus/devops-deployment-metrics
+          repository: flexion/devops-deployment-metrics
           path: devops-deployment-metrics
 
       - name: Install dependencies


### PR DESCRIPTION
# Update github workflow for devops-deployment-metrics repo

- Updated repo url for `devops-deployment-metrics` repo now that the PR has been merged
- Removed github username as it's not required by devops-deployment-metrics. Only the token is required
-  Updated to create whole content of config.toml file

## Issue

#317 