### PR TITLE
Refactor setHeaders to make non case-sensitive

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/auth/AuthRequestValidator.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/auth/AuthRequestValidator.java
@@ -67,7 +67,7 @@ public class AuthRequestValidator {
 
     protected String extractToken(DomainRequest request) {
         logger.logDebug("Extracting token from request...");
-        var authHeader = Optional.ofNullable(request.getHeaders().get("Authorization")).orElse("");
+        var authHeader = Optional.ofNullable(request.getHeaders().get("authorization")).orElse("");
         return authHeader.replace("Bearer ", "");
     }
 

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistration.java
@@ -18,8 +18,10 @@ import io.javalin.http.HandlerType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Registers the available domains to the application context and their specific handlers for the
@@ -170,10 +172,17 @@ public class DomainsRegistration {
 
     static DomainRequest javalinContextToDomainRequest(Context ctx) {
         var request = new DomainRequest();
+        var caseInsensitiveHeaderMap =
+                ctx.headerMap().entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        entry -> entry.getKey().toLowerCase(),
+                                        Map.Entry::getValue,
+                                        (oldValue, newValue) -> newValue));
 
         request.setBody(ctx.body());
         request.setUrl(ctx.url());
-        request.setHeaders(ctx.headerMap());
+        request.setHeaders(caseInsensitiveHeaderMap);
         request.setPathParams(ctx.pathParamMap());
 
         return request;

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistration.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistration.java
@@ -177,8 +177,7 @@ public class DomainsRegistration {
                         .collect(
                                 Collectors.toMap(
                                         entry -> entry.getKey().toLowerCase(),
-                                        Map.Entry::getValue,
-                                        (oldValue, newValue) -> newValue));
+                                        Map.Entry::getValue));
 
         request.setBody(ctx.body());
         request.setUrl(ctx.url());

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistrationTest.groovy
@@ -38,7 +38,7 @@ class DomainsRegistrationTest extends Specification {
         def bodyString = "DogCow"
         def urlString = "Moof"
         def headerMap = [
-            "Clarus": "is a DogCow"
+            "clarus": "is a DogCow"
         ]
 
         def javalinContext = Mock(Context)
@@ -321,6 +321,27 @@ class DomainsRegistrationTest extends Specification {
             handler.handle(context)
         }
         contentType == "application/x-yaml"
+    }
+
+    def "javalinContextToDomainRequest transforms ctx.headerMap so the keys are always lowercase"() {
+        given:
+        def headerMap = [
+            "testkey1": "testvalue1",
+            "TestKey2": "testvalue2",
+            "TESTKEY3": "testvalue3",
+        ]
+
+        def javalinContext = Mock(Context)
+        javalinContext.headerMap() >> headerMap
+
+        when:
+        def domainRequest = DomainsRegistration.javalinContextToDomainRequest(javalinContext)
+        def transformedHeaderMap = domainRequest.getHeaders()
+
+        then:
+        transformedHeaderMap.get("testkey1") == "testvalue1"
+        transformedHeaderMap.get("testkey2") == "testvalue2"
+        transformedHeaderMap.get("testkey3") == "testvalue3"
     }
 
     static class Example1DomainConnector implements DomainConnector {

--- a/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistrationTest.groovy
+++ b/app/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/javalin/DomainsRegistrationTest.groovy
@@ -101,6 +101,7 @@ class DomainsRegistrationTest extends Specification {
         }
         def javalinContext = Mock(Context)
         javalinContext.method() >> HandlerType.POST
+        javalinContext.headerMap() >> [:]
 
         when:
         def javalinHandler = DomainsRegistration.createHandler(rawHandler, false)
@@ -242,6 +243,7 @@ class DomainsRegistrationTest extends Specification {
 
         def mockContext = Mock(Context)
         mockContext.method() >> HandlerType.POST
+        mockContext.headerMap() >> [:]
 
         def mockAuthValidator = Mock(AuthRequestValidator)
         mockAuthValidator.isValidAuthenticatedRequest(_ as DomainRequest) >> false

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -123,7 +123,7 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleOrders(DomainRequest request) {
         Order<?> orders;
 
-        String submissionId = request.getHeaders().get("RecordId");
+        String submissionId = request.getHeaders().get("recordid");
         if (submissionId == null || submissionId.isEmpty()) {
             submissionId = null;
             logger.logError("Missing required header or empty: RecordId");

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -158,7 +158,7 @@ class EtorDomainRegistrationTest extends Specification {
         def expectedStatusCode = 200
 
         def request = new DomainRequest()
-        request.headers["RecordId"] = "recordId"
+        request.headers["recordid"] = "recordId"
 
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
@@ -191,7 +191,7 @@ class EtorDomainRegistrationTest extends Specification {
         def expectedStatusCode = 400
 
         def request = new DomainRequest()
-        request.headers["RecordId"] = "recordId"
+        request.headers["recordid"] = "recordId"
 
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
@@ -225,7 +225,7 @@ class EtorDomainRegistrationTest extends Specification {
         def expectedStatusCode = 400
 
         def request = new DomainRequest()
-        request.headers["RecordId"] = "recordId"
+        request.headers["recordid"] = "recordId"
 
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
@@ -252,7 +252,7 @@ class EtorDomainRegistrationTest extends Specification {
         given:
 
         def request = new DomainRequest()
-        request.headers["RecordId"] = null  //no metadata unique ID
+        request.headers["recordid"] = null  //no metadata unique ID
 
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)
@@ -283,7 +283,7 @@ class EtorDomainRegistrationTest extends Specification {
     def "handleOrders logs an error and continues the usecase like normal when the metadata unique ID is empty because we want to know when our integration with RS is broken"() {
         given:
         def request = new DomainRequest()
-        request.headers["RecordId"] = ""  // empty metadata unique ID
+        request.headers["recordid"] = ""  // empty metadata unique ID
 
         def domainRegistration = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, domainRegistration)

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -60,18 +60,20 @@ class SampleUser(FastHttpUser):
 
     @task(5)
     def post_v1_etor_orders(self):
-        headers={"Authorization": self.access_token, "RecordId": self.submission_id},
         self.client.post(
             ORDERS_ENDPOINT,
-            headers,
+            headers={
+                "Authorization": self.access_token,
+                "RecordId": self.submission_id,
+            },
             data=order_request_body,
         )
 
     @task(5)
     def get_v1_etor_metadata(self):
         self.client.get(
-        f"{METADATA_ENDPOINT}/{self.submission_id}",
-        headers={"Authorization": self.access_token},
+            f"{METADATA_ENDPOINT}/{self.submission_id}",
+            headers={"Authorization": self.access_token},
         )
 
 

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -11,6 +11,7 @@ HEALTH_ENDPOINT = "/health"
 AUTH_ENDPOINT = "/v1/auth/token"
 DEMOGRAPHICS_ENDPOINT = "/v1/etor/demographics"
 ORDERS_ENDPOINT = "/v1/etor/orders"
+METADATA_ENDPOINT = "/v1/etor/metadata"
 
 demographics_request_body = None
 order_request_body = None
@@ -63,6 +64,10 @@ class SampleUser(FastHttpUser):
             data=order_request_body,
             headers={"Authorization": self.access_token},
         )
+
+    @task(5)
+    def get_v1_etor_metadata(self):
+        self.client.get(METADATA_ENDPOINT,)
 
 
 @events.test_start.add_listener

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -11,7 +11,6 @@ HEALTH_ENDPOINT = "/health"
 AUTH_ENDPOINT = "/v1/auth/token"
 DEMOGRAPHICS_ENDPOINT = "/v1/etor/demographics"
 ORDERS_ENDPOINT = "/v1/etor/orders"
-METADATA_ENDPOINT = "/v1/etor/metadata"
 
 demographics_request_body = None
 order_request_body = None
@@ -25,7 +24,6 @@ class SampleUser(FastHttpUser):
 
     token_refresh_interval = 280
     access_token = None
-    submission_id = "1a2b3c"
 
     def on_start(self):
         self.authenticate()
@@ -62,17 +60,7 @@ class SampleUser(FastHttpUser):
     def post_v1_etor_orders(self):
         self.client.post(
             ORDERS_ENDPOINT,
-            headers={
-                "Authorization": self.access_token,
-                "RecordId": self.submission_id,
-            },
             data=order_request_body,
-        )
-
-    @task(5)
-    def get_v1_etor_metadata(self):
-        self.client.get(
-            f"{METADATA_ENDPOINT}/{self.submission_id}",
             headers={"Authorization": self.access_token},
         )
 

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -25,6 +25,7 @@ class SampleUser(FastHttpUser):
 
     token_refresh_interval = 280
     access_token = None
+    submission_id = "1a2b3c"
 
     def on_start(self):
         self.authenticate()
@@ -59,15 +60,19 @@ class SampleUser(FastHttpUser):
 
     @task(5)
     def post_v1_etor_orders(self):
+        headers={"Authorization": self.access_token, "RecordId": self.submission_id},
         self.client.post(
             ORDERS_ENDPOINT,
+            headers,
             data=order_request_body,
-            headers={"Authorization": self.access_token},
         )
 
     @task(5)
     def get_v1_etor_metadata(self):
-        self.client.get(METADATA_ENDPOINT,)
+        self.client.get(
+        f"{METADATA_ENDPOINT}/{self.submission_id}",
+        headers={"Authorization": self.access_token},
+        )
 
 
 @events.test_start.add_listener

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/domainconnector/DomainRequest.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/domainconnector/DomainRequest.java
@@ -26,6 +26,12 @@ public class DomainRequest {
         this.url = url;
     }
 
+    /**
+     * Returns the headers for the request. Please note that the keys (header names) are always
+     * lowercase.
+     *
+     * @return the headers Map for this request, with lowercase keys
+     */
     public Map<String, String> getHeaders() {
         return headers;
     }


### PR DESCRIPTION
# Refactor setHeaders to make non case-sensitive

The implementation to get headers we're using from Javalin is case-sensitive, while HTTP headers are non case-sensitive. We decided to transform the header names to lowercase while setting them to avoid this issue

## Issue

#672 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added JavaDocs where required
