### PR TITLE
Update PartnerMetadataStorage.readMetadata to return Optional<PartnerMetadata>

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
@@ -1,8 +1,17 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
+import java.util.Optional;
+
 /** Interface to store and retrieve our partner-facing metadata. */
 public interface PartnerMetadataStorage {
-    PartnerMetadata readMetadata(String uniqueId) throws PartnerMetadataException;
+
+    /**
+     * This method will retrieve and return the metadata for the given uniqueId, if it exists.
+     *
+     * @param uniqueId The uniqueId to read the metadata for.
+     * @return The metadata, if it exists. Otherwise, an empty Optional.
+     */
+    Optional<PartnerMetadata> readMetadata(String uniqueId) throws PartnerMetadataException;
 
     /**
      * This method will do "upserts". If the record doesn't exist, it is created. If the record

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.azure;
 
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
+import java.util.Optional;
 
 /** Implements the {@link PartnerMetadataStorage} using files stored in an Azure Storage Account. */
 public class AzureStorageAccountPartnerMetadataStorage implements PartnerMetadataStorage {
@@ -16,8 +17,8 @@ public class AzureStorageAccountPartnerMetadataStorage implements PartnerMetadat
     }
 
     @Override
-    public PartnerMetadata readMetadata(final String uniqueId) {
-        return null;
+    public Optional<PartnerMetadata> readMetadata(final String uniqueId) {
+        return Optional.empty();
     }
 
     @Override

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -18,7 +18,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
 
     @Override
     public Optional<PartnerMetadata> readMetadata(final String uniqueId) {
-        return null;
+        return Optional.empty();
     }
 
     @Override

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.database;
 
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
+import java.util.Optional;
 
 /** Implements the {@link PartnerMetadataStorage} using a database. */
 public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
@@ -16,7 +17,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
     }
 
     @Override
-    public PartnerMetadata readMetadata(final String uniqueId) {
+    public Optional<PartnerMetadata> readMetadata(final String uniqueId) {
         return null;
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Optional;
 import javax.inject.Inject;
 
 /** Implements the {@link PartnerMetadataStorage} using local files. */
@@ -42,9 +43,13 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     }
 
     @Override
-    public PartnerMetadata readMetadata(final String uniqueId) throws PartnerMetadataException {
+    public Optional<PartnerMetadata> readMetadata(final String uniqueId)
+            throws PartnerMetadataException {
         Path filePath = getFilePath(uniqueId);
         try {
+            if (!Files.exists(filePath)) {
+                return Optional.empty();
+            }
             String content = Files.readString(filePath);
             return formatter.convertJsonToObject(content, new TypeReference<>() {});
         } catch (IOException | FormatterProcessingException e) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -48,6 +48,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
         Path filePath = getFilePath(uniqueId);
         try {
             if (!Files.exists(filePath)) {
+                logger.logInfo("Metadata file not found: " + filePath);
                 return Optional.empty();
             }
             String content = Files.readString(filePath);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -48,7 +48,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
         Path filePath = getFilePath(uniqueId);
         try {
             if (!Files.exists(filePath)) {
-                logger.logWarning("Metadata file not found: " + filePath);
+                logger.logWarning("Metadata file not found: {}", filePath);
                 return Optional.empty();
             }
             String content = Files.readString(filePath);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -51,7 +51,9 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
                 return Optional.empty();
             }
             String content = Files.readString(filePath);
-            return formatter.convertJsonToObject(content, new TypeReference<>() {});
+            PartnerMetadata metadata =
+                    formatter.convertJsonToObject(content, new TypeReference<>() {});
+            return Optional.ofNullable(metadata);
         } catch (IOException | FormatterProcessingException e) {
             throw new PartnerMetadataException("Unable to read the metadata file", e);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -48,7 +48,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
         Path filePath = getFilePath(uniqueId);
         try {
             if (!Files.exists(filePath)) {
-                logger.logInfo("Metadata file not found: " + filePath);
+                logger.logWarning("Metadata file not found: " + filePath);
                 return Optional.empty();
             }
             String content = Files.readString(filePath);

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -32,7 +32,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedUniqueId)
 
         then:
-        actualMetadata == metadata
+        actualMetadata.get() == metadata
     }
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -64,4 +64,12 @@ class FilePartnerMetadataStorageTest extends Specification {
         then:
         thrown(PartnerMetadataException)
     }
+
+    def "readMetadata returns empty when file does not exist"() {
+        when:
+        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata("nonexistentId")
+
+        then:
+        !actualMetadata.isPresent()
+    }
 }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/DeployedLogger.java
@@ -45,8 +45,10 @@ public class DeployedLogger implements Logger {
     }
 
     @Override
-    public void logWarning(String warningMessage) {
-        LoggerHelper.logMessageAtLevel(LOGGER, Level.WARN, warningMessage).log();
+    public void logWarning(String warningMessage, Object... parameters) {
+        var logBuilder = LoggerHelper.logMessageAtLevel(LOGGER, Level.WARN, warningMessage);
+        Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
+        logBuilder.log();
     }
 
     @Override

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/slf4j/LocalLogger.java
@@ -77,13 +77,17 @@ public class LocalLogger implements Logger {
     }
 
     @Override
-    public void logWarning(String warningMessage) {
+    public void logWarning(String warningMessage, Object... parameters) {
         Level level = Level.WARN;
-        LoggerHelper.logMessageAtLevel(
+        var logBuilder =
+                LoggerHelper.logMessageAtLevel(
                         LOGGER,
                         level,
-                        wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), warningMessage))
-                .log();
+                        wrapMessageInColor(LEVEL_COLOR_MAPPING.get(level), warningMessage));
+
+        Arrays.stream(parameters).forEachOrdered(logBuilder::addArgument);
+
+        logBuilder.log();
     }
 
     @Override

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/Logger.java
@@ -11,7 +11,7 @@ public interface Logger {
 
     void logMap(String key, Map<String, Object> map);
 
-    void logWarning(String warningMessage);
+    void logWarning(String warningMessage, Object... parameters);
 
     void logError(String errorMessage);
 


### PR DESCRIPTION
# Update PartnerMetadataStorage.readMetadata to return Optional<PartnerMetadata>

We're missing a failure path in the case the metadata was not found, so we can return a `404` error instead of `400`. For this purpose I'm changing the return value of `readMetadata` to `Optional<PartnerMetadata>` so we can return and handle an empty value when the metadata is not found

## Issue

#672 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
