### PR TITLE
498: Change `prod` Environment Name to `prd` in Terraform

### DIFF
--- a/operations/environments/prod/main.tf
+++ b/operations/environments/prod/main.tf
@@ -27,6 +27,6 @@ provider "azurerm" {
 module "template" {
   source = "../../template/"
 
-  environment = "prod"
+  environment = "prd"
   deployer_id = "f5feabe7-5d37-40ba-94f2-e5c0760b4561" //github app registration in CDC Azure Entra
 }


### PR DESCRIPTION
# Change `prod` Environment Name to `prd` in Terraform

Changed the environment name being passed in for our production environment to be `prd` in the Terraform code.  CDC uses `prd` in the name of our Azure resource group.

## Issue

#498.
