### PR TITLE
Further update RS's setup instructions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,7 @@
         "filename": "README.md",
         "hashed_secret": "e07f44b0222f3680e0a3491edcf61030143e2ae7",
         "is_verified": false,
-        "line_number": 202,
+        "line_number": 214,
         "is_secret": false
       }
     ],
@@ -222,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-28T21:10:46Z"
+  "generated_at": "2023-09-08T20:46:09Z"
 }

--- a/README.md
+++ b/README.md
@@ -168,8 +168,20 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 
 #### CDC-TI Setup
 
-1. Checkout `rs-form-data` branch for `CDCgov/trusted-intermediary`
-2. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071 ./gradlew clean app:run`
+1. Checkout `main` branch for `CDCgov/trusted-intermediary`
+2. Edit the `app/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java` file and replace:
+   ```Java
+   │ 66 │        if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
+   │ 67 │            ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
+   │ 68 │        } else {
+   │ 69 │            ApplicationContext.register(OrderSender.class, ReportStreamOrderSender.getInstance());
+   │ 70 │        }
+   ```
+   with:
+   ```Java
+   │ 66 │        ApplicationContext.register(OrderSender.class, ReportStreamOrderSender.getInstance());
+   ```
+3. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071 ./gradlew clean app:run`
 
 #### ReportStream Setup
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 #### ReportStream Setup
 
 1. Checkout `master` branch for `CDCgov/prime-reportstream`
-2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#first-build) to build the baseline
+2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#building-the-baseline) to build the baseline
 3. CD to `prime-reportstream/prime-router`
 4. Run RS with `docker compose up --build -d`
 5. Run `./gradlew resetDB && ./gradlew reloadTable && ./gradlew reloadSettings`

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 
 #### ReportStream Setup
 
-1. Checkout `flexion/test/ti-rs-setup` branch for `CDCgov/prime-reportstream`
+1. Checkout `master` branch for `CDCgov/prime-reportstream`
 2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#first-build) to build the baseline
 3. CD to `prime-reportstream/prime-router`
 4. Run RS with `docker compose up --build -d`

--- a/README.md
+++ b/README.md
@@ -224,13 +224,19 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 
 #### Submit request to ReportStream
 
-`curl --header 'Content-Type: application/hl7-v2' --header 'Client: flexion.simulated-hospital' --header 'Authorization: Bearer none' --data-binary '@/path/to/ORM_O01.hl7' 'http://localhost:7071/api/waters'`
+```
+curl --header 'Content-Type: application/hl7-v2' --header 'Client: flexion.simulated-hospital' --header 'Authorization: Bearer <token>' --data-binary '@/path/to/message.hl7' 'http://localhost:7071/api/waters'
+```
 
 or
 
-`curl --header 'Content-Type: application/fhir+ndjson' --header 'Client: flexion.etor-service-sender' --header 'Authorization: Bearer none' --data-binary '@/path/to/lab_order.json' 'http://localhost:7071/api/waters'`
+```
+curl --header 'Content-Type: application/fhir+ndjson' --header 'Client: flexion.etor-service-sender' --header 'Authorization: Bearer <token>' --data-binary '@/path/to/message.fhir' 'http://localhost:7071/api/waters'
+```
 
 After one or two minutes, check that hl7 files have been dropped to `prime-reportstream/prime-router/build/sftp` folder
+
+**Note**: `<token>` should be replaced by the bearer token received from the `/api/token` endpoint
 
 ## DORA Metrics
 


### PR DESCRIPTION
- Updated RS branch name to `master` in setup instructions. Missed this in PR 503
- Updated RS url to point to right section of the docs
- Updated TI setup instruction to avoid relying on branch that is not up to date
