### PR TITLE
Reverted changes to bring back SentPayloadReader and newborn_patient.json

### DIFF
--- a/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/SentPayloadReader.java
+++ b/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/SentPayloadReader.java
@@ -1,0 +1,27 @@
+package gov.hhs.cdc.trustedintermediary.e2e;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SentPayloadReader {
+
+    public static String read() throws IOException {
+        Path payloadFile = findFilePayload();
+
+        return Files.readString(payloadFile);
+    }
+
+    private static Path findFilePayload() {
+
+        Path expectedFilePath = Path.of("..", "app", "localfileorder.json");
+
+        boolean doesFileExist = Files.exists(expectedFilePath);
+
+        if (!doesFileExist) {
+            expectedFilePath = Path.of("..", "localfileorder.json");
+        }
+
+        return expectedFilePath;
+    }
+}

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
@@ -4,16 +4,15 @@ import spock.lang.Specification
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 class DemographicsTest extends Specification {
 
     def demographicsClient = new EndpointClient("/v1/etor/demographics")
-    def newbornPatientJsonFileString = Files.readString(Path.of("..", "examples", "fhir/lab_order.json"))
+    def newbornPatientJsonFileString = Files.readString(Path.of("../examples/fhir/newborn_patient.json"))
 
     def "a demographics response is returned from the ETOR demographics endpoint"() {
         given:
-        def expectedFhirResourceId  = "Bundle/969bcbb3-cd34-49be-ac4f-e1b8479b8219"
+        def expectedFhirResourceId  = "Bundle/bundle-with-patient"
         def expectedPatientId  = "MRN7465737865"
 
         when:
@@ -30,17 +29,18 @@ class DemographicsTest extends Specification {
         when:
         def response = demographicsClient.submit(newbornPatientJsonFileString, true)
         def parsedResponseBody = JsonParsing.parseContent(response)
-        def sentPayload = Files.readString(Path.of("..", "examples", "fhir/lab_order.json"))
+        def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
 
         then:
         response.getCode() == 200
         parsedSentPayload.entry[0].resource.resourceType == "MessageHeader"
-        parsedSentPayload.entry[4].resource.resourceType == "ServiceRequest"
+        parsedSentPayload.entry[2].resource.resourceType == "ServiceRequest"
 
-        parsedSentPayload.entry[3].resource.resourceType == "Patient"
+        parsedSentPayload.entry[1].resource.resourceType == "Patient"
+        parsedSentPayload.entry[1].resource.id == "infant-twin-1"
 
-        parsedSentPayload.entry[3].resource.identifier[0].value == parsedResponseBody.patientId  //the second (index 1) identifier so happens to be the MRN
+        parsedSentPayload.entry[1].resource.identifier[1].value == parsedResponseBody.patientId  //the second (index 1) identifier so happens to be the MRN
         parsedSentPayload.resourceType + "/" + parsedSentPayload.id == parsedResponseBody.fhirResourceId
     }
 

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -3,12 +3,12 @@ package gov.hhs.cdc.trustedintermediary.e2e
 import spock.lang.Specification
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
 class OrderTest extends Specification {
 
     def orderClient = new EndpointClient("/v1/etor/orders")
-    def labOrderJsonFileString = Files.readString(Paths.get("../examples/fhir/lab_order.json"))
+    def labOrderJsonFileString = Files.readString(Path.of("../examples/fhir/lab_order.json"))
 
     def "an order response is returned from the ETOR order endpoint"() {
         given:
@@ -23,6 +23,18 @@ class OrderTest extends Specification {
         response.getCode() == 200
         parsedJsonBody.fhirResourceId == expectedFhirResourceId
         parsedJsonBody.patientId == expectedPatientId
+    }
+
+    def "payload file check"() {
+        when:
+        def response = orderClient.submit(labOrderJsonFileString, true)
+        def sentPayload = SentPayloadReader.read()
+        def parsedSentPayload = JsonParsing.parse(sentPayload)
+        def parsedLabOrderJsonFile = JsonParsing.parse(labOrderJsonFileString)
+
+        then:
+        response.getCode() == 200
+        parsedSentPayload == parsedLabOrderJsonFile
     }
 
     def "return a 400 response when request has unexpected format"() {

--- a/examples/fhir/newborn_patient.json
+++ b/examples/fhir/newborn_patient.json
@@ -1,0 +1,115 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-with-patient",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "infant-twin-1",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Jaina Solo (OFFICIAL)</b> female, DoB: 2017-05-15 ( Medical record number: MRN7465737865)</p></div>"
+        },
+        "extension": [
+          {
+            "extension" : [
+              {
+                "url" : "ombCategory",
+                "valueCoding" : {
+                  "system" : "urn:oid:2.16.840.1.113883.6.238",
+                  "code" : "2028-9",
+                  "display" : "Asian"
+                }
+              },
+              {
+                "url" : "text",
+                "valueString" : "Asian"
+              }
+            ],
+            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+            "valueString": "Organa"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://new-republic.gov/galactic-citizen-identifier",
+            "value": "7465737865"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR"
+                }
+              ]
+            },
+            "system": "http://coruscanthealth.org/main-hospital/patient-identifier",
+            "value": "MRN7465737865"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Solo",
+            "given": [
+              "Jaina"
+            ]
+          }
+        ],
+        "gender": "female",
+        "birthDate": "2017-05-15",
+        "_birthDate": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+              "valueDateTime": "2017-05-15T17:11:00+01:00"
+            }
+          ]
+        },
+        "multipleBirthInteger": 1,
+        "contact": [
+          {
+            "relationship": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "72705000",
+                    "display": "Mother"
+                  },
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+                    "code": "N"
+                  },
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                    "code": "MTH"
+                  }
+                ]
+              }
+            ],
+            "name": {
+              "use": "maiden",
+              "family": "Organa",
+              "given": [
+                "Leia"
+              ]
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "+31201234567",
+                "use": "mobile"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -106,7 +106,7 @@ def get_auth_request_body():
 
 def get_demographics_request_body():
     # read the sample request body for the demographics endpoint
-    with open("examples/fhir/MN NBS FHIR Order Message.json", "r") as f:
+    with open("examples/fhir/newborn_patient.json", "r") as f:
         return f.read()
 
 


### PR DESCRIPTION
- Bringed back `newborn_patient.json` and moved to `examples/fhir` folder
- Bringed back `SentPayloadReader` class
- Still pending: make sure we use only one copy of `localfileorder.json`

## Issue

#458 