### PR TITLE
Update FilePartnerMetadataStorage to use app path instead of temp path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,3 @@ ig/template
 
 __pycache__
 localfileorder.json
-
-tools/

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ build
 # Ignore VSCode Extension Pack for Java output
 bin
 
-# Ignore data directory
-data
-
 # Ignore environment file
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ build
 # Ignore VSCode Extension Pack for Java output
 bin
 
+# Ignore data directory
+data
+
 # Ignore environment file
 .env
 
@@ -35,3 +38,5 @@ ig/template
 
 __pycache__
 localfileorder.json
+
+tools/

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -10,8 +10,7 @@ import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.Paths;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -23,14 +22,13 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     @Inject Formatter formatter;
     @Inject Logger logger;
 
-    private static final Path metadataTempDirectory;
+    private static final Path metadataDirectory;
 
     static {
         try {
-            FileAttribute<?> onlyOwnerAttrs =
-                    PosixFilePermissions.asFileAttribute(
-                            PosixFilePermissions.fromString("rwx------"));
-            metadataTempDirectory = Files.createTempDirectory("metadata", onlyOwnerAttrs);
+            Path projectRoot = Paths.get(System.getProperty("user.dir"));
+            metadataDirectory = projectRoot.getParent().resolve("data/metadata");
+            Files.createDirectories(metadataDirectory);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -73,7 +71,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
         }
     }
 
-    private Path getFilePath(String uniqueId) {
-        return metadataTempDirectory.resolve(uniqueId + ".json");
+    private Path getFilePath(String metadataId) {
+        return metadataDirectory.resolve(metadataId + ".json");
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -26,9 +28,12 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
 
     static {
         try {
-            Path projectRoot = Paths.get(System.getProperty("user.dir"));
-            metadataDirectory = projectRoot.getParent().resolve("data/metadata");
-            Files.createDirectories(metadataDirectory);
+            Path projectRoot = Paths.get(System.getProperty("java.io.tmpdir"));
+            metadataDirectory = projectRoot.resolve("cdctimetadata");
+            FileAttribute<?> onlyOwnerAttrs =
+                    PosixFilePermissions.asFileAttribute(
+                            PosixFilePermissions.fromString("rwx------"));
+            Files.createDirectories(metadataDirectory, onlyOwnerAttrs);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -24,16 +24,16 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     @Inject Formatter formatter;
     @Inject Logger logger;
 
-    private static final Path metadataDirectory;
+    private static final Path METADATA_DIRECTORY;
 
     static {
         try {
-            Path projectRoot = Paths.get(System.getProperty("java.io.tmpdir"));
-            metadataDirectory = projectRoot.resolve("cdctimetadata");
+            Path userTempPath = Paths.get(System.getProperty("java.io.tmpdir"));
+            METADATA_DIRECTORY = userTempPath.resolve("cdctimetadata");
             FileAttribute<?> onlyOwnerAttrs =
                     PosixFilePermissions.asFileAttribute(
                             PosixFilePermissions.fromString("rwx------"));
-            Files.createDirectories(metadataDirectory, onlyOwnerAttrs);
+            Files.createDirectories(METADATA_DIRECTORY, onlyOwnerAttrs);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -77,6 +77,6 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     }
 
     private Path getFilePath(String metadataId) {
-        return metadataDirectory.resolve(metadataId + ".json");
+        return METADATA_DIRECTORY.resolve(metadataId + ".json");
     }
 }


### PR DESCRIPTION
# Update FilePartnerMetadataStorage to use app path instead of temp path

Changed because we need better persistence of the metadata file 

## Issue

#672 
