### PR TITLE
Fixing load tests

### DIFF
--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -99,7 +99,7 @@ def get_auth_request_body():
     with open("mock_credentials/report-stream-valid-token.jwt") as f:
         auth_token = f.read()
     params = urllib.parse.urlencode(
-        {"scope": auth_scope, "client_assertion": auth_token}
+        {"scope": auth_scope, "client_assertion": auth_token.strip()}
     )
     return params.encode("utf-8")
 


### PR DESCRIPTION
When we updated the key management library we had to strip newlines off of the end of our jwts. We missed one in our load test python file.  This removes that newline and makes the tests run successfully. 