### PR TITLE
Downgrade Apache Client5

### DIFF
--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -11,8 +11,8 @@ java {
 
 dependencies {
     //client
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.3'
 
     //jackson
     implementation 'com.fasterxml.jackson.core:jackson-core:2.16.0'

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     api 'org.fhir:ucum:1.0.8'
 
     // Apache Client
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.3'
 
     // jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'


### PR DESCRIPTION
# Downgrade Apache Client5: 5.3 to 5.2.3

This PR addresses the issues caused by updating Apache client 5 from version `5.2.3` to `5.3`. The main issues were incompatibility from the `org.apache.hc.core5.http.header` import and the response body from an incoming http request is corrupted, half of its data is cut-off/missing causing a format exception.

## Issue
#723 

