### PR TITLE
Add e2e test assertions for auth endpoint failures

### DIFF
--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/AuthTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/AuthTest.groovy
@@ -27,9 +27,11 @@ class AuthTest extends Specification {
 
         when:
         def response = AuthClient.authenticate(invalidRequest, "asdf")
+        def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
         response.getCode() == 400
+        !(parsedJsonBody.error as String).isEmpty()
     }
 
     def "a 401 response is returned when invalid token"() {
@@ -38,9 +40,11 @@ class AuthTest extends Specification {
 
         when:
         def response = AuthClient.authenticate(existingClientId, invalidToken)
+        def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
         response.getCode() == 401
+        !(parsedJsonBody.error as String).isEmpty()
     }
 
     def "a 401 response is returned when unknown organization"() {
@@ -49,8 +53,10 @@ class AuthTest extends Specification {
 
         when:
         def response = AuthClient.authenticate(invalidClientId, validToken)
+        def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
         response.getCode() == 401
+        !(parsedJsonBody.error as String).isEmpty()
     }
 }


### PR DESCRIPTION
# Add e2e test assertions for auth endpoint failures

Added e2e test assertions to make sure auth endpoint returns error message for failure responses (400 & 401)

## Issue

None
