### PR TITLE
Better Sent Payload File Handling

### DIFF
--- a/e2e-execute.sh
+++ b/e2e-execute.sh
@@ -10,9 +10,9 @@ start_api() {
 
     pushd ./app/
 
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     SUB_DIR="build/libs"
     JAR_NAME="app-all.jar"
-    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
     echo 'Starting API'
     java -jar "${DIR}"/"${SUB_DIR}"/"${JAR_NAME}" > /dev/null &

--- a/e2e-execute.sh
+++ b/e2e-execute.sh
@@ -7,13 +7,19 @@ shadowJar() {
 }
 
 start_api() {
-    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    SUB_DIR="app/build/libs"
+
+    pushd ./app/
+
+    SUB_DIR="build/libs"
     JAR_NAME="app-all.jar"
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
     echo 'Starting API'
     java -jar "${DIR}"/"${SUB_DIR}"/"${JAR_NAME}" > /dev/null &
     export API_PID="${!}"
     echo "API starting at PID ${API_PID}"
+
+    popd
 }
 
 wait_for_api() {

--- a/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/SentPayloadReader.java
+++ b/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/SentPayloadReader.java
@@ -6,22 +6,13 @@ import java.nio.file.Path;
 
 public class SentPayloadReader {
 
-    public static String read() throws IOException {
-        Path payloadFile = findFilePayload();
+    private static final Path SENT_PAYLOAD_PATH = Path.of("..", "app", "localfileorder.json");
 
-        return Files.readString(payloadFile);
+    public static String read() throws IOException {
+        return Files.readString(SENT_PAYLOAD_PATH);
     }
 
-    private static Path findFilePayload() {
-
-        Path expectedFilePath = Path.of("..", "app", "localfileorder.json");
-
-        boolean doesFileExist = Files.exists(expectedFilePath);
-
-        if (!doesFileExist) {
-            expectedFilePath = Path.of("..", "localfileorder.json");
-        }
-
-        return expectedFilePath;
+    public static void delete() throws IOException {
+        Files.deleteIfExists(SENT_PAYLOAD_PATH);
     }
 }

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
@@ -10,6 +10,10 @@ class DemographicsTest extends Specification {
     def demographicsClient = new EndpointClient("/v1/etor/demographics")
     def newbornPatientJsonFileString = Files.readString(Path.of("../examples/fhir/newborn_patient.json"))
 
+    def setup() {
+        SentPayloadReader.delete()
+    }
+
     def "a demographics response is returned from the ETOR demographics endpoint"() {
         given:
         def expectedFhirResourceId  = "Bundle/bundle-with-patient"

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -10,6 +10,10 @@ class OrderTest extends Specification {
     def orderClient = new EndpointClient("/v1/etor/orders")
     def labOrderJsonFileString = Files.readString(Path.of("../examples/fhir/MN NBS FHIR Order Message.json"))
 
+    def setup() {
+        SentPayloadReader.delete()
+    }
+
     def "an order response is returned from the ETOR order endpoint"() {
         given:
         def expectedFhirResourceId  = "Bundle/b4efef3a-749c-457d-956b-568e22768bf3"


### PR DESCRIPTION
# Better Sent Payload File Handling

Our e2e tests can be brittle and create confusing errors depending on how you've run these tests in the past.

This PR updates how our e2e tests run such that the sent payload file is generated in the same folder no matter how you may run TI.  This simplifies our `SentPayloadReader` in our e2e tests.  In addition to this simplification, I also added an ability to delete the sent payload file, and I call this in our e2e tests so they clean-up.

## Issue

_None_.

## Checklist

- [x] I have added tests to cover my changes

**Note**: You may remove items that are not applicable
