### PR TITLE
Stop Renovate from Pinning Digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,5 +23,6 @@
             "matchPackageNames": ["ca.uhn.hapi.fhir:org.hl7.fhir.utilities"],
             "allowedVersions": "!/5\\.6\\.881/"
         }
-    ]
+    ],
+    "pinDigests": false
 }


### PR DESCRIPTION
# Stop Renovate from Pinning Digests

Setting Renovate to not pin digests for dependencies.

## Issue

_None._