### PR TITLE
290: ORM to OML

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
@@ -2,7 +2,7 @@ package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 import gov.hhs.cdc.trustedintermediary.etor.demographics.Demographics;
 
-/** Interface for converting a demographics object into a lab order. */
+/** Interface for converting things to orders and things in orders. */
 public interface OrderConverter {
     Order<?> convertToOrder(Demographics<?> demographics);
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
@@ -5,4 +5,6 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.Demographics;
 /** Interface for converting a demographics object into a lab order. */
 public interface OrderConverter {
     Order<?> convertToOrder(Demographics<?> demographics);
+
+    Order<?> convertMetadataToOmlOrder(Order<?> order);
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -2,10 +2,11 @@ package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 import javax.inject.Inject;
 
-/** The overall logic to receive and subsequently send a lab order. */
+/** The overall logic to receive, convert to OML, and subsequently send a lab order. */
 public class SendOrderUseCase {
     private static final SendOrderUseCase INSTANCE = new SendOrderUseCase();
 
+    @Inject OrderConverter converter;
     @Inject OrderSender sender;
 
     private SendOrderUseCase() {}
@@ -14,7 +15,8 @@ public class SendOrderUseCase {
         return INSTANCE;
     }
 
-    public void send(Order<?> order) throws UnableToSendOrderException {
-        sender.sendOrder(order);
+    public void send(final Order<?> order) throws UnableToSendOrderException {
+        var omlOrder = converter.convertMetadataToOmlOrder(order);
+        sender.sendOrder(omlOrder);
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -98,7 +98,12 @@ public class HapiOrderConverter implements OrderConverter {
         var messageHeader =
                 HapiHelper.resourcesInBundle(orderBundle, MessageHeader.class)
                         .findFirst()
-                        .orElseGet(MessageHeader::new);
+                        .orElse(null);
+
+        if (messageHeader == null) {
+            messageHeader = new MessageHeader();
+            orderBundle.addEntry(new Bundle.BundleEntryComponent().setResource(messageHeader));
+        }
 
         messageHeader.setEvent(omlOrderCoding);
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -22,7 +22,8 @@ import org.hl7.fhir.r4.model.UrlType;
 
 /**
  * Converts {@link Demographics} to a Hapi-specific FHIR lab order ({@link HapiOrder} or {@link
- * Order <Bundle>}).
+ * Order <Bundle>}). Also converts an order to identify as an HL7v2 OML in the {@link
+ * MessageHeader}.
  */
 public class HapiOrderConverter implements OrderConverter {
     private static final HapiOrderConverter INSTANCE = new HapiOrderConverter();

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -82,6 +82,10 @@ public class HapiOrderConverter implements OrderConverter {
         return new HapiOrder(demographicsBundle);
     }
 
+    public Order<?> convertMetadataToOmlOrder(Order<?> order) {
+        return null;
+    }
+
     private MessageHeader createMessageHeader(Coding omlOrderCoding) {
         logger.logInfo("Creating new MessageHeader");
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -83,7 +83,7 @@ public class HapiOrderConverter implements OrderConverter {
     }
 
     public Order<?> convertMetadataToOmlOrder(Order<?> order) {
-        return null;
+        return order;
     }
 
     private MessageHeader createMessageHeader(Coding omlOrderCoding) {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -82,8 +82,27 @@ public class HapiOrderConverter implements OrderConverter {
         return new HapiOrder(demographicsBundle);
     }
 
+    @Override
     public Order<?> convertMetadataToOmlOrder(Order<?> order) {
-        return order;
+        logger.logInfo("Converting order to have OML metadata");
+
+        var hapiOrder = (Order<Bundle>) order;
+        var orderBundle = hapiOrder.getUnderlyingOrder();
+
+        var omlOrderCoding =
+                new Coding(
+                        "http://terminology.hl7.org/CodeSystem/v2-0003",
+                        "O21",
+                        "OML - Laboratory order");
+
+        var messageHeader =
+                HapiHelper.resourcesInBundle(orderBundle, MessageHeader.class)
+                        .findFirst()
+                        .orElseGet(MessageHeader::new);
+
+        messageHeader.setEvent(omlOrderCoding);
+
+        return new HapiOrder(orderBundle);
     }
 
     private MessageHeader createMessageHeader(Coding omlOrderCoding) {

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -15,8 +15,10 @@ class SendOrderUsecaseTest extends Specification {
     def "send sends successfully"() {
         given:
         def mockOrder = new OrderMock(null, null, null)
+        def mockConverter = Mock(OrderConverter)
         def mockSender = Mock(OrderSender)
 
+        TestApplicationContext.register(OrderConverter, mockConverter)
         TestApplicationContext.register(OrderSender, mockSender)
         TestApplicationContext.injectRegisteredImplementations()
 
@@ -24,15 +26,18 @@ class SendOrderUsecaseTest extends Specification {
         SendOrderUseCase.getInstance().send(mockOrder)
 
         then:
-        1 * mockSender.sendOrder(mockOrder)
+        1 * mockConverter.convertMetadataToOmlOrder(mockOrder)
+        1 * mockSender.sendOrder(_)
     }
 
     def "send fails to send"() {
         given:
         def mockOrder = new OrderMock(null, null, null)
+        def mockConverter = Mock(OrderConverter)
         def mockSender = Mock(OrderSender)
-        mockSender.sendOrder(_ as Order) >> { throw new UnableToSendOrderException("DogCow", new NullPointerException()) }
+        mockSender.sendOrder(_) >> { throw new UnableToSendOrderException("DogCow", new NullPointerException()) }
 
+        TestApplicationContext.register(OrderConverter, mockConverter)
         TestApplicationContext.register(OrderSender, mockSender)
         TestApplicationContext.injectRegisteredImplementations()
 

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -34,6 +34,15 @@ class OrderTest extends Specification {
 
         then:
         response.getCode() == 200
+
+        //test that the MessageHeader's event is now an OML_O21
+        parsedSentPayload.entry[0].resource.resourceType == "MessageHeader"
+        parsedSentPayload.entry[0].resource.eventCoding.code == "O21"
+        parsedSentPayload.entry[0].resource.eventCoding.display.contains("OML")
+
+        //test that everything else is the same except the MessageHeader's event
+        parsedSentPayload.entry[0].resource.remove("eventCoding")
+        parsedLabOrderJsonFile.entry[0].resource.remove("eventCoding")
         parsedSentPayload == parsedLabOrderJsonFile
     }
 

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -8,12 +8,12 @@ import java.nio.file.Path
 class OrderTest extends Specification {
 
     def orderClient = new EndpointClient("/v1/etor/orders")
-    def labOrderJsonFileString = Files.readString(Path.of("../examples/fhir/lab_order.json"))
+    def labOrderJsonFileString = Files.readString(Path.of("../examples/fhir/MN NBS FHIR Order Message.json"))
 
     def "an order response is returned from the ETOR order endpoint"() {
         given:
-        def expectedFhirResourceId  = "Bundle/969bcbb3-cd34-49be-ac4f-e1b8479b8219"
-        def expectedPatientId  = "MRN7465737865"
+        def expectedFhirResourceId  = "Bundle/b4efef3a-749c-457d-956b-568e22768bf3"
+        def expectedPatientId  = "11102779"
 
         when:
         def response = orderClient.submit(labOrderJsonFileString, true)


### PR DESCRIPTION
# ORM to OML

Added the ability for our order converter to also convert the order metadata from an ORM to an OML.  This is then used in our sending order usecase.

As part of the `HapiOrderConverter` changes, I also refactored how we set the OML `Coding`.  It used to be created on each call to the convert-demographics-to-order call, but I decided to promote the OML `Coding` object to a static class field now that it is also used identically in the new order-metadata-conversion call.

Lastly, I updated our e2e order test to use a different input file.  This input file is an ORM, which reflects how we will be called, instead of an OML file.

## Issue

#290

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
