### PR TITLE
672: Write Dummy Metadata

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -11,6 +11,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.ConvertAndSendDemograph
 import gov.hhs.cdc.trustedintermediary.etor.demographics.Demographics;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsController;
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResponse;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderConverter;
@@ -18,7 +19,9 @@ import gov.hhs.cdc.trustedintermediary.etor.orders.OrderResponse;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.orders.SendOrderUseCase;
 import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
+import gov.hhs.cdc.trustedintermediary.external.azure.AzureStorageAccountPartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiOrderConverter;
+import gov.hhs.cdc.trustedintermediary.external.localfile.FilePartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalFileOrderSender;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamOrderSender;
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
@@ -65,8 +68,13 @@ public class EtorDomainRegistration implements DomainConnector {
 
         if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
             ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());
+            ApplicationContext.register(
+                    PartnerMetadataStorage.class, FilePartnerMetadataStorage.getInstance());
         } else {
             ApplicationContext.register(OrderSender.class, ReportStreamOrderSender.getInstance());
+            ApplicationContext.register(
+                    PartnerMetadataStorage.class,
+                    AzureStorageAccountPartnerMetadataStorage.getInstance());
         }
 
         return endpoints;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -1,6 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
-import java.time.LocalTime;
+import java.time.Instant;
 
 /**
  * The partner-facing metadata.
@@ -12,4 +12,4 @@ import java.time.LocalTime;
  * @param hash The hash of the message.
  */
 public record PartnerMetadata(
-        String uniqueId, String sender, String receiver, LocalTime timeReceived, String hash) {}
+        String uniqueId, String sender, String receiver, Instant timeReceived, String hash) {}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -1,7 +1,10 @@
 package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetaDataStep;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetaData;
+import java.time.Instant;
 import javax.inject.Inject;
 
 /** The overall logic to receive, convert to OML, and subsequently send a lab order. */
@@ -10,6 +13,7 @@ public class SendOrderUseCase {
     @Inject OrderConverter converter;
     @Inject OrderSender sender;
     @Inject MetricMetaData metaData;
+    @Inject PartnerMetadataStorage partnerMetadataStorage;
 
     private SendOrderUseCase() {}
 
@@ -18,6 +22,11 @@ public class SendOrderUseCase {
     }
 
     public void convertAndSend(final Order<?> order) throws UnableToSendOrderException {
+        var partnerMetadata =
+                new PartnerMetadata(
+                        "uniqueId", "senderName", "receiverName", Instant.now(), "abcd");
+        partnerMetadataStorage.saveMetadata(partnerMetadata);
+
         var omlOrder = converter.convertMetadataToOmlOrder(order);
         metaData.put(order.getFhirResourceId(), EtorMetaDataStep.ORDER_CONVERTED_TO_OML);
         omlOrder = converter.addContactSectionToPatientResource(omlOrder);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
@@ -5,6 +5,16 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 
 /** Implements the {@link PartnerMetadataStorage} using files stored in an Azure Storage Account. */
 public class AzureStorageAccountPartnerMetadataStorage implements PartnerMetadataStorage {
+
+    private static final AzureStorageAccountPartnerMetadataStorage INSTANCE =
+            new AzureStorageAccountPartnerMetadataStorage();
+
+    private AzureStorageAccountPartnerMetadataStorage() {}
+
+    public static AzureStorageAccountPartnerMetadataStorage getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public PartnerMetadata readMetadata(final String uniqueId) {
         return null;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -5,6 +5,16 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 
 /** Implements the {@link PartnerMetadataStorage} using a database. */
 public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
+
+    private static final DatabasePartnerMetadataStorage INSTANCE =
+            new DatabasePartnerMetadataStorage();
+
+    private DatabasePartnerMetadataStorage() {}
+
+    public static DatabasePartnerMetadataStorage getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public PartnerMetadata readMetadata(final String uniqueId) {
         return null;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -5,6 +5,15 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 
 /** Implements the {@link PartnerMetadataStorage} using local files. */
 public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
+
+    private static final FilePartnerMetadataStorage INSTANCE = new FilePartnerMetadataStorage();
+
+    private FilePartnerMetadataStorage() {}
+
+    public static FilePartnerMetadataStorage getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public PartnerMetadata readMetadata(final String uniqueId) {
         return null;


### PR DESCRIPTION
# Write Dummy Metadata

- Write some sample partner-facing metadata when we are sent an order.
- Converted the partner-facing metadata to use an `Instant` instead of a `LocalTime`.

## Issue

#672.