### PR TITLE
Use ReportId to identify metadata for testing purposes

### DIFF
--- a/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/EndpointClient.java
+++ b/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/EndpointClient.java
@@ -29,7 +29,8 @@ public class EndpointClient {
         }
     }
 
-    public ClassicHttpResponse submit(String fhirBody, boolean loginFirst) throws IOException {
+    public ClassicHttpResponse submit(String fhirBody, String submissionId, boolean loginFirst)
+            throws IOException {
 
         Map<String, String> headers = new HashMap<>();
 
@@ -37,6 +38,7 @@ public class EndpointClient {
             var accessToken = AuthClient.requestAccessToken("report-stream", token);
             headers.put("Authorization", "Bearer " + accessToken);
         }
+        headers.put("RecordId", submissionId);
 
         return HttpClient.post(endpoint, fhirBody, ContentType.APPLICATION_JSON, headers);
     }

--- a/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/EndpointClient.java
+++ b/e2e/src/main/java/gov/hhs/cdc/trustedintermediary/e2e/EndpointClient.java
@@ -29,6 +29,10 @@ public class EndpointClient {
         }
     }
 
+    public ClassicHttpResponse submit(String fhirBody, boolean loginFirst) throws IOException {
+        return submit(fhirBody, null, loginFirst);
+    }
+
     public ClassicHttpResponse submit(String fhirBody, String submissionId, boolean loginFirst)
             throws IOException {
 
@@ -38,7 +42,10 @@ public class EndpointClient {
             var accessToken = AuthClient.requestAccessToken("report-stream", token);
             headers.put("Authorization", "Bearer " + accessToken);
         }
-        headers.put("RecordId", submissionId);
+
+        if (submissionId != null) {
+            headers.put("RecordId", submissionId);
+        }
 
         return HttpClient.post(endpoint, fhirBody, ContentType.APPLICATION_JSON, headers);
     }

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
@@ -9,7 +9,6 @@ class DemographicsTest extends Specification {
 
     def demographicsClient = new EndpointClient("/v1/etor/demographics")
     def newbornPatientJsonFileString = Files.readString(Path.of("../examples/fhir/newborn_patient.json"))
-    def submissionId = "submissionId"
 
     def setup() {
         SentPayloadReader.delete()
@@ -21,7 +20,7 @@ class DemographicsTest extends Specification {
         def expectedPatientId  = "MRN7465737865"
 
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, true)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -32,7 +31,7 @@ class DemographicsTest extends Specification {
 
     def "payload file check"() {
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, true)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, true)
         def parsedResponseBody = JsonParsing.parseContent(response)
         def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
@@ -54,7 +53,7 @@ class DemographicsTest extends Specification {
         def invalidJsonRequest = newbornPatientJsonFileString.substring(1)
 
         when:
-        def response = demographicsClient.submit(invalidJsonRequest, submissionId, true)
+        def response = demographicsClient.submit(invalidJsonRequest, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -64,7 +63,7 @@ class DemographicsTest extends Specification {
 
     def "return a 401 response when making an unauthenticated request"() {
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, false)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, false)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/DemographicsTest.groovy
@@ -9,6 +9,7 @@ class DemographicsTest extends Specification {
 
     def demographicsClient = new EndpointClient("/v1/etor/demographics")
     def newbornPatientJsonFileString = Files.readString(Path.of("../examples/fhir/newborn_patient.json"))
+    def submissionId = "submissionId"
 
     def setup() {
         SentPayloadReader.delete()
@@ -20,7 +21,7 @@ class DemographicsTest extends Specification {
         def expectedPatientId  = "MRN7465737865"
 
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, true)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -31,7 +32,7 @@ class DemographicsTest extends Specification {
 
     def "payload file check"() {
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, true)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, true)
         def parsedResponseBody = JsonParsing.parseContent(response)
         def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
@@ -53,7 +54,7 @@ class DemographicsTest extends Specification {
         def invalidJsonRequest = newbornPatientJsonFileString.substring(1)
 
         when:
-        def response = demographicsClient.submit(invalidJsonRequest, true)
+        def response = demographicsClient.submit(invalidJsonRequest, submissionId, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -63,7 +64,7 @@ class DemographicsTest extends Specification {
 
     def "return a 401 response when making an unauthenticated request"() {
         when:
-        def response = demographicsClient.submit(newbornPatientJsonFileString, false)
+        def response = demographicsClient.submit(newbornPatientJsonFileString, submissionId, false)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -9,6 +9,7 @@ class OrderTest extends Specification {
 
     def orderClient = new EndpointClient("/v1/etor/orders")
     def labOrderJsonFileString = Files.readString(Path.of("../examples/fhir/MN NBS FHIR Order Message.json"))
+    def submissionId = "submissionId"
 
     def setup() {
         SentPayloadReader.delete()
@@ -20,7 +21,7 @@ class OrderTest extends Specification {
         def expectedPatientId  = "11102779"
 
         when:
-        def response = orderClient.submit(labOrderJsonFileString, true)
+        def response = orderClient.submit(labOrderJsonFileString, submissionId, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -31,7 +32,7 @@ class OrderTest extends Specification {
 
     def "check that contact info is added to order before sending to report stream"() {
         when:
-        orderClient.submit(labOrderJsonFileString, true)
+        orderClient.submit(labOrderJsonFileString, submissionId, true)
         def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
 
@@ -41,7 +42,7 @@ class OrderTest extends Specification {
 
     def "check that the rest of the message is unchanged except the parts we changed"() {
         when:
-        orderClient.submit(labOrderJsonFileString, true)
+        orderClient.submit(labOrderJsonFileString, submissionId, true)
         def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
         def parsedLabOrderJsonFile = JsonParsing.parse(labOrderJsonFileString)
@@ -57,7 +58,7 @@ class OrderTest extends Specification {
 
     def "check that message type is converted to OML_O21"() {
         when:
-        orderClient.submit(labOrderJsonFileString, true)
+        orderClient.submit(labOrderJsonFileString, submissionId, true)
         def sentPayload = SentPayloadReader.read()
         def parsedSentPayload = JsonParsing.parse(sentPayload)
 
@@ -74,7 +75,7 @@ class OrderTest extends Specification {
         def invalidJsonRequest = labOrderJsonFileString.substring(1)
 
         when:
-        def response = orderClient.submit(invalidJsonRequest, true)
+        def response = orderClient.submit(invalidJsonRequest, submissionId, true)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:
@@ -84,7 +85,7 @@ class OrderTest extends Specification {
 
     def "return a 401 response when making an unauthenticated request"() {
         when:
-        def response = orderClient.submit(labOrderJsonFileString, false)
+        def response = orderClient.submit(labOrderJsonFileString, submissionId, false)
         def parsedJsonBody = JsonParsing.parseContent(response)
 
         then:

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -126,8 +126,17 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleOrders(DomainRequest request) {
         Order<?> orders;
 
+        String submissionId = request.getHeaders().get("RecordId");
+        // TODO: need to verify what we should do if we don't receive the RecordId header or if it's
+        // empty
+        // For now, returning a 400 error
+        if (submissionId == null) {
+            String errorMessage = "Missing required header: RecordId";
+            logger.logError(errorMessage);
+            return domainResponseHelper.constructErrorResponse(400, errorMessage);
+        }
+
         try {
-            String submissionId = request.getHeaders().get("RecordId");
             orders = orderController.parseOrders(request);
             sendOrderUseCase.convertAndSend(orders, submissionId);
         } catch (FhirParseException e) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -127,8 +127,9 @@ public class EtorDomainRegistration implements DomainConnector {
         Order<?> orders;
 
         String submissionId = request.getHeaders().get("RecordId");
-        if (submissionId == null) {
-            logger.logError("Missing required header: RecordId");
+        if (submissionId == null || submissionId.isEmpty()) {
+            submissionId = null;
+            logger.logError("Missing required header or empty: RecordId");
         }
 
         try {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -127,13 +127,8 @@ public class EtorDomainRegistration implements DomainConnector {
         Order<?> orders;
 
         String submissionId = request.getHeaders().get("RecordId");
-        // TODO: need to verify what we should do if we don't receive the RecordId header or if it's
-        // empty
-        // For now, returning a 400 error
         if (submissionId == null) {
-            String errorMessage = "Missing required header: RecordId";
-            logger.logError(errorMessage);
-            return domainResponseHelper.constructErrorResponse(400, errorMessage);
+            logger.logError("Missing required header: RecordId");
         }
 
         try {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -118,8 +118,9 @@ public class EtorDomainRegistration implements DomainConnector {
         Order<?> orders;
 
         try {
+            String submissionId = request.getHeaders().get("RecordId");
             orders = orderController.parseOrders(request);
-            sendOrderUseCase.convertAndSend(orders);
+            sendOrderUseCase.convertAndSend(orders, submissionId);
         } catch (FhirParseException e) {
             logger.logError("Unable to parse order request", e);
             return domainResponseHelper.constructErrorResponse(400, e);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -22,10 +22,11 @@ public class SendOrderUseCase {
         return INSTANCE;
     }
 
-    public void convertAndSend(final Order<?> order) throws UnableToSendOrderException {
+    public void convertAndSend(final Order<?> order, String submissionId)
+            throws UnableToSendOrderException {
         var partnerMetadata =
                 new PartnerMetadata(
-                        "uniqueId", "senderName", "receiverName", Instant.now(), "abcd");
+                        submissionId, "senderName", "receiverName", Instant.now(), "abcd");
         try {
             partnerMetadataStorage.saveMetadata(partnerMetadata);
         } catch (PartnerMetadataException e) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -45,6 +45,7 @@ public class SendOrderUseCase {
             return;
         }
 
+        // TODO: still need to get metadata from the order: sender, receiver, timeReceived, hash
         PartnerMetadata partnerMetadata =
                 new PartnerMetadata(
                         submissionId, "senderName", "receiverName", Instant.now(), "abcd");

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -4,6 +4,7 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
 import java.time.Instant;
 import javax.inject.Inject;
@@ -15,6 +16,7 @@ public class SendOrderUseCase {
     @Inject OrderSender sender;
     @Inject MetricMetadata metadata;
     @Inject PartnerMetadataStorage partnerMetadataStorage;
+    @Inject Logger logger;
 
     private SendOrderUseCase() {}
 
@@ -24,13 +26,11 @@ public class SendOrderUseCase {
 
     public void convertAndSend(final Order<?> order, String submissionId)
             throws UnableToSendOrderException {
-        var partnerMetadata =
-                new PartnerMetadata(
-                        submissionId, "senderName", "receiverName", Instant.now(), "abcd");
+
         try {
-            partnerMetadataStorage.saveMetadata(partnerMetadata);
+            savePartnerMetadata(submissionId);
         } catch (PartnerMetadataException e) {
-            throw new UnableToSendOrderException("Unable to save metadata for the order", e);
+            logger.logError("Unable to save metadata for submissionId " + submissionId, e);
         }
 
         var omlOrder = converter.convertMetadataToOmlOrder(order);
@@ -38,5 +38,16 @@ public class SendOrderUseCase {
         omlOrder = converter.addContactSectionToPatientResource(omlOrder);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.CONTACT_SECTION_ADDED_TO_PATIENT);
         sender.sendOrder(omlOrder);
+    }
+
+    private void savePartnerMetadata(String submissionId) throws PartnerMetadataException {
+        if (submissionId == null) {
+            return;
+        }
+
+        PartnerMetadata partnerMetadata =
+                new PartnerMetadata(
+                        submissionId, "senderName", "receiverName", Instant.now(), "abcd");
+        partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -157,6 +157,9 @@ class EtorDomainRegistrationTest extends Specification {
         given:
         def expectedStatusCode = 200
 
+        def request = new DomainRequest()
+        request.headers["RecordId"] = "recordId"
+
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
 
@@ -176,7 +179,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def res = connector.handleOrders(new DomainRequest())
+        def res = connector.handleOrders(request)
         def actualStatusCode = res.statusCode
 
         then:
@@ -187,6 +190,9 @@ class EtorDomainRegistrationTest extends Specification {
         given:
         def expectedStatusCode = 400
 
+        def request = new DomainRequest()
+        request.headers["RecordId"] = "recordId"
+
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
 
@@ -195,7 +201,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.register(OrderController, mockController)
 
         def mockUseCase = Mock(SendOrderUseCase)
-        mockUseCase.convertAndSend(_ as Order<?>) >> {
+        mockUseCase.convertAndSend(_ as Order<?>, _ as String) >> {
             throw new UnableToSendOrderException("error", new NullPointerException())
         }
         TestApplicationContext.register(SendOrderUseCase, mockUseCase)
@@ -207,7 +213,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def res = domainRegistration.handleOrders(new DomainRequest())
+        def res = domainRegistration.handleOrders(request)
         def actualStatusCode = res.statusCode
 
         then:
@@ -217,6 +223,9 @@ class EtorDomainRegistrationTest extends Specification {
     def "handleOrders returns a 400 response when the request is not parseable"() {
         given:
         def expectedStatusCode = 400
+
+        def request = new DomainRequest()
+        request.headers["RecordId"] = "recordId"
 
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
@@ -232,7 +241,7 @@ class EtorDomainRegistrationTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def res = domainRegistration.handleOrders(new DomainRequest())
+        def res = domainRegistration.handleOrders(request)
         def actualStatusCode = res.statusCode
 
         then:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -28,7 +28,7 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendOrderUseCase.getInstance().convertAndSend(mockOrder)
+        SendOrderUseCase.getInstance().convertAndSend(mockOrder, _ as String)
 
         then:
         1 * mockConverter.convertMetadataToOmlOrder(mockOrder)
@@ -42,7 +42,7 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendOrderUseCase.getInstance().convertAndSend(new OrderMock(null, null, null))
+        SendOrderUseCase.getInstance().convertAndSend(new OrderMock(null, null, null), _ as String)
 
         then:
         1 * SendOrderUseCase.getInstance().metadata.put(_, EtorMetadataStep.ORDER_CONVERTED_TO_OML)
@@ -55,7 +55,7 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendOrderUseCase.getInstance().convertAndSend(new OrderMock(null, null, null))
+        SendOrderUseCase.getInstance().convertAndSend(new OrderMock(null, null, null), _ as String)
 
         then:
         1 * SendOrderUseCase.getInstance().metadata.put(_, EtorMetadataStep.CONTACT_SECTION_ADDED_TO_PATIENT)
@@ -73,7 +73,7 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendOrderUseCase.getInstance().convertAndSend(mockOrder)
+        SendOrderUseCase.getInstance().convertAndSend(mockOrder, _ as String)
 
         then:
         thrown(UnableToSendOrderException)


### PR DESCRIPTION
# Use ReportId to identify metadata for testing purposes

While waiting for [this ReportStream ticket](https://github.com/CDCgov/prime-reportstream/issues/12624) in order to get a submission id, we'll temporarily use the `RecordId` as a placeholder to work on testing

## Issue

#672 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required

