### PR TITLE
600: Cached Our Private Key Only After Successful Auth with RS

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -136,10 +136,11 @@ public class ReportStreamOrderSender implements OrderSender {
     protected String requestToken() throws UnableToSendOrderException {
         logger.logInfo("Requesting token from ReportStream");
 
+        String ourPrivateKey;
         String token;
 
         try {
-            String ourPrivateKey = retrievePrivateKey();
+            ourPrivateKey = retrievePrivateKey();
             String senderToken =
                     jwt.generateToken(
                             CLIENT_NAME,
@@ -156,6 +157,9 @@ public class ReportStreamOrderSender implements OrderSender {
                     "Error getting the API token from ReportStream", e);
         }
 
+        // only cache our private key if we successfully authenticate to RS
+        keyCache.put(OUR_PRIVATE_KEY_ID, ourPrivateKey);
+
         return token;
     }
 
@@ -166,7 +170,7 @@ public class ReportStreamOrderSender implements OrderSender {
         }
 
         key = secrets.getKey(OUR_PRIVATE_KEY_ID);
-        keyCache.put(OUR_PRIVATE_KEY_ID, key);
+
         return key;
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -37,6 +37,9 @@ public class ReportStreamOrderSender implements OrderSender {
                     .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
                     .orElse("");
 
+    private static final String OUR_PRIVATE_KEY_ID =
+            "trusted-intermediary-private-key-" + ApplicationContext.getEnvironment();
+
     private static final String CLIENT_NAME = "flexion.etor-service-sender";
 
     private String rsTokenCache;
@@ -155,15 +158,13 @@ public class ReportStreamOrderSender implements OrderSender {
     }
 
     protected String retrievePrivateKey() throws SecretRetrievalException {
-        var senderPrivateKey =
-                "trusted-intermediary-private-key-" + ApplicationContext.getEnvironment();
-        String key = this.keyCache.get(senderPrivateKey);
+        String key = this.keyCache.get(OUR_PRIVATE_KEY_ID);
         if (key != null) {
             return key;
         }
 
-        key = secrets.getKey(senderPrivateKey);
-        this.keyCache.put(senderPrivateKey, key);
+        key = secrets.getKey(OUR_PRIVATE_KEY_ID);
+        this.keyCache.put(OUR_PRIVATE_KEY_ID, key);
         return key;
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -139,6 +139,7 @@ public class ReportStreamOrderSender implements OrderSender {
         String body;
         Map<String, String> headers = Map.of("Content-Type", "application/x-www-form-urlencoded");
         try {
+            var ourPrivateKey = retrievePrivateKey();
             senderToken =
                     jwt.generateToken(
                             CLIENT_NAME,
@@ -146,7 +147,7 @@ public class ReportStreamOrderSender implements OrderSender {
                             CLIENT_NAME,
                             RS_DOMAIN_NAME,
                             300,
-                            retrievePrivateKey());
+                            ourPrivateKey);
             body = composeRequestBody(senderToken);
             String rsResponse = client.post(RS_AUTH_API_URL, headers, body);
             token = extractToken(rsResponse);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -158,7 +158,7 @@ public class ReportStreamOrderSender implements OrderSender {
         }
 
         // only cache our private key if we successfully authenticate to RS
-        keyCache.put(OUR_PRIVATE_KEY_ID, ourPrivateKey);
+        cachePrivateKeyIfNotCachedAlready(ourPrivateKey);
 
         return token;
     }
@@ -172,6 +172,15 @@ public class ReportStreamOrderSender implements OrderSender {
         key = secrets.getKey(OUR_PRIVATE_KEY_ID);
 
         return key;
+    }
+
+    protected void cachePrivateKeyIfNotCachedAlready(String privateKey) {
+        String key = keyCache.get(OUR_PRIVATE_KEY_ID);
+        if (key != null) {
+            return;
+        }
+
+        keyCache.put(OUR_PRIVATE_KEY_ID, privateKey);
     }
 
     protected String extractToken(String responseBody) throws FormatterProcessingException {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -158,7 +158,7 @@ public class ReportStreamOrderSender implements OrderSender {
         }
 
         // only cache our private key if we successfully authenticate to RS
-        cachePrivateKeyIfNotCachedAlready(ourPrivateKey);
+        cacheOurPrivateKeyIfNotCachedAlready(ourPrivateKey);
 
         return token;
     }
@@ -174,7 +174,7 @@ public class ReportStreamOrderSender implements OrderSender {
         return key;
     }
 
-    protected void cachePrivateKeyIfNotCachedAlready(String privateKey) {
+    void cacheOurPrivateKeyIfNotCachedAlready(String privateKey) {
         String key = keyCache.get(OUR_PRIVATE_KEY_ID);
         if (key != null) {
             return;

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -86,8 +86,6 @@ class ReportStreamOrderSenderTest extends Specification {
 
     def "requestToken saves our private key only after successful call to RS"() {
         given:
-        def mockAuthEngine = Mock(AuthEngine)
-        def mockClient = Mock(HttpClient)
         def mockSecrets = Mock(Secrets)
         def mockCache = Mock(Cache)
         def mockFormatter = Mock(Formatter)
@@ -96,8 +94,8 @@ class ReportStreamOrderSenderTest extends Specification {
         mockSecrets.getKey(_ as String) >> fakeOurPrivateKey
         mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
 
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(HttpClient, Mock(HttpClient))
         TestApplicationContext.register(Formatter, mockFormatter)
         TestApplicationContext.register(Secrets, mockSecrets)
         TestApplicationContext.register(Cache, mockCache)
@@ -113,9 +111,7 @@ class ReportStreamOrderSenderTest extends Specification {
 
     def "requestToken doesn't cache our private key if RS auth call fails"() {
         given:
-        def mockAuthEngine = Mock(AuthEngine)
         def mockClient = Mock(HttpClient)
-        def mockSecrets = Mock(Secrets)
         def mockCache = Mock(Cache)
         def mockFormatter = Mock(Formatter)
 
@@ -123,10 +119,10 @@ class ReportStreamOrderSenderTest extends Specification {
 
         mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
 
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
         TestApplicationContext.register(HttpClient, mockClient)
         TestApplicationContext.register(Formatter, mockFormatter)
-        TestApplicationContext.register(Secrets, mockSecrets)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
         TestApplicationContext.register(Cache, mockCache)
 
         TestApplicationContext.injectRegisteredImplementations()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -135,7 +135,7 @@ class ReportStreamOrderSenderTest extends Specification {
         0 * mockCache.put(_ , _)
     }
 
-    def "cachePrivateKeyIfNotCachedAlready doesn't cache when the key is already is cached"() {
+    def "cacheOurPrivateKeyIfNotCachedAlready doesn't cache when the key is already is cached"() {
         given:
         def mockCache = Mock(Cache)
         mockCache.get(_ as String) >> "DogCow private key"
@@ -145,13 +145,13 @@ class ReportStreamOrderSenderTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamOrderSender.getInstance().cachePrivateKeyIfNotCachedAlready("Moof!")
+        ReportStreamOrderSender.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
 
         then:
         0 * mockCache.put(_, _)
     }
 
-    def "cachePrivateKeyIfNotCachedAlready caches when the key isn't cached"() {
+    def "cacheOurPrivateKeyIfNotCachedAlready caches when the key isn't cached"() {
         given:
         def mockCache = Mock(Cache)
         mockCache.get(_ as String) >> null
@@ -161,7 +161,7 @@ class ReportStreamOrderSenderTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamOrderSender.getInstance().cachePrivateKeyIfNotCachedAlready("Moof!")
+        ReportStreamOrderSender.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
 
         then:
         1 * mockCache.put(_, _)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -193,11 +193,9 @@ class ReportStreamOrderSenderTest extends Specification {
         given:
         def mockSecret = Mock(Secrets)
         def expected = "New Fake Azure Key"
-        def keyCache = KeyCache.getInstance()
-        def key = "trusted-intermediary-private-key-local"
         mockSecret.getKey(_ as String) >> expected
         TestApplicationContext.register(Secrets, mockSecret)
-        TestApplicationContext.register(Cache, keyCache)
+        TestApplicationContext.register(Cache, KeyCache.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
         def rsOrderSender = ReportStreamOrderSender.getInstance()
         when:
@@ -205,7 +203,6 @@ class ReportStreamOrderSenderTest extends Specification {
 
         then:
         actual == expected
-        keyCache.get(key) == expected
     }
 
     def "retrievePrivateKey works when cache is not empty" () {


### PR DESCRIPTION
# Cached Our Private Key Only After Successful Auth with RS

Before this PR, we cached our private key after retrieving it no matter what happened.  This prevented us from having to continually call Azure for our secret each time we need to login to ReportStream (which is about every 5 minutes).  But, if the key was bad for some reason, we would fail to login to RS in perpetuity until we restarted our application (which would clear the cache).  This happened because once we retrieved the secret, we cached it without ever clearing it.

Now, we don't even cache our private key in the first place if we fail to login to RS.  We also only cache the key if it wasn't already cached.  This prevents us from continuously caching the key whenever we successfully authenticate with a key that was already cached.

## Issue

#600.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly
