### PR TITLE
382: Internals in the Implementation Guide

### DIFF
--- a/ig/input/pagecontent/internals.md
+++ b/ig/input/pagecontent/internals.md
@@ -1,3 +1,12 @@
 ### Overview
 
-This is where we talk about GitHub and our internal interfaces.
+The ReportStream Intermediary is microservice behind the larger ReportStream system.  This page documents some of the internals behind the microservice.
+
+### GitHub
+
+We develop the ReportStream Intermediary on GitHub in an [opensource repository](https://github.com/CDCgov/trusted-intermediary).
+Please feel free to peruse our code and contribute.
+
+### Internal API
+
+The ReportStream Intermediary has its own internal API that can be called by specific, trusted clients.

--- a/ig/input/pagecontent/internals.md
+++ b/ig/input/pagecontent/internals.md
@@ -10,3 +10,7 @@ Please feel free to peruse our code and contribute.
 ### Internal API
 
 The ReportStream Intermediary has its own internal API that can be called by specific, trusted clients.
+
+One can view the OpenAPI documentation by either looking at the [different YAML files in our repository](https://github.com/CDCgov/trusted-intermediary/tree/main/app/src/main/resources)
+or run our application locally and hit the [OpenAPI endpoint](http://localhost:8080/openapi) to get a combined view of all the documentation.
+In the future, we may have a UI set-up to more easily interact with the documentation.

--- a/ig/input/pagecontent/internals.md
+++ b/ig/input/pagecontent/internals.md
@@ -1,6 +1,6 @@
 ### Overview
 
-The ReportStream Intermediary is microservice behind the larger ReportStream system.  This page documents some of the internals behind the microservice.
+The ReportStream Intermediary is a microservice behind the larger ReportStream system.  This page documents some of the internals behind the microservice.
 
 ### GitHub
 


### PR DESCRIPTION
# Internals in the Implementation Guide

Add a starting point for our internal section of the IG.  I think this could be fleshed out in the future.

@jorg3lopez, you mentioned about adding additional documentation around interacting with our API.  This file could be where that documentation resides.

## Issue

#382.

## Checklist

- [n/a] I have added tests to cover my changes
- [n/a] I have added logging where useful (with appropriate log level)
- [n/a] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
