### PR TITLE
Block Storage Account Public Access

### DIFF
--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -57,13 +57,13 @@ resource "azurerm_linux_web_app" "api" {
 }
 
 resource "azurerm_storage_account" "docs" {
-  name                              = "cdcti${var.environment}docs"
-  resource_group_name               = azurerm_resource_group.group.name
-  location                          = azurerm_resource_group.group.location
-  account_tier                      = "Standard"
-  account_replication_type          = "GRS"
-  account_kind                      = "StorageV2"
-  allow_nested_items_to_be_public   = false
+  name                            = "cdcti${var.environment}docs"
+  resource_group_name             = azurerm_resource_group.group.name
+  location                        = azurerm_resource_group.group.location
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
+  account_kind                    = "StorageV2"
+  allow_nested_items_to_be_public = false
 
   static_website {
     index_document = "index.html"

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -57,12 +57,13 @@ resource "azurerm_linux_web_app" "api" {
 }
 
 resource "azurerm_storage_account" "docs" {
-  name                     = "cdcti${var.environment}docs"
-  resource_group_name      = azurerm_resource_group.group.name
-  location                 = azurerm_resource_group.group.location
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
-  account_kind             = "StorageV2"
+  name                              = "cdcti${var.environment}docs"
+  resource_group_name               = azurerm_resource_group.group.name
+  location                          = azurerm_resource_group.group.location
+  account_tier                      = "Standard"
+  account_replication_type          = "GRS"
+  account_kind                      = "StorageV2"
+  allow_nested_items_to_be_public   = false
 
   static_website {
     index_document = "index.html"


### PR DESCRIPTION
# Block Storage Account Public Access

Prevent public access to API docs. This is likely a good pattern to follow for future storage accounts. This does not appear to limit access via the static website setting.

## Issue

#148

## Checklist

n/a
