### PR TITLE
Rename fsh provenance instance id to avoid duplication

### DIFF
--- a/ig/input/fsh/nbs-obr-segment.fsh
+++ b/ig/input/fsh/nbs-obr-segment.fsh
@@ -43,7 +43,7 @@ Usage: #definition
 * agent[+].type = http://terminology.hl7.org/CodeSystem/provenance-participant-type#author
 * agent[=].who.display = "jorg3lopez"
 
-Instance: segment-obr-logical-model-history-update
+Instance: segment-obr-logical-model-history-update-2
 InstanceOf: Provenance
 Title: "Addition of OBR-11 segment"
 Usage: #definition


### PR DESCRIPTION
Renamed fsh provenance instance id to avoid duplication. [This fixes the IG build failure](https://github.com/CDCgov/trusted-intermediary/actions/runs/6162751090/job/16725206712#step:8:774)
