### PR TITLE
Adding to documentation for Apple Silicon and Auth stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,14 +218,11 @@ CDC including this GitHub page may be subject to applicable federal law, includi
    ```
 3. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071 ./gradlew clean app:run`
 
-## ReportStream Setup
+#### ReportStream Setup
 
 For Apple Silicon you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
 After enabling this option it is recommended that you delete all docker images and containers and rebuild them
 with this option enabled.
-
-
-### Running TI with ReportStream
 
 1. Checkout `master` branch for `CDCgov/prime-reportstream`
 2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#building-the-baseline) to build the baseline

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # CDC Trusted Intermediary
 
 ## Requirements
-
 Any distribution of the Java 17 JDK.
 
-For apple silicon you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
-After enabling this option it is recommended that you delete all docker images and containers and rebuild them
-with this option enabled.
-
 ## Using and Running
-
 To run the application directly, execute...
 
 ```shell
@@ -17,6 +11,15 @@ To run the application directly, execute...
 ```
 
 This will run the web API on port 8080.  You can view the API documentation at `/openapi`.
+
+### Generating and using a token
+1. Run `brew install mike-engel/jwt-cli/jwt-cli`
+2. Run `jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256  --no-iat -S @/PATH_TO_FILE_ON_YOUR_MACHINE/trusted-intermediary/mock_credentials/organization-trusted-intermediary-private-key-local.pem`
+3. Copy token from terminal and paste into your postman body with the key `client_assertion`
+4. Add a key to the body with the key `scope` and value of `trusted-intermediary`
+5. Body type should be `x-wwww-form-urlencoded`
+6. You should be able to run the post call against the `v1/auth/token` endpoint to receive a bearer token [to be used in this step](#submit-request-to-reportstream)
+
 
 ## Development
 
@@ -215,15 +218,12 @@ CDC including this GitHub page may be subject to applicable federal law, includi
    ```
 3. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071 ./gradlew clean app:run`
 
-#### ReportStream Setup
+## ReportStream Setup
 
-### Generating and using a token
-1. Run `brew install mike-engel/jwt-cli/jwt-cli`
-2. Run `jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256  --no-iat -S @/PATH_TO_FILE_ON_YOUR_MACHINE/trusted-intermediary/mock_credentials/organization-trusted-intermediary-private-key-local.pem`
-3. Copy token from terminal and paste into your postman body with the key `client_assertion`
-4. Add a key to the body with the key `scope` and value of `trusted-intermediary`
-5. Body type should be `x-wwww-form-urlencoded`
-6. You should be able to run the post call against the `v1/auth/token` endpoint to receive a bearer token [to be used in this step](#submit-request-to-reportstream)
+For Apple Silicon you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
+After enabling this option it is recommended that you delete all docker images and containers and rebuild them
+with this option enabled.
+
 
 ### Running TI with ReportStream
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Any distribution of the Java 17 JDK.
 
-For apple silicone you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
+For apple silicon you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
 After enabling this option it is recommended that you delete all docker images and containers and rebuild them
 with this option enabled.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Any distribution of the Java 17 JDK.
 
+For apple silicone you will want to enable the Docker option for `Use Rosetta for x86/amd64 emulation on Apple Silicon`.
+After enabling this option it is recommended that you delete all docker images and containers and rebuild them
+with this option enabled.
+
 ## Using and Running
 
 To run the application directly, execute...
@@ -212,6 +216,16 @@ CDC including this GitHub page may be subject to applicable federal law, includi
 3. Run TI with `REPORT_STREAM_URL_PREFIX=http://localhost:7071 ./gradlew clean app:run`
 
 #### ReportStream Setup
+
+### Generating and using a token
+1. Run `brew install mike-engel/jwt-cli/jwt-cli`
+2. Run `jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256  --no-iat -S @/PATH_TO_FILE_ON_YOUR_MACHINE/trusted-intermediary/mock_credentials/organization-trusted-intermediary-private-key-local.pem`
+3. Copy token from terminal and paste into your postman body with the key `client_assertion`
+4. Add a key to the body with the key `scope` and value of `trusted-intermediary`
+5. Body type should be `x-wwww-form-urlencoded`
+6. You should be able to run the post call against the `v1/auth/token` endpoint to receive a bearer token [to be used in this step](#submit-request-to-reportstream)
+
+### Running TI with ReportStream
 
 1. Checkout `master` branch for `CDCgov/prime-reportstream`
 2. Follow [the steps in the ReportStream docs](https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/docs/docs-deprecated/getting-started/getting-started.md#building-the-baseline) to build the baseline

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -63,11 +63,11 @@ public class EtorDomainRegistration implements DomainConnector {
         ApplicationContext.register(OrderController.class, OrderController.getInstance());
         ApplicationContext.register(SendOrderUseCase.class, SendOrderUseCase.getInstance());
 
-        if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
-            ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
-        } else {
+//        if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
+//            ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
+//        } else {
             ApplicationContext.register(OrderSender.class, ReportStreamOrderSender.getInstance());
-        }
+//        }
 
         return endpoints;
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -63,11 +63,11 @@ public class EtorDomainRegistration implements DomainConnector {
         ApplicationContext.register(OrderController.class, OrderController.getInstance());
         ApplicationContext.register(SendOrderUseCase.class, SendOrderUseCase.getInstance());
 
-//        if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
-//            ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
-//        } else {
+        if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
+            ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
+        } else {
             ApplicationContext.register(OrderSender.class, ReportStreamOrderSender.getInstance());
-//        }
+        }
 
         return endpoints;
     }


### PR DESCRIPTION
# Adding to setup docs

We didn't have anything around generating a token but we were referencing said token in the instructions for interacting with Report Stream.  

