### PR TITLE
382: Implementation Guide Sync

### DIFF
--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -117,4 +117,4 @@ jobs:
       uses: azure/CLI@v1
       with:
         inlineScript: |
-            az storage blob sync --account-name cdcti${{ inputs.ENVIRONMENT }}docs -c '$web' -s ${{ steps.extract.outputs.destination }} --auth-mode key
+            az storage blob sync --account-name cdcti${{ inputs.ENVIRONMENT }}docs -c '$web' -s ${{ steps.extract.outputs.destination }}

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -117,4 +117,4 @@ jobs:
       uses: azure/CLI@v1
       with:
         inlineScript: |
-            az storage blob upload-batch --account-name cdcti${{ inputs.ENVIRONMENT }}docs --overwrite --auth-mode key -d '$web' -s ${{ steps.extract.outputs.destination }}
+            az storage blob sync --account-name cdcti${{ inputs.ENVIRONMENT }}docs -c '$web' -s ${{ steps.extract.outputs.destination }} --auth-mode key


### PR DESCRIPTION
# Implementation Guide Sync

Use `sync` to deploy our implementation guide.  This will delete any old files that are no longer needed by the latest deploy of an implementation guide.

## Issue

#382.

## Checklist

- [n/a] I have added tests to cover my changes
- [n/a] I have added logging where useful (with appropriate log level)
- [n/a] I have added JavaDocs where required
- [n/a] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
