### PR TITLE
Use Existing "Research" Label

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_research.md
+++ b/.github/ISSUE_TEMPLATE/design_research.md
@@ -2,7 +2,7 @@
 name: Design or Research Backlog Item
 about: High level design or research work needs to be accomplished
 title: ''
-labels: design/research
+labels: research
 assignees: ''
 
 ---


### PR DESCRIPTION
# Use Existing "Research" Label

Our issue template was set to auto-assign `design/research` as the label, but we don't really use that label.  We mostly use the `research` label.  So, I codified this in our template.

## Issue

_None_.