### PR TITLE
Ignore output for api server to reduce noise in load test output

### DIFF
--- a/load-execute.sh
+++ b/load-execute.sh
@@ -3,7 +3,7 @@ set -e
 
 start_api() {
     echo 'Starting API'
-    ./gradlew --no-daemon app:clean app:run &
+    ./gradlew --no-daemon app:clean app:run > /dev/null 2>&1 &
     export API_PID="${!}"
     echo "API starting at PID ${API_PID}"
 }


### PR DESCRIPTION
Muting output for api server so we can read the load test in output in console when running `load-execute.sh`
