### PR TITLE
382: Logging Locally

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,7 +131,8 @@ tasks.named('test') {
         excludes = [
             '**/javalin/App*',
             '**/jackson/Jackson*',
-            '**/slf4j/Slf4jLogger*',
+            '**/slf4j/LocalLogger*',
+            '**/slf4j/DeployedLogger*',
             '**/hapi/HapiFhirImplementation*',
             '**/jjwt/JjwtEngine*',
             '**/apache/ApacheClient*',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,7 @@ tasks.named('test') {
             '**/jackson/Jackson*',
             '**/slf4j/LocalLogger*',
             '**/slf4j/DeployedLogger*',
+            '**/slf4j/LoggerHelper*',
             '**/hapi/HapiFhirImplementation*',
             '**/jjwt/JjwtEngine*',
             '**/apache/ApacheClient*',

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -67,8 +67,8 @@ public class App {
         ApplicationContext.register(
                 Logger.class,
                 ApplicationContext.getEnvironment().equalsIgnoreCase("local")
-                        ? LocalLogger.getLogger()
-                        : DeployedLogger.getLogger());
+                        ? LocalLogger.getInstance()
+                        : DeployedLogger.getInstance());
         ApplicationContext.register(Formatter.class, Jackson.getInstance());
         ApplicationContext.register(HapiFhir.class, HapiFhirImplementation.getInstance());
         ApplicationContext.register(YamlCombiner.class, Jackson.getInstance());

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -13,8 +13,8 @@ import gov.hhs.cdc.trustedintermediary.external.inmemory.KeyCache;
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson;
 import gov.hhs.cdc.trustedintermediary.external.jjwt.JjwtEngine;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalSecrets;
+import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger;
-import gov.hhs.cdc.trustedintermediary.external.slf4j.Slf4jLogger;
 import gov.hhs.cdc.trustedintermediary.organizations.OrganizationsSettings;
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
 import gov.hhs.cdc.trustedintermediary.wrappers.Cache;
@@ -68,7 +68,7 @@ public class App {
                 Logger.class,
                 ApplicationContext.getEnvironment().equalsIgnoreCase("local")
                         ? LocalLogger.getLogger()
-                        : Slf4jLogger.getLogger());
+                        : DeployedLogger.getLogger());
         ApplicationContext.register(Formatter.class, Jackson.getInstance());
         ApplicationContext.register(HapiFhir.class, HapiFhirImplementation.getInstance());
         ApplicationContext.register(YamlCombiner.class, Jackson.getInstance());

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -13,6 +13,7 @@ import gov.hhs.cdc.trustedintermediary.external.inmemory.KeyCache;
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson;
 import gov.hhs.cdc.trustedintermediary.external.jjwt.JjwtEngine;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalSecrets;
+import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.Slf4jLogger;
 import gov.hhs.cdc.trustedintermediary.organizations.OrganizationsSettings;
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
@@ -63,7 +64,11 @@ public class App {
     }
 
     private static void registerClasses() {
-        ApplicationContext.register(Logger.class, Slf4jLogger.getLogger());
+        ApplicationContext.register(
+                Logger.class,
+                ApplicationContext.getEnvironment().equalsIgnoreCase("local")
+                        ? LocalLogger.getLogger()
+                        : Slf4jLogger.getLogger());
         ApplicationContext.register(Formatter.class, Jackson.getInstance());
         ApplicationContext.register(HapiFhir.class, HapiFhirImplementation.getInstance());
         ApplicationContext.register(YamlCombiner.class, Jackson.getInstance());

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -19,7 +19,7 @@ public class DeployedLogger implements Logger {
 
     private DeployedLogger() {}
 
-    public static DeployedLogger getLogger() {
+    public static DeployedLogger getInstance() {
         return INSTANCE;
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -8,9 +8,8 @@ import org.slf4j.MarkerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
 
 /**
- * Humble object interface for logging. This class was created in order to take away the 3rd party
- * dependency of the logger. The idea is to have the logger dependency only in this class. If there
- * ever is a reason to use a different logger, then we only need to make the changes here.
+ * Humble object interface for logging. Uses SLF4J behind the scenes. The deployed logger doesn't
+ * colorize its messages and uses a logger name that uses the JSON structured logging.
  */
 public class DeployedLogger implements Logger {
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -3,9 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.slf4j;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import java.util.Arrays;
 import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-import org.slf4j.spi.LoggingEventBuilder;
+import org.slf4j.event.Level;
 
 /**
  * Humble object interface for logging. Uses SLF4J behind the scenes. The deployed logger doesn't
@@ -24,22 +22,26 @@ public class DeployedLogger implements Logger {
 
     @Override
     public void logTrace(String traceMessage) {
-        LOGGER.atTrace().setMessage(() -> traceMessage).log();
+        Level level = Level.TRACE;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, traceMessage).log();
     }
 
     @Override
     public void logDebug(String debugMessage) {
-        LOGGER.atDebug().setMessage(() -> debugMessage).log();
+        Level level = Level.DEBUG;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, debugMessage).log();
     }
 
     @Override
     public void logDebug(String debugMessage, Throwable e) {
-        LOGGER.atDebug().setMessage(() -> debugMessage).setCause(e).log();
+        Level level = Level.DEBUG;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, debugMessage).setCause(e).log();
     }
 
     @Override
     public void logInfo(String infoMessage, Object... parameters) {
-        var logBuilder = LOGGER.atInfo().setMessage(() -> infoMessage);
+        Level level = Level.INFO;
+        var logBuilder = LoggerHelper.logMessageAtLevel(LOGGER, level, infoMessage);
 
         Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
 
@@ -48,31 +50,34 @@ public class DeployedLogger implements Logger {
 
     @Override
     public void logWarning(String warningMessage) {
-        LOGGER.atWarn().setMessage(() -> warningMessage).log();
+        Level level = Level.WARN;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, warningMessage).log();
     }
 
     @Override
     public void logError(String errorMessage) {
-        LOGGER.atError().setMessage(() -> errorMessage).log();
+        Level level = Level.ERROR;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, errorMessage).log();
     }
 
     @Override
     public void logError(String errorMessage, Throwable e) {
-        LOGGER.atError().setMessage(() -> errorMessage).setCause(e).log();
+        Level level = Level.ERROR;
+        LoggerHelper.logMessageAtLevel(LOGGER, level, errorMessage).setCause(e).log();
     }
 
     @Override
     public void logFatal(String fatalMessage) {
-        logAtFatal().setMessage(() -> fatalMessage).log();
+        Level level = Level.ERROR;
+        LoggerHelper.addFatalMarker(LoggerHelper.logMessageAtLevel(LOGGER, level, fatalMessage))
+                .log();
     }
 
     @Override
     public void logFatal(String fatalMessage, Throwable e) {
-        logAtFatal().setMessage(() -> fatalMessage).setCause(e).log();
-    }
-
-    private LoggingEventBuilder logAtFatal() {
-        Marker fatal = MarkerFactory.getMarker("FATAL");
-        return LOGGER.atError().addMarker(fatal);
+        Level level = Level.ERROR;
+        LoggerHelper.addFatalMarker(LoggerHelper.logMessageAtLevel(LOGGER, level, fatalMessage))
+                .setCause(e)
+                .log();
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -21,21 +21,9 @@ public class DeployedLogger implements Logger {
     }
 
     @Override
-    public void logTrace(String traceMessage) {
-        Level level = Level.TRACE;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, traceMessage).log();
-    }
-
-    @Override
     public void logDebug(String debugMessage) {
         Level level = Level.DEBUG;
         LoggerHelper.logMessageAtLevel(LOGGER, level, debugMessage).log();
-    }
-
-    @Override
-    public void logDebug(String debugMessage, Throwable e) {
-        Level level = Level.DEBUG;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, debugMessage).setCause(e).log();
     }
 
     @Override
@@ -64,13 +52,6 @@ public class DeployedLogger implements Logger {
     public void logError(String errorMessage, Throwable e) {
         Level level = Level.ERROR;
         LoggerHelper.logMessageAtLevel(LOGGER, level, errorMessage).setCause(e).log();
-    }
-
-    @Override
-    public void logFatal(String fatalMessage) {
-        Level level = Level.ERROR;
-        LoggerHelper.addFatalMarker(LoggerHelper.logMessageAtLevel(LOGGER, level, fatalMessage))
-                .log();
     }
 
     @Override

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -22,14 +22,12 @@ public class DeployedLogger implements Logger {
 
     @Override
     public void logDebug(String debugMessage) {
-        Level level = Level.DEBUG;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, debugMessage).log();
+        LoggerHelper.logMessageAtLevel(LOGGER, Level.DEBUG, debugMessage).log();
     }
 
     @Override
     public void logInfo(String infoMessage, Object... parameters) {
-        Level level = Level.INFO;
-        var logBuilder = LoggerHelper.logMessageAtLevel(LOGGER, level, infoMessage);
+        var logBuilder = LoggerHelper.logMessageAtLevel(LOGGER, Level.INFO, infoMessage);
 
         Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
 
@@ -38,26 +36,23 @@ public class DeployedLogger implements Logger {
 
     @Override
     public void logWarning(String warningMessage) {
-        Level level = Level.WARN;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, warningMessage).log();
+        LoggerHelper.logMessageAtLevel(LOGGER, Level.WARN, warningMessage).log();
     }
 
     @Override
     public void logError(String errorMessage) {
-        Level level = Level.ERROR;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, errorMessage).log();
+        LoggerHelper.logMessageAtLevel(LOGGER, Level.ERROR, errorMessage).log();
     }
 
     @Override
     public void logError(String errorMessage, Throwable e) {
-        Level level = Level.ERROR;
-        LoggerHelper.logMessageAtLevel(LOGGER, level, errorMessage).setCause(e).log();
+        LoggerHelper.logMessageAtLevel(LOGGER, Level.ERROR, errorMessage).setCause(e).log();
     }
 
     @Override
     public void logFatal(String fatalMessage, Throwable e) {
-        Level level = Level.ERROR;
-        LoggerHelper.addFatalMarker(LoggerHelper.logMessageAtLevel(LOGGER, level, fatalMessage))
+        LoggerHelper.addFatalMarker(
+                        LoggerHelper.logMessageAtLevel(LOGGER, Level.ERROR, fatalMessage))
                 .setCause(e)
                 .log();
     }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -12,14 +12,14 @@ import org.slf4j.spi.LoggingEventBuilder;
  * dependency of the logger. The idea is to have the logger dependency only in this class. If there
  * ever is a reason to use a different logger, then we only need to make the changes here.
  */
-public class Slf4jLogger implements Logger {
+public class DeployedLogger implements Logger {
 
-    private static final Slf4jLogger INSTANCE = new Slf4jLogger();
+    private static final DeployedLogger INSTANCE = new DeployedLogger();
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("tilogger");
 
-    private Slf4jLogger() {}
+    private DeployedLogger() {}
 
-    public static Slf4jLogger getLogger() {
+    public static DeployedLogger getLogger() {
         return INSTANCE;
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -1,0 +1,90 @@
+package gov.hhs.cdc.trustedintermediary.external.slf4j;
+
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
+import java.util.Arrays;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Humble object interface for logging. This class was created in order to take away the 3rd party
+ * dependency of the logger. The idea is to have the logger dependency only in this class. If there
+ * ever is a reason to use a different logger, then we only need to make the changes here.
+ */
+public class LocalLogger implements Logger {
+
+    private static final LocalLogger INSTANCE = new LocalLogger();
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("local");
+
+    // ANSI escape code
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_GREEN = "\u001B[32m";
+    public static final String ANSI_YELLOW = "\u001B[33m";
+    public static final String ANSI_PURPLE = "\u001B[35m";
+    public static final String ANSI_CYAN = "\u001B[36m";
+
+    private LocalLogger() {}
+
+    public static LocalLogger getLogger() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void logTrace(String traceMessage) {
+        Slf4jLogger.getLoggingEventBuilder(Level.TRACE, ANSI_PURPLE + traceMessage + ANSI_RESET)
+                .log();
+    }
+
+    @Override
+    public void logDebug(String debugMessage) {
+        Slf4jLogger.getLoggingEventBuilder(Level.DEBUG, ANSI_CYAN + debugMessage + ANSI_RESET)
+                .log();
+    }
+
+    @Override
+    public void logDebug(String debugMessage, Throwable e) {
+        Slf4jLogger.getLoggingEventBuilder(Level.DEBUG, ANSI_CYAN + debugMessage + ANSI_RESET)
+                .setCause(e)
+                .log();
+    }
+
+    @Override
+    public void logInfo(String infoMessage, Object... parameters) {
+        var logBuilder =
+                Slf4jLogger.getLoggingEventBuilder(
+                        Level.INFO, ANSI_GREEN + infoMessage + ANSI_RESET);
+
+        Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
+
+        logBuilder.log();
+    }
+
+    @Override
+    public void logWarning(String warningMessage) {
+        Slf4jLogger.getLoggingEventBuilder(Level.WARN, ANSI_YELLOW + warningMessage + ANSI_RESET)
+                .log();
+    }
+
+    @Override
+    public void logError(String errorMessage) {
+        Slf4jLogger.getLoggingEventBuilder(Level.ERROR, ANSI_RED + errorMessage + ANSI_RESET).log();
+    }
+
+    @Override
+    public void logError(String errorMessage, Throwable e) {
+        Slf4jLogger.getLoggingEventBuilder(Level.ERROR, ANSI_RED + errorMessage + ANSI_RESET)
+                .setCause(e)
+                .log();
+    }
+
+    @Override
+    public void logFatal(String fatalMessage) {
+        Slf4jLogger.getLoggingEventBuilder(Level.FATAL, ANSI_RED + fatalMessage + ANSI_RESET).log();
+    }
+
+    @Override
+    public void logFatal(String fatalMessage, Throwable e) {
+        Slf4jLogger.getLoggingEventBuilder(Level.FATAL, ANSI_RED + fatalMessage + ANSI_RESET)
+                .setCause(e)
+                .log();
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -43,33 +43,12 @@ public class LocalLogger implements Logger {
     }
 
     @Override
-    public void logTrace(String traceMessage) {
-        Level level = Level.TRACE;
-        LoggerHelper.logMessageAtLevel(
-                        LOGGER,
-                        level,
-                        wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), traceMessage))
-                .log();
-    }
-
-    @Override
     public void logDebug(String debugMessage) {
         Level level = Level.DEBUG;
         LoggerHelper.logMessageAtLevel(
                         LOGGER,
                         level,
                         wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), debugMessage))
-                .log();
-    }
-
-    @Override
-    public void logDebug(String debugMessage, Throwable e) {
-        Level level = Level.DEBUG;
-        LoggerHelper.logMessageAtLevel(
-                        LOGGER,
-                        level,
-                        wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), debugMessage))
-                .setCause(e)
                 .log();
     }
 
@@ -115,17 +94,6 @@ public class LocalLogger implements Logger {
                         level,
                         wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), errorMessage))
                 .setCause(e)
-                .log();
-    }
-
-    @Override
-    public void logFatal(String fatalMessage) {
-        Level level = Level.ERROR;
-        LoggerHelper.addFatalMarker(
-                        LoggerHelper.logMessageAtLevel(
-                                LOGGER,
-                                level,
-                                wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), fatalMessage)))
                 .log();
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -16,12 +16,12 @@ public class LocalLogger implements Logger {
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("local");
 
     // ANSI escape code
-    public static final String ANSI_RESET = "\u001B[0m";
-    public static final String ANSI_RED = "\u001B[31m";
-    public static final String ANSI_GREEN = "\u001B[32m";
-    public static final String ANSI_YELLOW = "\u001B[33m";
-    public static final String ANSI_PURPLE = "\u001B[35m";
-    public static final String ANSI_CYAN = "\u001B[36m";
+    private static final String ANSI_RESET = "\u001B[0m";
+    private static final String ANSI_RED = "\u001B[31m";
+    private static final String ANSI_GREEN = "\u001B[32m";
+    private static final String ANSI_YELLOW = "\u001B[33m";
+    private static final String ANSI_PURPLE = "\u001B[35m";
+    private static final String ANSI_CYAN = "\u001B[36m";
 
     private static final Map<Level, String> LEVEL_COLOR_MAPPING =
             Map.of(

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -8,9 +8,8 @@ import org.slf4j.MarkerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
 
 /**
- * Humble object interface for logging. This class was created in order to take away the 3rd party
- * dependency of the logger. The idea is to have the logger dependency only in this class. If there
- * ever is a reason to use a different logger, then we only need to make the changes here.
+ * Humble object interface for logging. Uses SLF4J behind the scenes. The local logger colorize its
+ * messages and prints things in an easy to read format.
  */
 public class LocalLogger implements Logger {
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -20,13 +20,10 @@ public class LocalLogger implements Logger {
     private static final String ANSI_RED = "\u001B[31m";
     private static final String ANSI_GREEN = "\u001B[32m";
     private static final String ANSI_YELLOW = "\u001B[33m";
-    private static final String ANSI_PURPLE = "\u001B[35m";
     private static final String ANSI_CYAN = "\u001B[36m";
 
     private static final Map<Level, String> LEVEL_COLOR_MAPPING =
             Map.of(
-                    Level.TRACE,
-                    ANSI_PURPLE,
                     Level.DEBUG,
                     ANSI_CYAN,
                     Level.INFO,

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -27,7 +27,7 @@ public class LocalLogger implements Logger {
 
     private LocalLogger() {}
 
-    public static LocalLogger getLogger() {
+    public static LocalLogger getInstance() {
         return INSTANCE;
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LoggerHelper.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LoggerHelper.java
@@ -1,0 +1,19 @@
+package gov.hhs.cdc.trustedintermediary.external.slf4j;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LoggingEventBuilder;
+
+class LoggerHelper {
+    public static LoggingEventBuilder logMessageAtLevel(
+            Logger logger, Level level, String message) {
+        return logger.atLevel(level).setMessage(() -> message);
+    }
+
+    public static LoggingEventBuilder addFatalMarker(LoggingEventBuilder loggingBuilder) {
+        Marker fatal = MarkerFactory.getMarker("FATAL");
+        return loggingBuilder.addMarker(fatal);
+    }
+}

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LoggerHelper.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LoggerHelper.java
@@ -6,7 +6,14 @@ import org.slf4j.MarkerFactory;
 import org.slf4j.event.Level;
 import org.slf4j.spi.LoggingEventBuilder;
 
+/**
+ * Helper class that centralizes logic used by the different loggers. This class is package private
+ * by choice and should be accessed through the loggers.
+ */
 class LoggerHelper {
+
+    private LoggerHelper() {}
+
     public static LoggingEventBuilder logMessageAtLevel(
             Logger logger, Level level, String message) {
         return logger.atLevel(level).setMessage(() -> message);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
@@ -15,15 +15,7 @@ import org.slf4j.spi.LoggingEventBuilder;
 public class Slf4jLogger implements Logger {
 
     private static final Slf4jLogger INSTANCE = new Slf4jLogger();
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("local");
-
-    // ANSI escape code
-    public static final String ANSI_RESET = "\u001B[0m";
-    public static final String ANSI_RED = "\u001B[31m";
-    public static final String ANSI_GREEN = "\u001B[32m";
-    public static final String ANSI_YELLOW = "\u001B[33m";
-    public static final String ANSI_PURPLE = "\u001B[35m";
-    public static final String ANSI_CYAN = "\u001B[36m";
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("tilogger");
 
     private Slf4jLogger() {}
 
@@ -80,18 +72,16 @@ public class Slf4jLogger implements Logger {
         getLoggingEventBuilder(Level.FATAL, fatalMessage).setCause(e).log();
     }
 
-    protected LoggingEventBuilder getLoggingEventBuilder(Level level, String message) {
+    protected static LoggingEventBuilder getLoggingEventBuilder(Level level, String message) {
         return switch (level) {
-            case TRACE -> LOGGER.atTrace().setMessage(() -> ANSI_PURPLE + message + ANSI_RESET);
-            case DEBUG -> LOGGER.atDebug().setMessage(() -> ANSI_CYAN + message + ANSI_RESET);
-            case INFO -> LOGGER.atInfo().setMessage(() -> ANSI_GREEN + message + ANSI_RESET);
-            case WARN -> LOGGER.atWarn().setMessage(() -> ANSI_YELLOW + message + ANSI_RESET);
-            case ERROR -> LOGGER.atError().setMessage(() -> ANSI_RED + message + ANSI_RESET);
+            case TRACE -> LOGGER.atTrace().setMessage(() -> message);
+            case DEBUG -> LOGGER.atDebug().setMessage(() -> message);
+            case INFO -> LOGGER.atInfo().setMessage(() -> message);
+            case WARN -> LOGGER.atWarn().setMessage(() -> message);
+            case ERROR -> LOGGER.atError().setMessage(() -> message);
             case FATAL -> {
                 Marker fatal = MarkerFactory.getMarker("FATAL");
-                yield LOGGER.atError()
-                        .addMarker(fatal)
-                        .setMessage(() -> ANSI_RED + message + ANSI_RESET);
+                yield LOGGER.atError().addMarker(fatal).setMessage(() -> message);
             }
         };
     }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
@@ -15,7 +15,7 @@ import org.slf4j.spi.LoggingEventBuilder;
 public class Slf4jLogger implements Logger {
 
     private static final Slf4jLogger INSTANCE = new Slf4jLogger();
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("tilogger");
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger("local");
 
     // ANSI escape code
     public static final String ANSI_RESET = "\u001B[0m";

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/Slf4jLogger.java
@@ -25,22 +25,22 @@ public class Slf4jLogger implements Logger {
 
     @Override
     public void logTrace(String traceMessage) {
-        getLoggingEventBuilder(Level.TRACE, traceMessage).log();
+        LOGGER.atTrace().setMessage(() -> traceMessage).log();
     }
 
     @Override
     public void logDebug(String debugMessage) {
-        getLoggingEventBuilder(Level.DEBUG, debugMessage).log();
+        LOGGER.atDebug().setMessage(() -> debugMessage).log();
     }
 
     @Override
     public void logDebug(String debugMessage, Throwable e) {
-        getLoggingEventBuilder(Level.DEBUG, debugMessage).setCause(e).log();
+        LOGGER.atDebug().setMessage(() -> debugMessage).setCause(e).log();
     }
 
     @Override
     public void logInfo(String infoMessage, Object... parameters) {
-        var logBuilder = getLoggingEventBuilder(Level.INFO, infoMessage);
+        var logBuilder = LOGGER.atInfo().setMessage(() -> infoMessage);
 
         Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
 
@@ -49,40 +49,31 @@ public class Slf4jLogger implements Logger {
 
     @Override
     public void logWarning(String warningMessage) {
-        getLoggingEventBuilder(Level.WARN, warningMessage).log();
+        LOGGER.atWarn().setMessage(() -> warningMessage).log();
     }
 
     @Override
     public void logError(String errorMessage) {
-        getLoggingEventBuilder(Level.ERROR, errorMessage).log();
+        LOGGER.atError().setMessage(() -> errorMessage).log();
     }
 
     @Override
     public void logError(String errorMessage, Throwable e) {
-        getLoggingEventBuilder(Level.ERROR, errorMessage).setCause(e).log();
+        LOGGER.atError().setMessage(() -> errorMessage).setCause(e).log();
     }
 
     @Override
     public void logFatal(String fatalMessage) {
-        getLoggingEventBuilder(Level.FATAL, fatalMessage).log();
+        logAtFatal().setMessage(() -> fatalMessage).log();
     }
 
     @Override
     public void logFatal(String fatalMessage, Throwable e) {
-        getLoggingEventBuilder(Level.FATAL, fatalMessage).setCause(e).log();
+        logAtFatal().setMessage(() -> fatalMessage).setCause(e).log();
     }
 
-    protected static LoggingEventBuilder getLoggingEventBuilder(Level level, String message) {
-        return switch (level) {
-            case TRACE -> LOGGER.atTrace().setMessage(() -> message);
-            case DEBUG -> LOGGER.atDebug().setMessage(() -> message);
-            case INFO -> LOGGER.atInfo().setMessage(() -> message);
-            case WARN -> LOGGER.atWarn().setMessage(() -> message);
-            case ERROR -> LOGGER.atError().setMessage(() -> message);
-            case FATAL -> {
-                Marker fatal = MarkerFactory.getMarker("FATAL");
-                yield LOGGER.atError().addMarker(fatal).setMessage(() -> message);
-            }
-        };
+    private LoggingEventBuilder logAtFatal() {
+        Marker fatal = MarkerFactory.getMarker("FATAL");
+        return LOGGER.atError().addMarker(fatal);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
@@ -3,15 +3,6 @@ package gov.hhs.cdc.trustedintermediary.wrappers;
 /** Interface that will be implemented with a humble object for logging */
 public interface Logger {
 
-    enum Level {
-        TRACE,
-        DEBUG,
-        INFO,
-        WARN,
-        ERROR,
-        FATAL
-    }
-
     void logTrace(String traceMessage);
 
     void logDebug(String debugMessage);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
@@ -3,11 +3,7 @@ package gov.hhs.cdc.trustedintermediary.wrappers;
 /** Interface that will be implemented with a humble object for logging */
 public interface Logger {
 
-    void logTrace(String traceMessage);
-
     void logDebug(String debugMessage);
-
-    void logDebug(String debugMessage, Throwable e);
 
     void logInfo(String infoMessage, Object... parameters);
 
@@ -16,8 +12,6 @@ public interface Logger {
     void logError(String errorMessage);
 
     void logError(String errorMessage, Throwable e);
-
-    void logFatal(String errorMessage);
 
     void logFatal(String errorMessage, Throwable e);
 }

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -22,9 +22,8 @@
   </appender>
 
   <appender name="TEXT_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-      <providers>
-      </providers>
+    <encoder>
+        <pattern>%date{ISO8601} [%thread] %-5level - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -14,14 +14,32 @@
     </encoder>
   </appender>
 
-  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+  <appender name="JSON_ASYNC" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="JSON_CONSOLE" />
     <queueSize>1024</queueSize>
     <discardingThreshold>0</discardingThreshold>
     <includeCallerData>false</includeCallerData>
   </appender>
 
+  <appender name="TEXT_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+      </providers>
+    </encoder>
+  </appender>
+
+  <appender name="TEXT_ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="TEXT_CONSOLE" />
+    <queueSize>1024</queueSize>
+    <discardingThreshold>0</discardingThreshold>
+    <includeCallerData>false</includeCallerData>
+  </appender>
+
+  <logger name="local" level="info" additivity="false">
+    <appender-ref ref="TEXT_ASYNC" />
+  </logger>
+
   <root level="info">
-    <appender-ref ref="ASYNC"/>
+    <appender-ref ref="JSON_ASYNC"/>
   </root>
 </configuration>

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
@@ -1,7 +1,8 @@
 package gov.hhs.cdc.trustedintermediary.context
 
+
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger
-import gov.hhs.cdc.trustedintermediary.external.slf4j.Slf4jLogger
+import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger
 
 /**
  * This test class resets the implementation registration in the ApplicationContext so different test cases can start on a clean slate.
@@ -10,7 +11,7 @@ class TestApplicationContext extends ApplicationContext {
 
     def static init() {
         //initialize some default implementations that we want by default across nearly all tests
-        register(Logger, Slf4jLogger.getLogger())
+        register(Logger, DeployedLogger.getLogger())
     }
 
     def static reset() {

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
@@ -1,6 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.context
 
-
+import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger
 import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger
 
@@ -11,7 +11,7 @@ class TestApplicationContext extends ApplicationContext {
 
     def static init() {
         //initialize some default implementations that we want by default across nearly all tests
-        register(Logger, DeployedLogger.getLogger())
+        register(Logger, LocalLogger.getLogger())
     }
 
     def static reset() {

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/context/TestApplicationContext.groovy
@@ -2,7 +2,6 @@ package gov.hhs.cdc.trustedintermediary.context
 
 import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger
-import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger
 
 /**
  * This test class resets the implementation registration in the ApplicationContext so different test cases can start on a clean slate.
@@ -11,7 +10,7 @@ class TestApplicationContext extends ApplicationContext {
 
     def static init() {
         //initialize some default implementations that we want by default across nearly all tests
-        register(Logger, LocalLogger.getLogger())
+        register(Logger, LocalLogger.getInstance())
     }
 
     def static reset() {


### PR DESCRIPTION
# Logging Locally

In general, we no longer have the raw ANSI color codes showing up in our deployed environment's logs, and we now have easy to read logs while running locally.

Specifically...

- Added a logger named `local` to `logback.xml` that logs in a simple console format (contrast this to the JSON format).
- Renamed `SLF4JLogger` to `LocalLogger`.
- Changed `LocalLogger` to use the new `local` logger from `logback.xml`.
- Created a new `DeployedLogger` that uses a logger that continues to use the JSON format.
- Removed the `Level` enum.
- Created a helper, `LoggerHelper`, to centralize some of the logging logic.  I'm not entirely sure I'm getting much out of this helper since it replaces 1 line anyway.

## Issue

#382.

## Checklist

- [x] Rename `Slf4JLogger` to something about deployment or structure.
- [n/a] I have added tests to cover my changes
- [n/a] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [n/a] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
