### PR TITLE
Downgrade Apache HTTP Client and Renovate Stops Updating to 5.3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
                 "org.apache.httpcomponents.client5:httpclient5",
                 "org.apache.httpcomponents.client5:httpclient5-fluent"
             ],
-            "allowedVersions": "!/^5.3$/"
+            "allowedVersions": "!/^5\\.3$/"
         }],
     "pinDigests": false
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,13 @@
         {
             "matchPackageNames": ["amazoncorretto"],
             "allowedVersions": "/17.*/"
-        }
-    ],
+        },
+        {
+            "matchPackageNames": [
+                "org.apache.httpcomponents.client5:httpclient5",
+                "org.apache.httpcomponents.client5:httpclient5-fluent"
+            ],
+            "allowedVersions": "!/^5.3$/"
+        }],
     "pinDigests": false
 }

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -11,8 +11,8 @@ java {
 
 dependencies {
     //client
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.3'
 
     //jackson
     implementation 'com.fasterxml.jackson.core:jackson-core:2.16.0'

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     api 'org.fhir:ucum:1.0.8'
 
     // Apache Client
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.3'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.2.3'
 
     // jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'


### PR DESCRIPTION
# Downgrade Apache HTTP Client and Renovate Stops Updating to 5.3

- Downgraded our Apache HTTP client back to version 5.2.3.
- Told Renovate to ignore version 5.3.

## Issue

#723.
See [this comment](https://github.com/CDCgov/trusted-intermediary/issues/723#issuecomment-1861251376) for additional insight into the bug.
