### PR TITLE
Reverting Jetty version workaround

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     testImplementation testFixtures(project(':shared'))
 
     implementation 'io.javalin:javalin:5.6.3'
-    implementation 'org.eclipse.jetty:jetty-http:11.0.17' // Overriding the version of Jetty from Javalin
 
     testImplementation 'org.apache.groovy:groovy:4.0.15'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'


### PR DESCRIPTION
# Reverting Jetty workaround

We had a cve around the transitive dependency jetty inside of the javalin library.  javalin updated to mitigate this issue so the workaround is no longer needed. 

## Issue
#570 


