### PR TITLE
Jetty Workaround

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation testFixtures(project(':shared'))
 
     implementation 'io.javalin:javalin:5.6.2'
+    implementation 'org.eclipse.jetty:jetty-http:11.0.17' // Overriding the version of Jetty from Javalin
 
     testImplementation 'org.apache.groovy:groovy:4.0.15'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'


### PR DESCRIPTION
# Update Jetty

This PR updates Jetty in our application. Currently, the application uses the Jetty server through Javalin. Javalin is not using the latest version at the moment and their current Jetty version was flagged with a vulnerability. The workaround is adding the newer version to the gradle file.


