### PR TITLE
Revert to Java 17

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,10 @@
     "packageRules": [{
             "matchPackageNames": ["ca.uhn.hapi.fhir:org.hl7.fhir.utilities"],
             "allowedVersions": "!/5\\.6\\.881/"
+        },
+        {
+            "matchPackageNames": ["amazoncorretto"],
+            "allowedVersions": "/17.*/"
         }
     ],
     "pinDigests": false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Linux-Alpine image
-FROM amazoncorretto:21-alpine
+FROM amazoncorretto:17.0.8-alpine
 
 ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
 


### PR DESCRIPTION
# Revert to Java 17

Our Staging and Internal environment are failing to handle much of any traffic (it seems to have crashed again since the afternoon).  Dev seems unaffected.  This seems to originate from Javalin not supporting Loom (virtual threads) fully yet.  Dev was on an older commit before Java 21 was being used.

We upgraded to Java 21 earlier this week, and it introduces Loom.  Javalin was configured to use these types of threads by default, but Javalin doesn't seem to fully work with them just yet.  See https://github.com/javalin/javalin/issues/2011 and https://github.com/javalin/javalin/issues/1778.  Javalin, in fact, plans to [_not_ use Loom by default](https://github.com/javalin/javalin/pull/2023) in a future release.

I also updated Renovate to stay within Java 17.

## Issue

_None._

