### PR TITLE
Enforce Bearer Token

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -101,13 +101,13 @@ public class EtorDomainRegistration implements DomainConnector {
     }
 
     DomainResponse handleOrders(DomainRequest domainRequest) {
-        // Validate token
+        // TODO Validate token
 
-        // var orders = OrdersController.ParseOrders(request);
+        // TODO var orders = OrdersController.ParseOrders(request);
 
-        // convertAndSendLabOrderUseCase.covertAndSend(order);
+        // TODO convertAndSendLabOrderUseCase.covertAndSend(order);
 
-        // return OrderController.constructResponse(OrdersResponse);
+        // TODO return OrderController.constructResponse(OrdersResponse);
         return new DomainResponse(200);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -100,11 +100,26 @@ public class EtorDomainRegistration implements DomainConnector {
         return patientDemographicsController.constructResponse(patientDemographicsResponse);
     }
 
-    DomainResponse handleOrders(DomainRequest domainRequest) {
+    DomainResponse handleOrders(DomainRequest request) {
         //  Validate token
-        //  var orders = OrdersController.ParseOrders(request)
+        try {
+            if (!authValidator.isValidAuthenticatedRequest(request)) {
+                var errorMessage = "The request failed the authentication check";
+                logger.logError(errorMessage);
+
+                // ordersController.constructResponse(401, errorMessage)
+                return new DomainResponse(401);
+            }
+        } catch (SecretRetrievalException | IllegalArgumentException e) {
+            logger.logFatal("Unable to validate whether the request is authenticated", e);
+
+            // return ordersController.constructResponse(500, e)
+            return new DomainResponse(500);
+        }
+
+        //  var orders = ordersController.ParseOrders(request)
         //  convertAndSendLabOrderUseCase.covertAndSend(order)
-        //  return OrdersController.constructResponse(OrdersResponse)
+        //  return ordersController.constructResponse(OrdersResponse)
         return new DomainResponse(200);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -101,13 +101,13 @@ public class EtorDomainRegistration implements DomainConnector {
     }
 
     DomainResponse handleOrders(DomainRequest domainRequest) {
-        // TODO Validate token
+        //  Validate token
 
-        // TODO var orders = OrdersController.ParseOrders(request);
+        //  var orders = OrdersController.ParseOrders(request);
 
-        // TODO convertAndSendLabOrderUseCase.covertAndSend(order);
+        //  convertAndSendLabOrderUseCase.covertAndSend(order);
 
-        // TODO return OrdersController.constructResponse(OrdersResponse);
+        //  return OrdersController.constructResponse(OrdersResponse);
         return new DomainResponse(200);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -102,12 +102,9 @@ public class EtorDomainRegistration implements DomainConnector {
 
     DomainResponse handleOrders(DomainRequest domainRequest) {
         //  Validate token
-
-        //  var orders = OrdersController.ParseOrders(request);
-
-        //  convertAndSendLabOrderUseCase.covertAndSend(order);
-
-        //  return OrdersController.constructResponse(OrdersResponse);
+        //  var orders = OrdersController.ParseOrders(request)
+        //  convertAndSendLabOrderUseCase.covertAndSend(order)
+        //  return OrdersController.constructResponse(OrdersResponse)
         return new DomainResponse(200);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -26,7 +26,8 @@ import java.util.function.Function;
 import javax.inject.Inject;
 
 /**
- * The domain connector for the ETOR domain. It connects it with the larger trusted intermediary.
+ * The domain connector for the ETOR domain. It connects it with the larger trusted intermediary. It
+ * houses the request processing logic for the demographics and orders endpoints.
  */
 public class EtorDomainRegistration implements DomainConnector {
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -100,7 +100,7 @@ public class EtorDomainRegistration implements DomainConnector {
         return patientDemographicsController.constructResponse(patientDemographicsResponse);
     }
 
-    private DomainResponse handleOrders(DomainRequest domainRequest) {
+    DomainResponse handleOrders(DomainRequest domainRequest) {
         // Validate token
 
         // var orders = OrdersController.ParseOrders(request);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -36,7 +36,9 @@ public class EtorDomainRegistration implements DomainConnector {
     @Inject AuthRequestValidator authValidator;
 
     private final Map<HttpEndpoint, Function<DomainRequest, DomainResponse>> endpoints =
-            Map.of(new HttpEndpoint("POST", "/v1/etor/demographics"), this::handleOrder);
+            Map.of(
+                    new HttpEndpoint("POST", "/v1/etor/demographics"), this::handleDemographics,
+                    new HttpEndpoint("POST", "/v1/etor/orders"), this::handleOrders);
 
     @Override
     public Map<HttpEndpoint, Function<DomainRequest, DomainResponse>> domainRegistration() {
@@ -69,7 +71,7 @@ public class EtorDomainRegistration implements DomainConnector {
         }
     }
 
-    DomainResponse handleOrder(DomainRequest request) {
+    DomainResponse handleDemographics(DomainRequest request) {
 
         // Validate token
         try {
@@ -96,5 +98,16 @@ public class EtorDomainRegistration implements DomainConnector {
                 new PatientDemographicsResponse(demographics);
 
         return patientDemographicsController.constructResponse(patientDemographicsResponse);
+    }
+
+    private DomainResponse handleOrders(DomainRequest domainRequest) {
+        // Validate token
+
+        // var orders = OrdersController.ParseOrders(request);
+
+        // convertAndSendLabOrderUseCase.covertAndSend(order);
+
+        // return OrderController.constructResponse(OrdersResponse);
+        return new DomainResponse(200);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -107,7 +107,7 @@ public class EtorDomainRegistration implements DomainConnector {
 
         // TODO convertAndSendLabOrderUseCase.covertAndSend(order);
 
-        // TODO return OrderController.constructResponse(OrdersResponse);
+        // TODO return OrdersController.constructResponse(OrdersResponse);
         return new DomainResponse(200);
     }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -24,14 +24,16 @@ class EtorDomainRegistrationTest extends Specification {
     def "domain registration has endpoints"() {
         given:
         def domainRegistration = new EtorDomainRegistration()
-        def specifiedEndpoint = new HttpEndpoint("POST", "/v1/etor/demographics")
+        def demographicsEndpoint = new HttpEndpoint("POST", "/v1/etor/demographics")
+        def ordersEndpoint = new HttpEndpoint("POST", "/v1/etor/orders")
 
         when:
         def endpoints = domainRegistration.domainRegistration()
 
         then:
         !endpoints.isEmpty()
-        endpoints.get(specifiedEndpoint) != null
+        endpoints.get(demographicsEndpoint) != null
+        endpoints.get(ordersEndpoint) != null
     }
 
     def "has an OpenAPI specification"() {
@@ -81,7 +83,7 @@ class EtorDomainRegistrationTest extends Specification {
         1 * mockUsecase.convertAndSend(_ as Demographics)
     }
 
-    def "handleOrder generates an error response when the usecase throws an exception"() {
+    def "handleDemographics generates an error response when the usecase throws an exception"() {
         given:
         def domainRegistration = new EtorDomainRegistration()
         def mockDemographicConrollor = Mock(PatientDemographicsController)

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -193,4 +193,25 @@ class EtorDomainRegistrationTest extends Specification {
         then:
         actual == expected
     }
+
+    def "Orders endpoint validator throws SecretRetrievalException unhappy path"() {
+        given:
+        def mockAuthValidator = Mock(AuthRequestValidator)
+        TestApplicationContext.register(AuthRequestValidator, mockAuthValidator)
+        def expected = 500
+        def connector = new EtorDomainRegistration()
+        TestApplicationContext.register(EtorDomainRegistration, connector)
+        def req = new DomainRequest()
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        mockAuthValidator.isValidAuthenticatedRequest(_ as DomainRequest) >> {
+            throw new SecretRetrievalException("DogCaow", new NullPointerException())
+        }
+        def res = connector.handleOrders(req)
+        def actual = res.statusCode
+
+        then:
+        actual == expected
+    }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -155,4 +155,18 @@ class EtorDomainRegistrationTest extends Specification {
         }
         0 * mockDemographicsController.parseDemographics(_)
     }
+
+    def "Orders endpoint happy path"() {
+        given:
+        def expected = 200
+        def connector = new EtorDomainRegistration()
+        def req = new DomainRequest()
+
+        when:
+        def res = connector.handleOrders(req)
+        def actual = res.statusCode
+
+        then:
+        actual == expected
+    }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -214,4 +214,26 @@ class EtorDomainRegistrationTest extends Specification {
         then:
         actual == expected
     }
+
+    def "Orders endpoint validator throws IllegalArgumentException unhappy path"() {
+        given:
+        def mockAuthValidator = Mock(AuthRequestValidator)
+        TestApplicationContext.register(AuthRequestValidator, mockAuthValidator)
+        def expected = 500
+        def connector = new EtorDomainRegistration()
+        TestApplicationContext.register(EtorDomainRegistration, connector)
+        def req = new DomainRequest()
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        mockAuthValidator.isValidAuthenticatedRequest(_ as DomainRequest) >> {
+            throw new IllegalArgumentException("DogCaow", new NullPointerException())
+        }
+        def res = connector.handleOrders(req)
+        def actual = res.statusCode
+        println("status code: " + actual)
+
+        then:
+        actual == expected
+    }
 }

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -158,11 +158,16 @@ class EtorDomainRegistrationTest extends Specification {
 
     def "Orders endpoint happy path"() {
         given:
+        def mockAuthValidator = Mock(AuthRequestValidator)
+        TestApplicationContext.register(AuthRequestValidator, mockAuthValidator)
         def expected = 200
         def connector = new EtorDomainRegistration()
+        TestApplicationContext.register(EtorDomainRegistration, connector)
         def req = new DomainRequest()
+        TestApplicationContext.injectRegisteredImplementations()
 
         when:
+        mockAuthValidator.isValidAuthenticatedRequest(_ as DomainRequest) >> true
         def res = connector.handleOrders(req)
         def actual = res.statusCode
 

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -72,7 +72,7 @@ class EtorDomainRegistrationTest extends Specification {
         def domainRequest = new DomainRequest()
 
         when:
-        domainRegistration.handleOrder(domainRequest)
+        domainRegistration.handleDemographics(domainRequest)
 
         then:
         1 * mockDemographicsController.constructResponse(_ as PatientDemographicsResponse) >> { PatientDemographicsResponse demographicsResponse ->
@@ -100,7 +100,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def res = domainRegistration.handleOrder(domainRequest)
+        def res = domainRegistration.handleDemographics(domainRequest)
 
         then:
         res.statusCode == 400
@@ -121,7 +121,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        domainRegistration.handleOrder(new DomainRequest())
+        domainRegistration.handleDemographics(new DomainRequest())
 
         then:
         1 * mockDemographicsController.constructResponse(_ as Integer, _ as String) >> { Integer httpStatus, String errorString ->
@@ -145,7 +145,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        domainRegistration.handleOrder(new DomainRequest())
+        domainRegistration.handleDemographics(new DomainRequest())
 
         then:
         1 * mockDemographicsController.constructResponse(_ as Integer, _ as Exception) >> { Integer httpStatus, Exception exception ->

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -174,4 +174,23 @@ class EtorDomainRegistrationTest extends Specification {
         then:
         actual == expected
     }
+
+    def "Orders endpoint validator returns false unhappy path" () {
+        given:
+        def mockAuthValidator = Mock(AuthRequestValidator)
+        TestApplicationContext.register(AuthRequestValidator, mockAuthValidator)
+        def expected = 401
+        def connector = new EtorDomainRegistration()
+        TestApplicationContext.register(EtorDomainRegistration, connector)
+        def req = new DomainRequest()
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        mockAuthValidator.isValidAuthenticatedRequest(_ as DomainRequest) >> false
+        def res = connector.handleOrders(req)
+        def actual = res.statusCode
+
+        then:
+        actual == expected
+    }
 }


### PR DESCRIPTION
# Orders Endpoint Enforce Bearer Token

This PR adds the logic, to the orders endpoint, to enforce a bearer token.

## Issue
#382 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
