### PR TITLE
Document steps to connect to ReportStream

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -31,8 +31,9 @@ As a _, so that _, I need _.
   - [ ] Documentation and diagrams created or updated
     - [ ] Implementation guide (`/ig` folder)
     - [ ] ADRs (`/adr` folder)
-    - [ ] Main README.md
+    - [ ] Main `README.md`
     - [ ] Other READMEs in the repo
+    - [ ] If applicable, update the `ReportStream Setup` section in `README.md`
   - [ ] Threat model updated
   - [ ] API documentation updated
   - [ ] Source code documentation created when the code is not self-documenting

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,15 +128,7 @@
         "filename": "README.md",
         "hashed_secret": "e07f44b0222f3680e0a3491edcf61030143e2ae7",
         "is_verified": false,
-        "line_number": 187,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "README.md",
-        "hashed_secret": "5122eb756aa447f4eebb7e4174f26f070db3fdef",
-        "is_verified": false,
-        "line_number": 192,
+        "line_number": 186,
         "is_secret": false
       }
     ],
@@ -230,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-17T17:50:09Z"
+  "generated_at": "2023-08-17T18:48:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -122,13 +122,31 @@
         "is_secret": false
       }
     ],
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "e07f44b0222f3680e0a3491edcf61030143e2ae7",
+        "is_verified": false,
+        "line_number": 187,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "5122eb756aa447f4eebb7e4174f26f070db3fdef",
+        "is_verified": false,
+        "line_number": 192,
+        "is_secret": false
+      }
+    ],
     "app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java": [
       {
         "type": "Private Key",
         "filename": "app/src/main/java/gov/hhs/cdc/trustedintermediary/external/jjwt/JjwtEngine.java",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 155,
         "is_secret": false
       }
     ],
@@ -192,6 +210,15 @@
         "is_secret": false
       }
     ],
+    "mock_credentials/trusted-intermediary-valid-token.jwt": [
+      {
+        "type": "JSON Web Token",
+        "filename": "mock_credentials/trusted-intermediary-valid-token.jwt",
+        "hashed_secret": "a3748a4dd079b3aee10c6654f505013258e9c99b",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
     "mock_credentials/weak-rsa-key.pem": [
       {
         "type": "Private Key",
@@ -203,5 +230,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-09T20:23:14Z"
+  "generated_at": "2023-08-17T17:50:09Z"
 }

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 #### ReportStream Setup
 
 1. Checkout `flexion/test/ti-rs-setup` branch for `CDCgov/prime-reportstream`
-2. CD to `prime-reportstream/prime-router`
-3. Point to RS docs to run RS
+2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#first-build) to build the baseline
+3. CD to `prime-reportstream/prime-router`
 4. Run RS with `docker compose up --build -d`
 5. Run `./prime multiple-settings set -i ./settings/staging/0149-etor.yml`
 6. Run `./prime organization addkey --public-key /path/to/trusted-intermediary/mock_credentials/organization-trusted-intermediary-public-key-local.pem --scope "flexion.*.report" --orgName flexion --kid flexion.etor-service-sender --doit`

--- a/README.md
+++ b/README.md
@@ -169,14 +169,13 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 #### CDC-TI Setup
 
 1. Checkout `rs-form-data` branch for `CDCgov/trusted-intermediary`
-2. Run `./gradlew shadowJar`
-3. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071/ ./gradlew clean app:run`
+2. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071/ ./gradlew clean app:run`
 
 #### ReportStream Setup
 
 1. Checkout `flexion/test/ti-rs-setup` branch for `CDCgov/prime-reportstream`
 2. CD to `prime-reportstream/prime-router`
-3. Run `./gradlew clean package`
+3. Point to RS docs to run RS
 4. Run RS with `docker compose up --build -d`
 5. Run `./prime multiple-settings set -i ./settings/staging/0149-etor.yml`
 6. Run `./prime organization addkey --public-key /path/to/trusted-intermediary/mock_credentials/organization-trusted-intermediary-public-key-local.pem --scope "flexion.*.report" --orgName flexion --kid flexion.etor-service-sender --doit`
@@ -189,12 +188,12 @@ CDC including this GitHub page may be subject to applicable federal law, includi
         ```
         {
           "@type": "UserApiKey",
-          "apiKey": "RS Private Key at trusted-intermediary/mock_credentials/organization-report-stream-private-key.pem",
+          "apiKey": "TI's private key in RS at trusted-intermediary/mock_credentials/organization-report-stream-private-key.pem",
           "user": "flexion"
         }
         ```
 
-## Submit request to ReportStream:
+#### Submit request to ReportStream
 
 `curl --header 'Content-Type: application/hl7-v2' --header 'Client: flexion.simulated-hospital' --header 'Authorization: Bearer none' --data-binary '@/path/to/ORM_O01.hl7' 'http://localhost:7071/api/reports'`
 


### PR DESCRIPTION
- Added a section to `readme.md` with steps to set up the connection between TI and RS. The steps will need to be updated soon as we make the process more streamlined
- Also updated the `.secrets.baseline` by running `detect-secrets scan --baseline .secrets.baseline` and ignored a couple of false-positive detections in the added readme section

## Issue

#290