### PR TITLE
More Securely Log Into Docker Registry

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,8 +36,6 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-#      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-#      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,8 +36,8 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
+#      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
+#      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -54,8 +54,8 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.REGISTRY }}
-        username: ${{ secrets.ACR_USERNAME }}
-        password: ${{ secrets.ACR_PASSWORD }}
+        username: ${{ secrets.AZURE_CLIENT_ID }}
+#        password: ${{ secrets.ACR_PASSWORD }}
 
     - name: Build and push container image to registry
       uses: docker/build-push-action@v5

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -19,10 +19,6 @@ on:
         required: true
         type: string
     secrets:
-      ACR_USERNAME:
-        required: true
-      ACR_PASSWORD:
-        required: true
       AZURE_CLIENT_ID:
         required: true
       AZURE_TENANT_ID:

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -53,13 +53,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-#    - name: Log in to registry
-#      uses: docker/login-action@v3
-#      with:
-#        registry: ${{ inputs.REGISTRY }}
-#        username: ${{ secrets.ACR_USERNAME }}
-#        password: ${{ secrets.ACR_PASSWORD }}
-
     - name: Login via Azure CLI
       uses: azure/login@v1
       with:
@@ -67,21 +60,21 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Log in to registry 2
+    - name: Retrieve registry password
       id: login-to-registry
       uses: azure/CLI@v1
       with:
         inlineScript: |
-          ACR2_PASSWORD=$(az acr login --name ${{ inputs.REGISTRY }} --expose-token --output tsv --query accessToken)
-          echo "::add-mask::$ACR2_PASSWORD"
-          echo "ACR2_PASSWORD=$ACR2_PASSWORD" >> "$GITHUB_OUTPUT"
+          ACR_PASSWORD=$(az acr login --name ${{ inputs.REGISTRY }} --expose-token --output tsv --query accessToken)
+          echo "::add-mask::$ACR_PASSWORD"
+          echo "ACR_PASSWORD=$ACR_PASSWORD" >> "$GITHUB_OUTPUT"
 
-    - name: Log in to registry 3
+    - name: Log in to registry
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.REGISTRY }}
         username: 00000000-0000-0000-0000-000000000000
-        password: ${{ steps.login-to-registry.outputs.ACR2_PASSWORD }}
+        password: ${{ steps.login-to-registry.outputs.ACR_PASSWORD }}
 
     - name: Build and push container image to registry
       uses: docker/build-push-action@v5
@@ -125,12 +118,21 @@ jobs:
         slot-name: production
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'
 
+    - name: Retrieve registry password
+      id: login-to-registry
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          ACR_PASSWORD=$(az acr login --name ${{ inputs.REGISTRY }} --expose-token --output tsv --query accessToken)
+          echo "::add-mask::$ACR_PASSWORD"
+          echo "ACR_PASSWORD=$ACR_PASSWORD" >> "$GITHUB_OUTPUT"
+
     - name: Log in to registry
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.REGISTRY }}
-        username: ${{ secrets.ACR_USERNAME }}
-        password: ${{ secrets.ACR_PASSWORD }}
+        username: 00000000-0000-0000-0000-000000000000
+        password: ${{ steps.login-to-registry.outputs.ACR_PASSWORD }}
 
     - name: Extract generated documentation from the documentation image
       id: extract

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -57,7 +57,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Retrieve registry password
-      id: login-to-registry
+      id: retrieve-registry-password
       uses: azure/CLI@v1
       with:
         inlineScript: |
@@ -70,7 +70,7 @@ jobs:
       with:
         registry: ${{ inputs.REGISTRY }}
         username: 00000000-0000-0000-0000-000000000000
-        password: ${{ steps.login-to-registry.outputs.ACR_PASSWORD }}
+        password: ${{ steps.retrieve-registry-password.outputs.ACR_PASSWORD }}
 
     - name: Build and push container image to registry
       uses: docker/build-push-action@v5
@@ -115,7 +115,7 @@ jobs:
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'
 
     - name: Retrieve registry password
-      id: login-to-registry
+      id: retrieve-registry-password
       uses: azure/CLI@v1
       with:
         inlineScript: |
@@ -128,7 +128,7 @@ jobs:
       with:
         registry: ${{ inputs.REGISTRY }}
         username: 00000000-0000-0000-0000-000000000000
-        password: ${{ steps.login-to-registry.outputs.ACR_PASSWORD }}
+        password: ${{ steps.retrieve-registry-password.outputs.ACR_PASSWORD }}
 
     - name: Extract generated documentation from the documentation image
       id: extract

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -34,6 +34,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -50,12 +50,25 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to registry
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ inputs.REGISTRY }}
-        username: ${{ secrets.AZURE_CLIENT_ID }}
+#    - name: Log in to registry
+#      uses: docker/login-action@v3
+#      with:
+#        registry: ${{ inputs.REGISTRY }}
+#        username: ${{ secrets.ACR_USERNAME }}
 #        password: ${{ secrets.ACR_PASSWORD }}
+
+    - name: Login via Azure CLI
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Log in to registry 2
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az acr login --name ${{ inputs.REGISTRY }}
 
     - name: Build and push container image to registry
       uses: docker/build-push-action@v5

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -68,10 +68,20 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Log in to registry 2
+      id: login-to-registry
       uses: azure/CLI@v1
       with:
         inlineScript: |
-          az acr login --name ${{ inputs.REGISTRY }}
+          ACR2_PASSWORD=$(az acr login --name ${{ inputs.REGISTRY }} --expose-token --output tsv --query accessToken)
+          echo "::add-mask::$ACR2_PASSWORD"
+          echo "ACR2_PASSWORD=$ACR2_PASSWORD" >> "$GITHUB_OUTPUT"
+
+    - name: Log in to registry 3
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.REGISTRY }}
+        username: 00000000-0000-0000-0000-000000000000
+        password: ${{ steps.login-to-registry.outputs.ACR2_PASSWORD }}
 
     - name: Build and push container image to registry
       uses: docker/build-push-action@v5

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -29,8 +29,6 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CDC_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_CDC_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_CDC_DMZ_C1_SUBSCRIPTION_ID }}

--- a/.github/workflows/internal-deploy.yml
+++ b/.github/workflows/internal-deploy.yml
@@ -29,8 +29,8 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
+#      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
+#      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/internal-deploy.yml
+++ b/.github/workflows/internal-deploy.yml
@@ -29,8 +29,6 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-#      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-#      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -61,8 +61,6 @@ jobs:
       APP: ${{ needs.terraform-deploy.outputs.APP }}
       REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
     secrets:
-      ACR_USERNAME: ${{ needs.terraform-deploy.outputs.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ needs.terraform-deploy.outputs.ACR_PASSWORD }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -28,12 +28,6 @@ on:
       APP:
         description: The web application's name
         value: ${{ jobs.terraform-deploy.outputs.APP }}
-#      ACR_USERNAME:
-#        description: The username to login to the container registry
-#        value: ${{ jobs.terraform-deploy.outputs.ACR_USERNAME }}
-#      ACR_PASSWORD:
-#        description: The password to login to the container registry
-#        value: ${{ jobs.terraform-deploy.outputs.ACR_PASSWORD }}
 
 jobs:
   terraform-deploy:
@@ -54,8 +48,6 @@ jobs:
     outputs:
       REGISTRY: ${{ steps.export-terraform-output.outputs.REGISTRY }}
       APP: ${{ steps.export-terraform-output.outputs.APP }}
-#      ACR_USERNAME: ${{ steps.export-terraform-output.outputs.ACR_USERNAME }}
-#      ACR_PASSWORD: ${{ steps.export-terraform-output.outputs.ACR_PASSWORD }}
 
     steps:
 
@@ -77,6 +69,3 @@ jobs:
         run: |
           echo "REGISTRY=$(terraform output -raw registry)" >> "$GITHUB_OUTPUT"
           echo "APP=$(terraform output -raw publish_app)" >> "$GITHUB_OUTPUT"
-#          echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"
-#          echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> "$GITHUB_OUTPUT"
-#          echo "" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -79,3 +79,4 @@ jobs:
           echo "APP=$(terraform output -raw publish_app)" >> "$GITHUB_OUTPUT"
           echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"
           echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> "$GITHUB_OUTPUT"
+          echo "" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -28,12 +28,12 @@ on:
       APP:
         description: The web application's name
         value: ${{ jobs.terraform-deploy.outputs.APP }}
-      ACR_USERNAME:
-        description: The username to login to the container registry
-        value: ${{ jobs.terraform-deploy.outputs.ACR_USERNAME }}
-      ACR_PASSWORD:
-        description: The password to login to the container registry
-        value: ${{ jobs.terraform-deploy.outputs.ACR_PASSWORD }}
+#      ACR_USERNAME:
+#        description: The username to login to the container registry
+#        value: ${{ jobs.terraform-deploy.outputs.ACR_USERNAME }}
+#      ACR_PASSWORD:
+#        description: The password to login to the container registry
+#        value: ${{ jobs.terraform-deploy.outputs.ACR_PASSWORD }}
 
 jobs:
   terraform-deploy:
@@ -54,8 +54,8 @@ jobs:
     outputs:
       REGISTRY: ${{ steps.export-terraform-output.outputs.REGISTRY }}
       APP: ${{ steps.export-terraform-output.outputs.APP }}
-      ACR_USERNAME: ${{ steps.export-terraform-output.outputs.ACR_USERNAME }}
-      ACR_PASSWORD: ${{ steps.export-terraform-output.outputs.ACR_PASSWORD }}
+#      ACR_USERNAME: ${{ steps.export-terraform-output.outputs.ACR_USERNAME }}
+#      ACR_PASSWORD: ${{ steps.export-terraform-output.outputs.ACR_PASSWORD }}
 
     steps:
 
@@ -75,9 +75,8 @@ jobs:
       - id: export-terraform-output
         name: Export Terraform Output
         run: |
-          echo "::add-mask::$(terraform output -raw acr_password)"
           echo "REGISTRY=$(terraform output -raw registry)" >> "$GITHUB_OUTPUT"
           echo "APP=$(terraform output -raw publish_app)" >> "$GITHUB_OUTPUT"
-          echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"
-          echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> "$GITHUB_OUTPUT"
-          echo "" >> "$GITHUB_OUTPUT"
+#          echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"
+#          echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> "$GITHUB_OUTPUT"
+#          echo "" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -75,7 +75,7 @@ jobs:
       - id: export-terraform-output
         name: Export Terraform Output
         run: |
-          echo "REGISTRY=$(terraform output -raw registry)" >> $GITHUB_OUTPUT
-          echo "APP=$(terraform output -raw publish_app)" >> $GITHUB_OUTPUT
-          echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> $GITHUB_OUTPUT
-          echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> $GITHUB_OUTPUT
+          echo "REGISTRY=$(terraform output -raw registry)" >> "$GITHUB_OUTPUT"
+          echo "APP=$(terraform output -raw publish_app)" >> "$GITHUB_OUTPUT"
+          echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"
+          echo "ACR_PASSWORD=$(terraform output -raw acr_password)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -75,6 +75,7 @@ jobs:
       - id: export-terraform-output
         name: Export Terraform Output
         run: |
+          echo "::add-mask::$(terraform output -raw acr_password)"
           echo "REGISTRY=$(terraform output -raw registry)" >> "$GITHUB_OUTPUT"
           echo "APP=$(terraform output -raw publish_app)" >> "$GITHUB_OUTPUT"
           echo "ACR_USERNAME=$(terraform output -raw acr_username)" >> "$GITHUB_OUTPUT"

--- a/operations/environments/dev/outputs.tf
+++ b/operations/environments/dev/outputs.tf
@@ -1,17 +1,6 @@
 output "registry" {
   value = module.template.registry
 }
-
-output "acr_username" {
-  value     = module.template.acr_username
-  sensitive = true
-}
-
-output "acr_password" {
-  value     = module.template.acr_password
-  sensitive = true
-}
-
 output "publish_app" {
   value = module.template.publish_app
 }

--- a/operations/environments/internal/outputs.tf
+++ b/operations/environments/internal/outputs.tf
@@ -2,16 +2,6 @@ output "registry" {
   value = module.template.registry
 }
 
-output "acr_username" {
-  value     = module.template.acr_username
-  sensitive = true
-}
-
-output "acr_password" {
-  value     = module.template.acr_password
-  sensitive = true
-}
-
 output "publish_app" {
   value = module.template.publish_app
 }

--- a/operations/environments/pr/outputs.tf
+++ b/operations/environments/pr/outputs.tf
@@ -2,16 +2,6 @@ output "registry" {
   value = module.template.registry
 }
 
-output "acr_username" {
-  value     = module.template.acr_username
-  sensitive = true
-}
-
-output "acr_password" {
-  value     = module.template.acr_password
-  sensitive = true
-}
-
 output "publish_app" {
   value = module.template.publish_app
 }

--- a/operations/environments/staging/outputs.tf
+++ b/operations/environments/staging/outputs.tf
@@ -2,16 +2,6 @@ output "registry" {
   value = module.template.registry
 }
 
-output "acr_username" {
-  value     = module.template.acr_username
-  sensitive = true
-}
-
-output "acr_password" {
-  value     = module.template.acr_password
-  sensitive = true
-}
-
 output "publish_app" {
   value = module.template.publish_app
 }

--- a/operations/template/outputs.tf
+++ b/operations/template/outputs.tf
@@ -1,21 +1,6 @@
-# Output Container Registry information
-
 output "registry" {
   value = azurerm_container_registry.registry.login_server
 }
-
-output "acr_username" {
-  value     = azurerm_container_registry.registry.admin_username
-  sensitive = true
-}
-
-output "acr_password" {
-  value     = azurerm_container_registry.registry.admin_password
-  sensitive = true
-}
-
-
-# Output App Service information
 
 output "publish_app" {
   value = azurerm_linux_web_app.api.name


### PR DESCRIPTION
# More Securely Log Into Docker Registry

This fixes our recent failing deployments.

We now use our Azure credentials (through OIDC) to log into our Docker registry instead of using an admin username and password (which required passing these secrets between GitHub Action jobs).  This allows us to remove the ACR username and password outputs from Terraform too.

Deploys started failing last Friday, October 13, 2023.  GitHub Actions does not allow secrets being outputted from jobs, and seemingly GitHub Actions has changed the heuristics to determine whether an output from a job is a secret or not.  We were outputting a password secret to our Docker registry that stores our Docker images, which started getting caught by GitHub's checks.  This secret was never being outputted to the log so there was no leak.

## Issue

#582.

