### PR TITLE
reverting docker compose workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,6 @@ jobs:
       - name: ShadowJar
         run: ./gradlew shadowJar
 
-      - name: Install Latest Version of Docker Compose v2
-        run: |
-          COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq '.tag_name' -r)
-          INSTALL_LOCATION=/usr/libexec/docker/cli-plugins/docker-compose
-          sudo curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o ${INSTALL_LOCATION}
-          sudo chmod +x ${INSTALL_LOCATION}
-          docker compose version
-
       - name: Run Container
         run: docker compose up --build -d
 

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -26,14 +26,6 @@ jobs:
       - name: ShadowJar
         run: ./gradlew clean shadowJar
 
-      - name: Install Latest Version of Docker Compose v2
-        run: |
-          COMPOSE_VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq '.tag_name' -r)
-          INSTALL_LOCATION=/usr/libexec/docker/cli-plugins/docker-compose
-          sudo curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" -o ${INSTALL_LOCATION}
-          sudo chmod +x ${INSTALL_LOCATION}
-          docker compose version
-
       - name: Run App in Container
         run: docker compose up --build -d
 


### PR DESCRIPTION
# Using Github actions docker image

We had to put a workaround in to stop relying on the Github actions docker-compose image since there was an error with that specific version.  This is removing the workaround and putting us back to the standard image used by the actions.

## Issue

#368

## Checklist

**Note**: You may remove items that are not applicable
