### PR TITLE
672: Parter Metadata Orchestrator Skeleton

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -56,7 +56,7 @@ public class EtorDomainRegistration implements DomainConnector {
     @Inject SendOrderUseCase sendOrderUseCase;
     @Inject Logger logger;
     @Inject DomainResponseHelper domainResponseHelper;
-    @Inject PartnerMetadataStorage partnerMetadataStorage;
+    @Inject PartnerMetadataOrchestrator partnerMetadataOrchestrator;
     @Inject Formatter formatter;
 
     private final Map<HttpEndpoint, Function<DomainRequest, DomainResponse>> endpoints =
@@ -153,7 +153,8 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleMetadata(DomainRequest request) {
         try {
             String metadataId = request.getPathParams().get("id");
-            Optional<PartnerMetadata> metadata = partnerMetadataStorage.readMetadata(metadataId);
+            Optional<PartnerMetadata> metadata =
+                    partnerMetadataOrchestrator.getMetadata(metadataId);
 
             if (metadata.isEmpty()) {
                 return domainResponseHelper.constructErrorResponse(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -13,6 +13,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsCont
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResponse;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataOrchestrator;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController;
@@ -75,6 +76,8 @@ public class EtorDomainRegistration implements DomainConnector {
         ApplicationContext.register(OrderConverter.class, HapiOrderConverter.getInstance());
         ApplicationContext.register(OrderController.class, OrderController.getInstance());
         ApplicationContext.register(SendOrderUseCase.class, SendOrderUseCase.getInstance());
+        ApplicationContext.register(
+                PartnerMetadataOrchestrator.class, PartnerMetadataOrchestrator.getInstance());
 
         if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
             ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -37,6 +37,8 @@ public class PartnerMetadataOrchestrator {
             throws PartnerMetadataException {
         // call the metadata storage and add the sent order's submission ID to the existing metadata
         // entry
+        // PartnerMetadata may need to be updated to store both the received order's submission ID
+        // _and_ the sent order's submission ID.
     }
 
     public Optional<PartnerMetadata> getMetadata(String submissionId)

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -1,10 +1,14 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
+import java.time.Instant;
+import javax.inject.Inject;
 
 public class PartnerMetadataOrchestrator {
 
     private static final PartnerMetadataOrchestrator INSTANCE = new PartnerMetadataOrchestrator();
+
+    @Inject PartnerMetadataStorage partnerMetadataStorage;
 
     public static PartnerMetadataOrchestrator getInstance() {
         return INSTANCE;
@@ -12,22 +16,29 @@ public class PartnerMetadataOrchestrator {
 
     private PartnerMetadataOrchestrator() {}
 
-    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order) {
+    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order)
+            throws PartnerMetadataException {
         // will call the RS history API given the submissionId (albeit, right now this won't work
         // given the way RS works).
         // from the history API response, extract the sender (organization + sender client), and
         // time received.
         // we will calculate the hash.
         // then we call the metadata storage to save this stuff.
+
+        PartnerMetadata partnerMetadata =
+                new PartnerMetadata(
+                        submissionId, "senderName", "receiverName", Instant.now(), "abcd");
+        partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
     public void updateMetadataForSentOrder(
-            String receivedSubmissionId, String sentSubmissionId, Order<?> order) {
+            String receivedSubmissionId, String sentSubmissionId, Order<?> order)
+            throws PartnerMetadataException {
         // call the metadata storage and add the sent order's submission ID to the existing metadata
         // entry
     }
 
-    public PartnerMetadata getMetadata(String submissionId) {
+    public PartnerMetadata getMetadata(String submissionId) throws PartnerMetadataException {
         // call the metadata storage to get the metadata.
         // check if the receiver is filled out, and if it isn't, call the RS history API to get the
         // receiver.

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import java.time.Instant;
+import java.util.Optional;
 import javax.inject.Inject;
 
 public class PartnerMetadataOrchestrator {
@@ -38,13 +39,14 @@ public class PartnerMetadataOrchestrator {
         // entry
     }
 
-    public PartnerMetadata getMetadata(String submissionId) throws PartnerMetadataException {
+    public Optional<PartnerMetadata> getMetadata(String submissionId)
+            throws PartnerMetadataException {
         // call the metadata storage to get the metadata.
         // check if the receiver is filled out, and if it isn't, call the RS history API to get the
         // receiver.
         // if had to call the history API, extract the receiver and call the metadata storage to
         // save the metadata with the receiver added.
         // return the metadata.
-        return null;
+        return partnerMetadataStorage.readMetadata(submissionId);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -5,6 +5,11 @@ import java.time.Instant;
 import java.util.Optional;
 import javax.inject.Inject;
 
+/**
+ * The PartnerMetadataOrchestrator class is responsible for updating and retrieving partner-facing
+ * metadata. It interacts with the metadata storage and the history API to create, update, and store
+ * metadata.
+ */
 public class PartnerMetadataOrchestrator {
 
     private static final PartnerMetadataOrchestrator INSTANCE = new PartnerMetadataOrchestrator();

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -12,12 +12,28 @@ public class PartnerMetadataOrchestrator {
 
     private PartnerMetadataOrchestrator() {}
 
-    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order) {}
+    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order) {
+        // will call the RS history API given the submissionId (albeit, right now this won't work
+        // given the way RS works).
+        // from the history API response, extract the sender (organization + sender client), and
+        // time received.
+        // we will calculate the hash.
+        // then we call the metadata storage to save this stuff.
+    }
 
     public void updateMetadataForSentOrder(
-            String receivedSubmissionId, String sentSubmissionId, Order<?> order) {}
+            String receivedSubmissionId, String sentSubmissionId, Order<?> order) {
+        // call the metadata storage and add the sent order's submission ID to the existing metadata
+        // entry
+    }
 
     public PartnerMetadata getMetadata(String submissionId) {
+        // call the metadata storage to get the metadata.
+        // check if the receiver is filled out, and if it isn't, call the RS history API to get the
+        // receiver.
+        // if had to call the history API, extract the receiver and call the metadata storage to
+        // save the metadata with the receiver added.
+        // return the metadata.
         return null;
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -1,0 +1,23 @@
+package gov.hhs.cdc.trustedintermediary.etor.metadata;
+
+import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
+
+public class PartnerMetadataOrchestrator {
+
+    private static final PartnerMetadataOrchestrator INSTANCE = new PartnerMetadataOrchestrator();
+
+    public static PartnerMetadataOrchestrator getInstance() {
+        return INSTANCE;
+    }
+
+    private PartnerMetadataOrchestrator() {}
+
+    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order) {}
+
+    public void updateMetadataForSentOrder(
+            String receivedSubmissionId, String sentSubmissionId, Order<?> order) {}
+
+    public PartnerMetadata getMetadata(String submissionId) {
+        return null;
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -33,7 +33,10 @@ public class SendOrderUseCase {
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.CONTACT_SECTION_ADDED_TO_PATIENT);
         sender.sendOrder(omlOrder);
 
-        saveSentOrderSubmissionId(submissionId, "DogCow", order);
+        saveSentOrderSubmissionId(
+                submissionId,
+                "TBD, need to be filled in from the sender.sendOrder(omlOrder) call",
+                order);
     }
 
     private void savePartnerMetadataForReceivedOrder(String submissionId, final Order<?> order) {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -13,7 +13,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsCont
 import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResponse
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
-import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataOrchestrator
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderResponse
@@ -321,9 +321,9 @@ class EtorDomainRegistrationTest extends Specification {
         def request = new DomainRequest()
         request.setPathParams(["id": "metadataId"])
 
-        def mockPartnerMetadataStorage = Mock(PartnerMetadataStorage)
-        mockPartnerMetadataStorage.readMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataId", "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd"))
-        TestApplicationContext.register(PartnerMetadataStorage, mockPartnerMetadataStorage)
+        def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataId", "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd"))
+        TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)
         mockResponseHelper.constructOkResponse(_ as String) >> new DomainResponse(expectedStatusCode)
@@ -350,9 +350,9 @@ class EtorDomainRegistrationTest extends Specification {
         def request = new DomainRequest()
         request.setPathParams(["id": "metadataId"])
 
-        def mockPartnerMetadataStorage = Mock(PartnerMetadataStorage)
-        mockPartnerMetadataStorage.readMetadata(_ as String) >> Optional.empty()
-        TestApplicationContext.register(PartnerMetadataStorage, mockPartnerMetadataStorage)
+        def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.empty()
+        TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)
         mockResponseHelper.constructErrorResponse(expectedStatusCode, _ as String) >> new DomainResponse(expectedStatusCode)
@@ -378,9 +378,9 @@ class EtorDomainRegistrationTest extends Specification {
         def request = new DomainRequest()
         request.setPathParams(["id": "metadataId"])
 
-        def mockPartnerMetadataStorage = Mock(PartnerMetadataStorage)
-        mockPartnerMetadataStorage.readMetadata(_ as String) >> { throw new PartnerMetadataException("DogCow", new Exception()) }
-        TestApplicationContext.register(PartnerMetadataStorage, mockPartnerMetadataStorage)
+        def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> { throw new PartnerMetadataException("DogCow", new Exception()) }
+        TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)
         mockResponseHelper.constructErrorResponse(expectedStatusCode, _ as String) >> new DomainResponse(expectedStatusCode)
@@ -406,9 +406,9 @@ class EtorDomainRegistrationTest extends Specification {
         def request = new DomainRequest()
         request.setPathParams(["id": "metadataId"])
 
-        def mockPartnerMetadataStorage = Mock(PartnerMetadataStorage)
-        mockPartnerMetadataStorage.readMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataUniqueId", "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd"))
-        TestApplicationContext.register(PartnerMetadataStorage, mockPartnerMetadataStorage)
+        def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataUniqueId", "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd"))
+        TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> { throw new FormatterProcessingException("DogCow", new Exception()) }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -3,7 +3,7 @@ package gov.hhs.cdc.trustedintermediary.etor.orders
 import gov.hhs.cdc.trustedintermediary.OrderMock
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep
-import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage
+import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataOrchestrator
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
 import spock.lang.Specification
 
@@ -14,7 +14,7 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.init()
         TestApplicationContext.register(SendOrderUseCase, SendOrderUseCase.getInstance())
         TestApplicationContext.register(MetricMetadata, Mock(MetricMetadata))
-        TestApplicationContext.register(PartnerMetadataStorage, Mock(PartnerMetadataStorage))
+        TestApplicationContext.register(PartnerMetadataOrchestrator, Mock(PartnerMetadataOrchestrator))
     }
 
     def "send sends successfully"() {


### PR DESCRIPTION
# Parter Metadata Orchestrator Skeleton

I've created a skeleton for the orchestration of calling the RS history API and our storage implementation to populate, save, and retrieve the partner metadata.

## Issue

#672.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
