### PR TITLE
382: IG Onboarding and Tooling Updates

### DIFF
--- a/ig/Dockerfile-local-dev
+++ b/ig/Dockerfile-local-dev
@@ -5,3 +5,5 @@ RUN cp `find /usr/lib/ruby/gems/*/gems/jekyll-*/exe/jekyll` /usr/bin
 RUN npm install -g fsh-sushi
 
 WORKDIR /trusted-intermediary
+
+CMD ./_updatePublisher.sh -y && ./fix-execute.sh && ./_genonce.sh

--- a/ig/README.md
+++ b/ig/README.md
@@ -45,9 +45,16 @@ In practice, when generating the documentation, VSCode is unable to cope with re
 VSCode may use significant amounts of your CPU, locking up your computer and will typically crash.  To avoid this issue, it is recommended that a different
 IDE is used to work on the CDC Trusted Intermediary documentation such as IntelliJ.
 
+### Helper Script
+
 1. In a terminal, navigate to this `ig` directory
-2. run `docker build -t ig-local-dev -f Dockerfile-local-dev .` to build the Docker container
-3. run `docker run -it --mount type=bind,source="$(pwd)",target=/trusted-intermediary ig-local-dev bash` to run the container and use an interactive `bash` shell inside the container
+2. Run `./local-generate.sh`.  This will execute all of the commands in the below section for you plus opening the IG in your web browser after generation.
+
+### Running Manually
+
+1. In a terminal, navigate to this `ig` directory
+2. Run `docker build -t ig-local-dev -f Dockerfile-local-dev .` to build the Docker container
+3. Run `docker run -it --mount type=bind,source="$(pwd)",target=/trusted-intermediary ig-local-dev bash` to run the container and use an interactive `bash` shell inside the container
 4. Inside the container environment it should default to a working directory of `/trusted-intermediary`; this is bound to the `ig` directory in your local git repo
 5. Periodically update the IG Publisher by running `./_updatePublisher.sh`.  The IG Publisher is updated multiple times per week to fix bugs and add new functionality.  Staying up to date with the latest version is a good idea. Notification messages when the IG Publisher is updated can be found at: https://chat.fhir.org/#narrow/stream/217600-tooling.2Freleases
 6. After running the publisher update, you will have to fix the execute permission on a couple of the scripts by running `./fix-execute.sh`

--- a/ig/README.md
+++ b/ig/README.md
@@ -46,7 +46,7 @@ VSCode may use significant amounts of your CPU, locking up your computer and wil
 IDE is used to work on the CDC Trusted Intermediary documentation such as IntelliJ.
 
 1. In a terminal, navigate to this `ig` directory
-2. run `docker buildx build -t ig-local-dev -f Dockerfile-local-dev .` to build the Docker container
+2. run `docker build -t ig-local-dev -f Dockerfile-local-dev .` to build the Docker container
 3. run `docker run -it --mount type=bind,source="$(pwd)",target=/trusted-intermediary ig-local-dev bash` to run the container and use an interactive `bash` shell inside the container
 4. Inside the container environment it should default to a working directory of `/trusted-intermediary`; this is bound to the `ig` directory in your local git repo
 5. Periodically update the IG Publisher by running `./_updatePublisher.sh`.  The IG Publisher is updated multiple times per week to fix bugs and add new functionality.  Staying up to date with the latest version is a good idea. Notification messages when the IG Publisher is updated can be found at: https://chat.fhir.org/#narrow/stream/217600-tooling.2Freleases

--- a/ig/fix-execute.sh
+++ b/ig/fix-execute.sh
@@ -2,3 +2,4 @@
 
 chmod +x ./_updatePublisher.sh
 chmod +x ./_genonce.sh
+chmod +x ./_gencontinuous.sh

--- a/ig/input/pagecontent/onboarding.md
+++ b/ig/input/pagecontent/onboarding.md
@@ -1,3 +1,16 @@
 ### Overview
 
-This is where we add some information about how to onboard. We will have separate sections for public health labs and HCOs
+The onboarding process boils down to 2 steps.
+
+1. [Contact us](mailto:cdc-ti@flexion.us).
+2. Fill out the [ReportStream onboarding form](https://reportstream.cdc.gov/resources/elr-checklist).
+
+### Contacting Us
+
+We'd love to chat to get a feel for what you are looking to get out of the ReportStream Intermediary.  Drop [us](mailto:cdc-ti@flexion.us) a line.
+
+### ReportStream Form
+
+After contacting us, and we are all on the same page, we'll request you fill out the [ReportStream onboarding form](https://reportstream.cdc.gov/resources/elr-checklist).
+The Interediary uses the larger [ReportStream](https://reportstream.cdc.gov) ecosystem to receive and send messages.
+That means that you'll be onboarded to ReportStream as part of this process.

--- a/ig/local-generate.sh
+++ b/ig/local-generate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker build -t ig-local-dev -f Dockerfile-local-dev .
+docker run -it --rm --mount type=bind,source="$(pwd)",target=/trusted-intermediary ig-local-dev
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  open ./output/index.html
+fi


### PR DESCRIPTION
# IG Onboarding and Tooling Updates

- Updated the onboarding documentation with a proposed process.
- Created `local-generate.sh` that automates the generation of the IG instead of you having to run the Docker and IG commands manually.
- Updated the documentation on `local-generate.sh`.
- Update `fix-execute.sh` to also update the permissions for `_gencontinuous.sh`.
- Give the local IG Dockerfile a default run set of arguments (`CMD` are overwritten when providing a command in the `docker run` command).
- Remove `buildx` from the local IG creation because it isn't needed.

## Issue

#382.

## Checklist

- [n/a] I have added tests to cover my changes
- [n/a] I have added logging where useful (with appropriate log level)
- [n/a] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
