### PR TITLE
Call the history API for outbound orders

### DIFF
--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
@@ -33,7 +33,7 @@ class MetadataTest extends Specification {
 
         then:
         metadataResponse.getCode() == expectedStatusCode
-        parsedJsonBody.uniqueId == submissionId
+        parsedJsonBody.receivedSubmissionId == submissionId
     }
 
     def "a 404 is returned when there is no metadata for a given ID"() {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -129,15 +129,15 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleOrders(DomainRequest request) {
         Order<?> orders;
 
-        String submissionId = request.getHeaders().get("recordid");
-        if (submissionId == null || submissionId.isEmpty()) {
-            submissionId = null;
+        String receivedSubmissionId = request.getHeaders().get("recordid");
+        if (receivedSubmissionId == null || receivedSubmissionId.isEmpty()) {
+            receivedSubmissionId = null;
             logger.logError("Missing required header or empty: RecordId");
         }
 
         try {
             orders = orderController.parseOrders(request);
-            sendOrderUseCase.convertAndSend(orders, submissionId);
+            sendOrderUseCase.convertAndSend(orders, receivedSubmissionId);
         } catch (FhirParseException e) {
             logger.logError("Unable to parse order request", e);
             return domainResponseHelper.constructErrorResponse(400, e);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -75,6 +75,8 @@ public class EtorDomainRegistration implements DomainConnector {
         ApplicationContext.register(SendOrderUseCase.class, SendOrderUseCase.getInstance());
         ApplicationContext.register(
                 PartnerMetadataOrchestrator.class, PartnerMetadataOrchestrator.getInstance());
+        ApplicationContext.register(
+                ReportStreamEndpointClient.class, ReportStreamEndpointClient.getInstance());
 
         if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
             ApplicationContext.register(OrderSender.class, LocalFileOrderSender.getInstance());

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -27,6 +27,7 @@ import gov.hhs.cdc.trustedintermediary.external.azure.AzureStorageAccountPartner
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiOrderConverter;
 import gov.hhs.cdc.trustedintermediary.external.localfile.FilePartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalFileOrderSender;
+import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamOrderSender;
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -19,7 +19,19 @@ public record PartnerMetadata(
         String receiver,
         Instant timeReceived,
         String hash) {
-    public PartnerMetadata(String receivedSubmissionId) {
-        this(receivedSubmissionId, null, null, null, null, null);
+
+    public PartnerMetadata(
+            String receivedSubmissionId, String sender, Instant timeReceived, String hash) {
+        this(receivedSubmissionId, null, sender, null, timeReceived, hash);
+    }
+
+    public PartnerMetadata withSentSubmissionFields(String sentSubmissionId, String receiver) {
+        return new PartnerMetadata(
+                this.receivedSubmissionId,
+                sentSubmissionId,
+                this.sender,
+                receiver,
+                this.timeReceived,
+                this.hash);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -5,11 +5,21 @@ import java.time.Instant;
 /**
  * The partner-facing metadata.
  *
- * @param uniqueId The unique ID that identifies this specific metadata.
+ * @param receivedSubmissionId The received submission ID.
+ * @param sentSubmissionId The sent submission ID.
  * @param sender The name of the sender of the message.
  * @param receiver The name of the receiver of the message.
  * @param timeReceived The time the message was received.
  * @param hash The hash of the message.
  */
 public record PartnerMetadata(
-        String uniqueId, String sender, String receiver, Instant timeReceived, String hash) {}
+        String receivedSubmissionId,
+        String sentSubmissionId,
+        String sender,
+        String receiver,
+        Instant timeReceived,
+        String hash) {
+    public PartnerMetadata(String receivedSubmissionId) {
+        this(receivedSubmissionId, null, null, null, null, null);
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -25,10 +25,20 @@ public record PartnerMetadata(
         this(receivedSubmissionId, null, sender, null, timeReceived, hash);
     }
 
-    public PartnerMetadata withSentSubmissionFields(String sentSubmissionId, String receiver) {
+    public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 sentSubmissionId,
+                this.sender,
+                this.receiver,
+                this.timeReceived,
+                this.hash);
+    }
+
+    public PartnerMetadata withReceiver(String receiver) {
+        return new PartnerMetadata(
+                this.receivedSubmissionId,
+                this.sentSubmissionId,
                 this.sender,
                 receiver,
                 this.timeReceived,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -22,8 +22,8 @@ public class PartnerMetadataOrchestrator {
     private static final PartnerMetadataOrchestrator INSTANCE = new PartnerMetadataOrchestrator();
 
     @Inject PartnerMetadataStorage partnerMetadataStorage;
-    @Inject private ReportStreamEndpointClient rsclient;
-    @Inject private Formatter formatter;
+    @Inject ReportStreamEndpointClient rsclient;
+    @Inject Formatter formatter;
 
     public static PartnerMetadataOrchestrator getInstance() {
         return INSTANCE;
@@ -47,8 +47,7 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
-    public void updateMetadataForSentOrder(
-            String receivedSubmissionId, String sentSubmissionId, Order<?> order)
+    public void updateMetadataForSentOrder(String receivedSubmissionId, String sentSubmissionId)
             throws PartnerMetadataException {
 
         String receiver;
@@ -78,7 +77,7 @@ public class PartnerMetadataOrchestrator {
         return partnerMetadataStorage.readMetadata(submissionId);
     }
 
-    private String getReceiverName(String clientResponse) throws FormatterProcessingException {
+    String getReceiverName(String clientResponse) throws FormatterProcessingException {
         Map<String, Object> responseObject =
                 formatter.convertJsonToObject(clientResponse, new TypeReference<>() {});
         Object destinationsObj = responseObject.get("destinations");

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -31,7 +31,7 @@ public class PartnerMetadataOrchestrator {
 
     private PartnerMetadataOrchestrator() {}
 
-    public void updateMetadataForReceivedOrder(String submissionId, Order<?> order)
+    public void updateMetadataForReceivedOrder(String receivedSubmissionId, Order<?> order)
             throws PartnerMetadataException {
         // will call the RS history API given the submissionId, currently blocked by:
         // https://github.com/CDCgov/prime-reportstream/issues/12624
@@ -43,7 +43,7 @@ public class PartnerMetadataOrchestrator {
         Instant timeReceived = Instant.now();
         String hash = String.valueOf(order.hashCode());
         PartnerMetadata partnerMetadata =
-                new PartnerMetadata(submissionId, sender, timeReceived, hash);
+                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
@@ -66,7 +66,7 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
-    public Optional<PartnerMetadata> getMetadata(String submissionId)
+    public Optional<PartnerMetadata> getMetadata(String receivedSubmissionId)
             throws PartnerMetadataException {
         // call the metadata storage to get the metadata.
         // check if the receiver is filled out, and if it isn't, call the RS history API to get the
@@ -74,12 +74,12 @@ public class PartnerMetadataOrchestrator {
         // if had to call the history API, extract the receiver and call the metadata storage to
         // save the metadata with the receiver added.
         // return the metadata.
-        return partnerMetadataStorage.readMetadata(submissionId);
+        return partnerMetadataStorage.readMetadata(receivedSubmissionId);
     }
 
-    String getReceiverName(String clientResponse) throws FormatterProcessingException {
+    String getReceiverName(String responseBody) throws FormatterProcessingException {
         Map<String, Object> responseObject =
-                formatter.convertJsonToObject(clientResponse, new TypeReference<>() {});
+                formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
         Object destinationsObj = responseObject.get("destinations");
         if (!(destinationsObj instanceof ArrayList<?> destinationsList)) {
             throw new FormatterProcessingException(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -83,6 +83,20 @@ public class PartnerMetadataOrchestrator {
     }
 
     String getReceiverName(String responseBody) throws FormatterProcessingException {
+        // Before we can get the organization_id and service from the response,
+        // we need to validate that the response has the correct structure
+        // the expected json structure is:
+        // {
+        //    ...
+        //    "destinations" : [ {
+        //        ...
+        //        "organization_id" : "flexion",
+        //        "service" : "simulated-lab",
+        //        ...
+        //    } ],
+        //    ...
+        // }
+
         Map<String, Object> responseObject =
                 formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
         Object destinationsObj = responseObject.get("destinations");
@@ -97,8 +111,8 @@ public class PartnerMetadataOrchestrator {
                     "First item in destinations is not a Map", new Exception());
         }
 
-        var organizationId = destination.get("organization_id");
-        var service = destination.get("service");
+        String organizationId = destination.get("organization_id").toString();
+        String service = destination.get("service").toString();
 
         if (organizationId == null || service == null) {
             throw new FormatterProcessingException(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -52,7 +52,8 @@ public class PartnerMetadataOrchestrator {
 
         PartnerMetadata partnerMetadata =
                 partnerMetadataStorage.readMetadata(receivedSubmissionId).orElseThrow();
-        if (!sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
+        if (sentSubmissionId != null
+                && !sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
             partnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId);
             partnerMetadataStorage.saveMetadata(partnerMetadata);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -51,8 +51,6 @@ public class PartnerMetadataOrchestrator {
         try {
             String bearerToken = rsclient.getRsToken();
             String responseBody = rsclient.requestHistoryEndpoint(sentSubmissionId, bearerToken);
-            Map<String, Object> responseObject =
-                    formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
             receiver = getReceiverName(responseBody);
         } catch (ReportStreamEndpointClientException | FormatterProcessingException e) {
             throw new PartnerMetadataException(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -9,7 +9,6 @@ import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -53,7 +52,7 @@ public class PartnerMetadataOrchestrator {
 
         PartnerMetadata partnerMetadata =
                 partnerMetadataStorage.readMetadata(receivedSubmissionId).orElseThrow();
-        if (!Objects.equals(partnerMetadata.sentSubmissionId(), sentSubmissionId)) {
+        if (!sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
             partnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId);
             partnerMetadataStorage.saveMetadata(partnerMetadata);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -6,6 +6,7 @@ import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpoin
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +39,11 @@ public class PartnerMetadataOrchestrator {
         // we will calculate the hash.
         // then we call the metadata storage to save this stuff.
 
-        PartnerMetadata partnerMetadata = new PartnerMetadata(submissionId);
+        String sender = "unknown";
+        Instant timeReceived = Instant.now();
+        String hash = String.valueOf(order.hashCode());
+        PartnerMetadata partnerMetadata =
+                new PartnerMetadata(submissionId, sender, timeReceived, hash);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
@@ -57,8 +62,8 @@ public class PartnerMetadataOrchestrator {
         }
 
         PartnerMetadata partnerMetadata =
-                new PartnerMetadata(
-                        receivedSubmissionId, sentSubmissionId, null, receiver, null, null);
+                partnerMetadataStorage.readMetadata(receivedSubmissionId).orElseThrow();
+        partnerMetadata = partnerMetadata.withSentSubmissionFields(sentSubmissionId, receiver);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
-import java.time.Instant;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -31,9 +30,7 @@ public class PartnerMetadataOrchestrator {
         // we will calculate the hash.
         // then we call the metadata storage to save this stuff.
 
-        PartnerMetadata partnerMetadata =
-                new PartnerMetadata(
-                        submissionId, "senderName", "receiverName", Instant.now(), "abcd");
+        PartnerMetadata partnerMetadata = new PartnerMetadata(submissionId);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -83,9 +83,7 @@ public class PartnerMetadataOrchestrator {
     }
 
     String getReceiverName(String responseBody) throws FormatterProcessingException {
-        // Before we can get the organization_id and service from the response,
-        // we need to validate that the response has the correct structure
-        // the expected json structure is:
+        // the expected json structure for the response is:
         // {
         //    ...
         //    "destinations" : [ {
@@ -97,26 +95,18 @@ public class PartnerMetadataOrchestrator {
         //    ...
         // }
 
-        Map<String, Object> responseObject =
-                formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
-        Object destinationsObj = responseObject.get("destinations");
-        if (!(destinationsObj instanceof ArrayList<?> destinationsList)) {
+        String organizationId;
+        String service;
+        try {
+            Map<String, Object> responseObject =
+                    formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
+            ArrayList<?> destinations = (ArrayList<?>) responseObject.get("destinations");
+            Map<?, ?> destination = (Map<?, ?>) destinations.get(0);
+            organizationId = destination.get("organization_id").toString();
+            service = destination.get("service").toString();
+        } catch (Exception e) {
             throw new FormatterProcessingException(
-                    "destinations is not an ArrayList", new Exception());
-        }
-
-        if (destinationsList.isEmpty()
-                || !(destinationsList.get(0) instanceof Map<?, ?> destination)) {
-            throw new FormatterProcessingException(
-                    "First item in destinations is not a Map", new Exception());
-        }
-
-        String organizationId = destination.get("organization_id").toString();
-        String service = destination.get("service").toString();
-
-        if (organizationId == null || service == null) {
-            throw new FormatterProcessingException(
-                    "organization_id or service is null", new Exception());
+                    "Unable to extract receiver name from response due to unexpected format", e);
         }
 
         return organizationId + "." + service;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -32,10 +32,9 @@ public class PartnerMetadataOrchestrator {
 
     public void updateMetadataForReceivedOrder(String submissionId, Order<?> order)
             throws PartnerMetadataException {
-        // will call the RS history API given the submissionId (albeit, right now this won't work
-        // given the way RS works).
-        // from the history API response, extract the sender (organization + sender client), and
-        // time received.
+        // will call the RS history API given the submissionId, currently blocked by:
+        // https://github.com/CDCgov/prime-reportstream/issues/12624
+        // from the response, extract the "sender" and "timestamp" (timeReceived)
         // we will calculate the hash.
         // then we call the metadata storage to save this stuff.
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -50,10 +50,13 @@ public class PartnerMetadataOrchestrator {
     public void updateMetadataForSentOrder(String receivedSubmissionId, String sentSubmissionId)
             throws PartnerMetadataException {
 
+        if (sentSubmissionId == null) {
+            return;
+        }
+
         PartnerMetadata partnerMetadata =
                 partnerMetadataStorage.readMetadata(receivedSubmissionId).orElseThrow();
-        if (sentSubmissionId != null
-                && !sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
+        if (!sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
             partnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId);
             partnerMetadataStorage.saveMetadata(partnerMetadata);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
@@ -8,10 +8,11 @@ public interface PartnerMetadataStorage {
     /**
      * This method will retrieve and return the metadata for the given submissionId, if it exists.
      *
-     * @param submissionId The submission Id to read the metadata for.
+     * @param receivedSubmissionId The submission Id to read the metadata for.
      * @return The metadata, if it exists. Otherwise, an empty Optional.
      */
-    Optional<PartnerMetadata> readMetadata(String submissionId) throws PartnerMetadataException;
+    Optional<PartnerMetadata> readMetadata(String receivedSubmissionId)
+            throws PartnerMetadataException;
 
     /**
      * This method will do "upserts". If the record doesn't exist, it is created. If the record

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataStorage.java
@@ -6,12 +6,12 @@ import java.util.Optional;
 public interface PartnerMetadataStorage {
 
     /**
-     * This method will retrieve and return the metadata for the given uniqueId, if it exists.
+     * This method will retrieve and return the metadata for the given submissionId, if it exists.
      *
-     * @param uniqueId The uniqueId to read the metadata for.
+     * @param submissionId The submission Id to read the metadata for.
      * @return The metadata, if it exists. Otherwise, an empty Optional.
      */
-    Optional<PartnerMetadata> readMetadata(String uniqueId) throws PartnerMetadataException;
+    Optional<PartnerMetadata> readMetadata(String submissionId) throws PartnerMetadataException;
 
     /**
      * This method will do "upserts". If the record doesn't exist, it is created. If the record

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderSender.java
@@ -2,5 +2,5 @@ package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 /** Interface for sending a lab order. */
 public interface OrderSender {
-    void sendOrder(Order<?> order) throws UnableToSendOrderException;
+    Optional<String> sendOrder(Order<?> order) throws UnableToSendOrderException;
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderSender.java
@@ -1,5 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.etor.orders;
 
+import java.util.Optional;
+
 /** Interface for sending a lab order. */
 public interface OrderSender {
     Optional<String> sendOrder(Order<?> order) throws UnableToSendOrderException;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -41,6 +41,8 @@ public class SendOrderUseCase {
     private void savePartnerMetadataForReceivedOrder(
             String receivedSubmissionId, final Order<?> order) {
         if (receivedSubmissionId == null) {
+            logger.logWarning(
+                    "Received submissionId is null so not saving metadata for received order");
             return;
         }
 
@@ -54,6 +56,8 @@ public class SendOrderUseCase {
 
     private void saveSentOrderSubmissionId(String receivedSubmissionId, String sentSubmissionId) {
         if (sentSubmissionId == null || receivedSubmissionId == null) {
+            logger.logWarning(
+                    "Received and/or sent submissionId is null so not saving metadata for sent order");
             return;
         }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -38,15 +38,17 @@ public class SendOrderUseCase {
         saveSentOrderSubmissionId(receivedSubmissionId, sentSubmissionId);
     }
 
-    private void savePartnerMetadataForReceivedOrder(String submissionId, final Order<?> order) {
-        if (submissionId == null) {
+    private void savePartnerMetadataForReceivedOrder(
+            String receivedSubmissionId, final Order<?> order) {
+        if (receivedSubmissionId == null) {
             return;
         }
 
         try {
-            partnerMetadataOrchestrator.updateMetadataForReceivedOrder(submissionId, order);
+            partnerMetadataOrchestrator.updateMetadataForReceivedOrder(receivedSubmissionId, order);
         } catch (PartnerMetadataException e) {
-            logger.logError("Unable to save metadata for submissionId " + submissionId, e);
+            logger.logError(
+                    "Unable to save metadata for receivedSubmissionId " + receivedSubmissionId, e);
         }
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -22,21 +22,20 @@ public class SendOrderUseCase {
         return INSTANCE;
     }
 
-    public void convertAndSend(final Order<?> order, String submissionId)
+    public void convertAndSend(final Order<?> order, String receivedSubmissionId)
             throws UnableToSendOrderException {
 
-        savePartnerMetadataForReceivedOrder(submissionId, order);
+        savePartnerMetadataForReceivedOrder(receivedSubmissionId, order);
 
         var omlOrder = converter.convertMetadataToOmlOrder(order);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.ORDER_CONVERTED_TO_OML);
+
         omlOrder = converter.addContactSectionToPatientResource(omlOrder);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.CONTACT_SECTION_ADDED_TO_PATIENT);
-        sender.sendOrder(omlOrder);
 
-        saveSentOrderSubmissionId(
-                submissionId,
-                "TBD, need to be filled in from the sender.sendOrder(omlOrder) call",
-                order);
+        String sentSubmissionId = sender.sendOrder(omlOrder).orElse(null);
+
+        saveSentOrderSubmissionId(receivedSubmissionId, sentSubmissionId, order);
     }
 
     private void savePartnerMetadataForReceivedOrder(String submissionId, final Order<?> order) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -35,7 +35,7 @@ public class SendOrderUseCase {
 
         String sentSubmissionId = sender.sendOrder(omlOrder).orElse(null);
 
-        saveSentOrderSubmissionId(receivedSubmissionId, sentSubmissionId, order);
+        saveSentOrderSubmissionId(receivedSubmissionId, sentSubmissionId);
     }
 
     private void savePartnerMetadataForReceivedOrder(String submissionId, final Order<?> order) {
@@ -50,15 +50,14 @@ public class SendOrderUseCase {
         }
     }
 
-    private void saveSentOrderSubmissionId(
-            String receivedSubmissionId, String sentSubmissionId, final Order<?> order) {
+    private void saveSentOrderSubmissionId(String receivedSubmissionId, String sentSubmissionId) {
         if (sentSubmissionId == null || receivedSubmissionId == null) {
             return;
         }
 
         try {
             partnerMetadataOrchestrator.updateMetadataForSentOrder(
-                    receivedSubmissionId, sentSubmissionId, order);
+                    receivedSubmissionId, sentSubmissionId);
         } catch (PartnerMetadataException e) {
             logger.logError(
                     "Unable to update metadata for received submissionId "

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorage.java
@@ -53,7 +53,7 @@ public class AzureStorageAccountPartnerMetadataStorage implements PartnerMetadat
 
     @Override
     public void saveMetadata(final PartnerMetadata metadata) throws PartnerMetadataException {
-        String metadataFileName = getMetadataFileName(metadata.uniqueId());
+        String metadataFileName = getMetadataFileName(metadata.receivedSubmissionId());
         try {
             BlobClient blobClient = client.getBlobClient(metadataFileName);
             String content = formatter.convertToJsonString(metadata);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -65,14 +65,18 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
 
     @Override
     public void saveMetadata(final PartnerMetadata metadata) throws PartnerMetadataException {
-        Path metadataFilePath = getFilePath(metadata.uniqueId());
+        Path metadataFilePath = getFilePath(metadata.receivedSubmissionId());
         try {
             String content = formatter.convertToJsonString(metadata);
             Files.writeString(metadataFilePath, content);
-            logger.logInfo("Saved metadata for " + metadata.uniqueId() + " to " + metadataFilePath);
+            logger.logInfo(
+                    "Saved metadata for "
+                            + metadata.receivedSubmissionId()
+                            + " to "
+                            + metadataFilePath);
         } catch (IOException | FormatterProcessingException e) {
             throw new PartnerMetadataException(
-                    "Error saving metadata for " + metadata.uniqueId(), e);
+                    "Error saving metadata for " + metadata.receivedSubmissionId(), e);
         }
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -70,10 +70,9 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
             String content = formatter.convertToJsonString(metadata);
             Files.writeString(metadataFilePath, content);
             logger.logInfo(
-                    "Saved metadata for "
-                            + metadata.receivedSubmissionId()
-                            + " to "
-                            + metadataFilePath);
+                    "Saved metadata for {} to {}",
+                    metadata.receivedSubmissionId(),
+                    metadataFilePath);
         } catch (IOException | FormatterProcessingException e) {
             throw new PartnerMetadataException(
                     "Error saving metadata for " + metadata.receivedSubmissionId(), e);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -46,9 +46,9 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     }
 
     @Override
-    public Optional<PartnerMetadata> readMetadata(final String uniqueId)
+    public Optional<PartnerMetadata> readMetadata(final String receivedSubmissionId)
             throws PartnerMetadataException {
-        Path filePath = getFilePath(uniqueId);
+        Path filePath = getFilePath(receivedSubmissionId);
         try {
             if (!Files.exists(filePath)) {
                 logger.logWarning("Metadata file not found: {}", filePath);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/LocalFileOrderSender.java
@@ -10,6 +10,7 @@ import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Optional;
 import javax.inject.Inject;
 
 /** Accepts a {@link Order} and writes it to a local file. */
@@ -30,7 +31,7 @@ public class LocalFileOrderSender implements OrderSender {
     private LocalFileOrderSender() {}
 
     @Override
-    public void sendOrder(final Order<?> order) throws UnableToSendOrderException {
+    public Optional<String> sendOrder(final Order<?> order) throws UnableToSendOrderException {
         var fileLocation = Paths.get(LOCAL_FILE_NAME);
         logger.logInfo("Sending the order to the hard drive at {}", fileLocation.toAbsolutePath());
 
@@ -41,5 +42,7 @@ public class LocalFileOrderSender implements OrderSender {
         } catch (Exception e) {
             throw new UnableToSendOrderException("Error writing the lab order", e);
         }
+
+        return Optional.empty();
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
@@ -21,18 +21,16 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 public class ReportStreamEndpointClient {
-    private static final String RS_URL_PREFIX_PROPERTY = "REPORT_STREAM_URL_PREFIX";
+    private static final String RS_URL_PREFIX =
+            ApplicationContext.getProperty("REPORT_STREAM_URL_PREFIX");
     private static final String RS_DOMAIN_NAME =
-            Optional.ofNullable(ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY))
+            Optional.ofNullable(RS_URL_PREFIX)
                     .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
                     .orElse("");
-    private static final String RS_WATERS_API_URL =
-            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/waters";
-    private static final String RS_AUTH_API_URL =
-            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/token";
+    private static final String RS_WATERS_API_URL = RS_URL_PREFIX + "/api/waters";
+    private static final String RS_AUTH_API_URL = RS_URL_PREFIX + "/api/token";
     private static final String RS_HISTORY_API_URL =
-            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY)
-                    + "/api/waters/report/{id}/history";
+            RS_URL_PREFIX + "/api/waters/report/{id}/history";
 
     private static final String OUR_PRIVATE_KEY_ID =
             "trusted-intermediary-private-key-" + ApplicationContext.getEnvironment();
@@ -114,11 +112,11 @@ public class ReportStreamEndpointClient {
         Map<String, String> headers = Map.of("Authorization", "Bearer " + bearerToken);
 
         try {
-            var url = RS_HISTORY_API_URL.replace("{id}", submissionId);
+            String url = RS_HISTORY_API_URL.replace("{id}", submissionId);
             return client.get(url, headers);
         } catch (HttpClientException e) {
             throw new ReportStreamEndpointClientException(
-                    "Error GETing the history from ReportStream", e);
+                    "Error GETting the history from ReportStream", e);
         }
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.external.reportstream;
 
 import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
-import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
 import gov.hhs.cdc.trustedintermediary.wrappers.Cache;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
@@ -61,7 +60,7 @@ public class ReportStreamEndpointClient {
 
     private ReportStreamEndpointClient() {}
 
-    protected String getRsToken() throws UnableToSendOrderException {
+    protected String getRsToken() throws ReportStreamEndpointClientException {
         logger.logInfo("Looking up ReportStream token");
 
         var token = cache.get(RS_TOKEN_CACHE_ID);
@@ -85,7 +84,7 @@ public class ReportStreamEndpointClient {
     }
 
     protected String sendRequestBody(@Nonnull String json, @Nonnull String bearerToken)
-            throws UnableToSendOrderException {
+            throws ReportStreamEndpointClientException {
         logger.logInfo("Sending payload to ReportStream");
 
         String res = "";
@@ -100,13 +99,14 @@ public class ReportStreamEndpointClient {
         try {
             res = client.post(RS_WATERS_API_URL, headers, json);
         } catch (HttpClientException e) {
-            throw new UnableToSendOrderException("Error POSTing the payload to ReportStream", e);
+            throw new ReportStreamEndpointClientException(
+                    "Error POSTing the payload to ReportStream", e);
         }
 
         return res;
     }
 
-    protected String requestToken() throws UnableToSendOrderException {
+    protected String requestToken() throws ReportStreamEndpointClientException {
         logger.logInfo("Requesting token from ReportStream");
 
         String ourPrivateKey;
@@ -126,7 +126,7 @@ public class ReportStreamEndpointClient {
             String rsResponse = client.post(RS_AUTH_API_URL, RS_AUTH_API_HEADERS, body);
             token = extractToken(rsResponse);
         } catch (Exception e) {
-            throw new UnableToSendOrderException(
+            throw new ReportStreamEndpointClientException(
                     "Error getting the API token from ReportStream", e);
         }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClient.java
@@ -1,0 +1,179 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream;
+
+import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
+import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
+import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
+import gov.hhs.cdc.trustedintermediary.wrappers.Cache;
+import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
+import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
+import gov.hhs.cdc.trustedintermediary.wrappers.HttpClientException;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
+import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
+import gov.hhs.cdc.trustedintermediary.wrappers.SecretRetrievalException;
+import gov.hhs.cdc.trustedintermediary.wrappers.Secrets;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+public class ReportStreamEndpointClient {
+    private static final String RS_URL_PREFIX_PROPERTY = "REPORT_STREAM_URL_PREFIX";
+    private static final String RS_DOMAIN_NAME =
+            Optional.ofNullable(ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY))
+                    .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
+                    .orElse("");
+    private static final String RS_WATERS_API_URL =
+            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/waters";
+    private static final String RS_AUTH_API_URL =
+            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/token";
+    private static final String RS_HISTORY_API_URL =
+            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY)
+                    + "/api/waters/report/{id}/history";
+
+    private static final String OUR_PRIVATE_KEY_ID =
+            "trusted-intermediary-private-key-" + ApplicationContext.getEnvironment();
+    private static final String RS_TOKEN_CACHE_ID = "report-stream-token";
+
+    private static final String CLIENT_NAME = "flexion.etor-service-sender";
+    private static final Map<String, String> RS_AUTH_API_HEADERS =
+            Map.of("Content-Type", "application/x-www-form-urlencoded");
+
+    @Inject private HttpClient client;
+    @Inject private AuthEngine jwt;
+    @Inject private Formatter formatter;
+    @Inject private HapiFhir fhir;
+    @Inject private Logger logger;
+    @Inject private Secrets secrets;
+    @Inject private Cache cache;
+
+    @Inject MetricMetadata metadata;
+
+    private static final ReportStreamEndpointClient INSTANCE = new ReportStreamEndpointClient();
+
+    public static ReportStreamEndpointClient getInstance() {
+        return INSTANCE;
+    }
+
+    private ReportStreamEndpointClient() {}
+
+    protected String getRsToken() throws UnableToSendOrderException {
+        logger.logInfo("Looking up ReportStream token");
+
+        var token = cache.get(RS_TOKEN_CACHE_ID);
+
+        if (token != null && isValidToken(token)) {
+            logger.logDebug("valid cache token");
+            return token;
+        }
+
+        token = requestToken();
+
+        cache.put(RS_TOKEN_CACHE_ID, token);
+
+        return token;
+    }
+
+    protected boolean isValidToken(String token) {
+        LocalDateTime expirationDate = jwt.getExpirationDate(token);
+
+        return LocalDateTime.now().isBefore(expirationDate.minus(15, ChronoUnit.SECONDS));
+    }
+
+    protected String sendRequestBody(@Nonnull String json, @Nonnull String bearerToken)
+            throws UnableToSendOrderException {
+        logger.logInfo("Sending payload to ReportStream");
+
+        String res = "";
+        Map<String, String> headers =
+                Map.of(
+                        "Authorization",
+                        "Bearer " + bearerToken,
+                        "client",
+                        CLIENT_NAME,
+                        "Content-Type",
+                        "application/fhir+ndjson");
+        try {
+            res = client.post(RS_WATERS_API_URL, headers, json);
+        } catch (HttpClientException e) {
+            throw new UnableToSendOrderException("Error POSTing the payload to ReportStream", e);
+        }
+
+        return res;
+    }
+
+    protected String requestToken() throws UnableToSendOrderException {
+        logger.logInfo("Requesting token from ReportStream");
+
+        String ourPrivateKey;
+        String token;
+
+        try {
+            ourPrivateKey = retrievePrivateKey();
+            String senderToken =
+                    jwt.generateToken(
+                            CLIENT_NAME,
+                            CLIENT_NAME,
+                            CLIENT_NAME,
+                            RS_DOMAIN_NAME,
+                            300,
+                            ourPrivateKey);
+            String body = composeRequestBody(senderToken);
+            String rsResponse = client.post(RS_AUTH_API_URL, RS_AUTH_API_HEADERS, body);
+            token = extractToken(rsResponse);
+        } catch (Exception e) {
+            throw new UnableToSendOrderException(
+                    "Error getting the API token from ReportStream", e);
+        }
+
+        // only cache our private key if we successfully authenticate to RS
+        cacheOurPrivateKeyIfNotCachedAlready(ourPrivateKey);
+
+        return token;
+    }
+
+    protected String retrievePrivateKey() throws SecretRetrievalException {
+        String key = cache.get(OUR_PRIVATE_KEY_ID);
+        if (key != null) {
+            return key;
+        }
+
+        key = secrets.getKey(OUR_PRIVATE_KEY_ID);
+
+        return key;
+    }
+
+    void cacheOurPrivateKeyIfNotCachedAlready(String privateKey) {
+        String key = cache.get(OUR_PRIVATE_KEY_ID);
+        if (key != null) {
+            return;
+        }
+
+        cache.put(OUR_PRIVATE_KEY_ID, privateKey);
+    }
+
+    protected String extractToken(String responseBody) throws FormatterProcessingException {
+        var value =
+                formatter.convertJsonToObject(
+                        responseBody, new TypeReference<Map<String, String>>() {});
+        return value.get("access_token");
+    }
+
+    protected String composeRequestBody(String senderToken) {
+        String scope = "flexion.*.report";
+        String grantType = "client_credentials";
+        String clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+        return "scope="
+                + scope
+                + "&grant_type="
+                + grantType
+                + "&client_assertion_type="
+                + clientAssertionType
+                + "&client_assertion="
+                + senderToken;
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientException.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientException.java
@@ -1,0 +1,10 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream;
+
+/**
+ * This exception class gets triggered when any exception occurs when sending a request to a RS API
+ */
+public class ReportStreamEndpointClientException extends Exception {
+    public ReportStreamEndpointClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -1,27 +1,17 @@
 package gov.hhs.cdc.trustedintermediary.external.reportstream;
 
-import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
-import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine;
-import gov.hhs.cdc.trustedintermediary.wrappers.Cache;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
-import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
-import gov.hhs.cdc.trustedintermediary.wrappers.HttpClientException;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
-import gov.hhs.cdc.trustedintermediary.wrappers.SecretRetrievalException;
-import gov.hhs.cdc.trustedintermediary.wrappers.Secrets;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 /** Accepts a {@link Order} and sends it to ReportStream. */
@@ -29,32 +19,10 @@ public class ReportStreamOrderSender implements OrderSender {
 
     private static final ReportStreamOrderSender INSTANCE = new ReportStreamOrderSender();
 
-    private static final String RS_URL_PREFIX_PROPERTY = "REPORT_STREAM_URL_PREFIX";
-    private static final String RS_WATERS_API_URL =
-            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/waters";
-    private static final String RS_AUTH_API_URL =
-            ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY) + "/api/token";
-    private static final String RS_DOMAIN_NAME =
-            Optional.ofNullable(ApplicationContext.getProperty(RS_URL_PREFIX_PROPERTY))
-                    .map(urlPrefix -> urlPrefix.replace("https://", "").replace("http://", ""))
-                    .orElse("");
-
-    private static final String OUR_PRIVATE_KEY_ID =
-            "trusted-intermediary-private-key-" + ApplicationContext.getEnvironment();
-    private static final String RS_TOKEN_CACHE_ID = "report-stream-token";
-
-    private static final String CLIENT_NAME = "flexion.etor-service-sender";
-    private static final Map<String, String> RS_AUTH_API_HEADERS =
-            Map.of("Content-Type", "application/x-www-form-urlencoded");
-
-    @Inject private HttpClient client;
-    @Inject private AuthEngine jwt;
+    @Inject private ReportStreamEndpointClient rsclient;
     @Inject private Formatter formatter;
     @Inject private HapiFhir fhir;
     @Inject private Logger logger;
-    @Inject private Secrets secrets;
-    @Inject private Cache cache;
-
     @Inject MetricMetadata metadata;
 
     public static ReportStreamOrderSender getInstance() {
@@ -65,10 +33,10 @@ public class ReportStreamOrderSender implements OrderSender {
 
     @Override
     public Optional<String> sendOrder(final Order<?> order) throws UnableToSendOrderException {
-        logger.logInfo("Sending the order to ReportStream at {}", RS_DOMAIN_NAME);
+        //        logger.logInfo("Sending the order to ReportStream at {}", RS_DOMAIN_NAME);
         String json = fhir.encodeResourceToJson(order.getUnderlyingOrder());
-        String bearerToken = getRsToken();
-        String rsResponseBody = sendRequestBody(json, bearerToken);
+        String bearerToken = rsclient.getRsToken();
+        String rsResponseBody = rsclient.sendRequestBody(json, bearerToken);
         Optional<String> submissionId = getSubmissionId(rsResponseBody);
         logger.logInfo("Order successfully sent, ReportStream submissionId={}", submissionId);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.SENT_TO_REPORT_STREAM);
@@ -86,121 +54,5 @@ public class ReportStreamOrderSender implements OrderSender {
         }
 
         return Optional.empty();
-    }
-
-    protected String getRsToken() throws UnableToSendOrderException {
-        logger.logInfo("Looking up ReportStream token");
-
-        var token = cache.get(RS_TOKEN_CACHE_ID);
-
-        if (token != null && isValidToken(token)) {
-            logger.logDebug("valid cache token");
-            return token;
-        }
-
-        token = requestToken();
-
-        cache.put(RS_TOKEN_CACHE_ID, token);
-
-        return token;
-    }
-
-    protected boolean isValidToken(String token) {
-        LocalDateTime expirationDate = jwt.getExpirationDate(token);
-
-        return LocalDateTime.now().isBefore(expirationDate.minus(15, ChronoUnit.SECONDS));
-    }
-
-    protected String sendRequestBody(@Nonnull String json, @Nonnull String bearerToken)
-            throws UnableToSendOrderException {
-        logger.logInfo("Sending payload to ReportStream");
-
-        String res = "";
-        Map<String, String> headers =
-                Map.of(
-                        "Authorization",
-                        "Bearer " + bearerToken,
-                        "client",
-                        CLIENT_NAME,
-                        "Content-Type",
-                        "application/fhir+ndjson");
-        try {
-            res = client.post(RS_WATERS_API_URL, headers, json);
-        } catch (HttpClientException e) {
-            throw new UnableToSendOrderException("Error POSTing the payload to ReportStream", e);
-        }
-
-        return res;
-    }
-
-    protected String requestToken() throws UnableToSendOrderException {
-        logger.logInfo("Requesting token from ReportStream");
-
-        String ourPrivateKey;
-        String token;
-
-        try {
-            ourPrivateKey = retrievePrivateKey();
-            String senderToken =
-                    jwt.generateToken(
-                            CLIENT_NAME,
-                            CLIENT_NAME,
-                            CLIENT_NAME,
-                            RS_DOMAIN_NAME,
-                            300,
-                            ourPrivateKey);
-            String body = composeRequestBody(senderToken);
-            String rsResponse = client.post(RS_AUTH_API_URL, RS_AUTH_API_HEADERS, body);
-            token = extractToken(rsResponse);
-        } catch (Exception e) {
-            throw new UnableToSendOrderException(
-                    "Error getting the API token from ReportStream", e);
-        }
-
-        // only cache our private key if we successfully authenticate to RS
-        cacheOurPrivateKeyIfNotCachedAlready(ourPrivateKey);
-
-        return token;
-    }
-
-    protected String retrievePrivateKey() throws SecretRetrievalException {
-        String key = cache.get(OUR_PRIVATE_KEY_ID);
-        if (key != null) {
-            return key;
-        }
-
-        key = secrets.getKey(OUR_PRIVATE_KEY_ID);
-
-        return key;
-    }
-
-    void cacheOurPrivateKeyIfNotCachedAlready(String privateKey) {
-        String key = cache.get(OUR_PRIVATE_KEY_ID);
-        if (key != null) {
-            return;
-        }
-
-        cache.put(OUR_PRIVATE_KEY_ID, privateKey);
-    }
-
-    protected String extractToken(String responseBody) throws FormatterProcessingException {
-        var value =
-                formatter.convertJsonToObject(
-                        responseBody, new TypeReference<Map<String, String>>() {});
-        return value.get("access_token");
-    }
-
-    protected String composeRequestBody(String senderToken) {
-        String scope = "flexion.*.report";
-        String grantType = "client_credentials";
-        String clientAssertionType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-        return "scope="
-                + scope
-                + "&grant_type="
-                + grantType
-                + "&client_assertion_type="
-                + clientAssertionType
-                + "&client_assertion="
-                + senderToken;
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -39,7 +39,7 @@ public class ReportStreamOrderSender implements OrderSender {
         String rsResponseBody;
         try {
             bearerToken = rsclient.getRsToken();
-            rsResponseBody = rsclient.sendRequestBody(json, bearerToken);
+            rsResponseBody = rsclient.requestWatersEndpoint(json, bearerToken);
         } catch (ReportStreamEndpointClientException e) {
             throw new UnableToSendOrderException("Unable to send order to ReportStream", e);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -35,8 +35,14 @@ public class ReportStreamOrderSender implements OrderSender {
     public Optional<String> sendOrder(final Order<?> order) throws UnableToSendOrderException {
         //        logger.logInfo("Sending the order to ReportStream at {}", RS_DOMAIN_NAME);
         String json = fhir.encodeResourceToJson(order.getUnderlyingOrder());
-        String bearerToken = rsclient.getRsToken();
-        String rsResponseBody = rsclient.sendRequestBody(json, bearerToken);
+        String bearerToken;
+        String rsResponseBody;
+        try {
+            bearerToken = rsclient.getRsToken();
+            rsResponseBody = rsclient.sendRequestBody(json, bearerToken);
+        } catch (ReportStreamEndpointClientException e) {
+            throw new UnableToSendOrderException("Unable to send order to ReportStream", e);
+        }
         Optional<String> submissionId = getSubmissionId(rsResponseBody);
         logger.logInfo("Order successfully sent, ReportStream submissionId={}", submissionId);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.SENT_TO_REPORT_STREAM);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -61,9 +61,8 @@ public class ReportStreamOrderSender implements OrderSender {
 
     protected Optional<String> getSubmissionId(String rsResponseBody) {
         try {
-            var rsResponse =
-                    formatter.convertJsonToObject(
-                            rsResponseBody, new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> rsResponse =
+                    formatter.convertJsonToObject(rsResponseBody, new TypeReference<>() {});
             return Optional.ofNullable(rsResponse.get("submissionId").toString());
         } catch (FormatterProcessingException e) {
             logger.logError("Unable to get the submissionId", e);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -54,7 +54,7 @@ public class ReportStreamOrderSender implements OrderSender {
             var rsResponse =
                     formatter.convertJsonToObject(
                             rsResponseBody, new TypeReference<Map<String, Object>>() {});
-            return Optional.ofNullable((String) rsResponse.get("submissionId"));
+            return Optional.ofNullable(rsResponse.get("submissionId").toString());
         } catch (FormatterProcessingException e) {
             logger.logError("Unable to get the submissionId", e);
         }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -321,7 +321,7 @@ class EtorDomainRegistrationTest extends Specification {
         request.setPathParams(["id": "metadataId"])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
-        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataId", "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd"))
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataId"))
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -321,7 +321,7 @@ class EtorDomainRegistrationTest extends Specification {
         request.setPathParams(["id": "metadataId"])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
-        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("metadataId"))
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), "hash"))
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -29,7 +29,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         def partnerMetadataStorage = Mock(PartnerMetadataStorage)
         def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sender", Instant.now(), "hash")
-        def updatedPartnerMetadata = partnerMetadata.withSentSubmissionFields(sentSubmissionId, receiver)
+        def updatedPartnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId).withReceiver(receiver)
         TestApplicationContext.register(PartnerMetadataStorage, partnerMetadataStorage)
 
         def mockClient = Mock(ReportStreamEndpointClient)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -1,0 +1,196 @@
+package gov.hhs.cdc.trustedintermediary.etor.metadata
+
+import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
+import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
+import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient
+import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClientException
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference
+
+import java.time.Instant
+import spock.lang.Specification
+
+class PartnerMetadataOrchestratorTest extends Specification {
+
+    def setup() {
+        TestApplicationContext.reset()
+        TestApplicationContext.init()
+        TestApplicationContext.register(PartnerMetadataOrchestrator, PartnerMetadataOrchestrator.getInstance())
+    }
+
+    def "updateMetadataForSentOrder updates metadata successfully"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
+        def bearerToken = "token"
+        def receiver = "org.service"
+        def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
+
+        def partnerMetadataStorage = Mock(PartnerMetadataStorage)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sender", Instant.now(), "hash")
+        def updatedPartnerMetadata = partnerMetadata.withSentSubmissionFields(sentSubmissionId, receiver)
+        TestApplicationContext.register(PartnerMetadataStorage, partnerMetadataStorage)
+
+        def mockClient = Mock(ReportStreamEndpointClient)
+        TestApplicationContext.register(ReportStreamEndpointClient, mockClient)
+
+        def mockFormatter = Mock(Formatter)
+        mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [destinations: [
+                [organization_id: "org", service: "service"]
+            ]]
+        TestApplicationContext.register(Formatter, mockFormatter)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder(receivedSubmissionId, sentSubmissionId)
+
+        then:
+        1 * mockClient.getRsToken() >> bearerToken
+        1 * mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        1 * partnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        1 * partnerMetadataStorage.saveMetadata(updatedPartnerMetadata)
+    }
+
+    def "updateMetadataForSentOrder throws PartnerMetadataException on client error"() {
+        given:
+        def mockClient = Mock(ReportStreamEndpointClient)
+        mockClient.getRsToken() >> "token"
+        mockClient.requestHistoryEndpoint(_ as String, _ as String) >> { throw new ReportStreamEndpointClientException("Client error", new Exception()) }
+        TestApplicationContext.register(ReportStreamEndpointClient, mockClient)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder("receivedSubmissionId", "sentSubmissionId")
+
+        then:
+        thrown(PartnerMetadataException)
+    }
+
+    def "updateMetadataForSentOrder throws PartnerMetadataException on formatter error"() {
+        given:
+        def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
+
+        def mockClient = Mock(ReportStreamEndpointClient)
+        mockClient.getRsToken() >> "token"
+        mockClient.requestHistoryEndpoint(_ as String, _ as String) >> rsHistoryApiResponse
+        TestApplicationContext.register(ReportStreamEndpointClient, mockClient)
+
+
+        def mockFormatter = Mock(Formatter)
+        mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> { throw new FormatterProcessingException("Formatter error", new Exception()) }
+        TestApplicationContext.register(Formatter, mockFormatter)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder("receivedSubmissionId", "sentSubmissionId")
+
+        then:
+        thrown(PartnerMetadataException)
+    }
+
+    def "getMetadata retrieves metadata successfully"() {
+        given:
+        String receivedSubmissionId = "receivedSubmissionId"
+        PartnerMetadata metadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), "hash")
+
+        def partnerMetadataStorage = Mock(PartnerMetadataStorage)
+        TestApplicationContext.register(PartnerMetadataStorage, partnerMetadataStorage)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+
+        then:
+        result.isPresent()
+        result.get() == metadata
+        1 * partnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(metadata)
+    }
+
+    def "getReceiverName returns correct receiver name from valid JSON response"() {
+        given:
+        String validJson = "{\"destinations\": [{\"organization_id\": \"org_id\", \"service\": \"service_name\"}]}"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        String receiverName = PartnerMetadataOrchestrator.getInstance().getReceiverName(validJson)
+
+        then:
+        receiverName == "org_id.service_name"
+    }
+
+    def "getReceiverName throws FormatterProcessingException for invalid JSON response"() {
+        given:
+        String invalidJson = "invalid JSON"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().getReceiverName(invalidJson)
+
+        then:
+        thrown(FormatterProcessingException)
+    }
+
+    def "getReceiverName throws FormatterProcessingException for JSON without destinations"() {
+        given:
+        String jsonWithoutDestinations = "{\"someotherkey\": \"value\"}"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().getReceiverName(jsonWithoutDestinations)
+
+        then:
+        thrown(FormatterProcessingException)
+    }
+
+    def "getReceiverName throws FormatterProcessingException for JSON with empty destinations"() {
+        given:
+        String jsonWithEmptyDestinations = "{\"destinations\": []}"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().getReceiverName(jsonWithEmptyDestinations)
+
+        then:
+        thrown(FormatterProcessingException)
+    }
+
+    def "getReceiverName throws FormatterProcessingException for JSON without organization_id"() {
+        given:
+        String jsonWithoutOrgId = "{\"destinations\":[{\"service\":\"service\"}]}"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().getReceiverName(jsonWithoutOrgId)
+
+        then:
+        thrown(FormatterProcessingException)
+    }
+
+    def "getReceiverName throws FormatterProcessingException for JSON without service"() {
+        given:
+        String jsonWithoutService = "{\"destinations\":[{\"organization_id\":\"org_id\"}]}"
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().getReceiverName(jsonWithoutService)
+
+        then:
+        thrown(FormatterProcessingException)
+    }
+}

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -55,14 +55,23 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentOrder throws PartnerMetadataException on client error"() {
         given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
+
+        def partnerMetadataStorage = Mock(PartnerMetadataStorage)
+        PartnerMetadata partnerMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, "sender", "receiver", Instant.now(), "hash")
+        partnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        TestApplicationContext.register(PartnerMetadataStorage, partnerMetadataStorage)
+
         def mockClient = Mock(ReportStreamEndpointClient)
         mockClient.getRsToken() >> "token"
         mockClient.requestHistoryEndpoint(_ as String, _ as String) >> { throw new ReportStreamEndpointClientException("Client error", new Exception()) }
         TestApplicationContext.register(ReportStreamEndpointClient, mockClient)
+
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder("receivedSubmissionId", "sentSubmissionId")
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder(receivedSubmissionId, sentSubmissionId)
 
         then:
         thrown(PartnerMetadataException)
@@ -70,13 +79,19 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentOrder throws PartnerMetadataException on formatter error"() {
         given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
+
+        def partnerMetadataStorage = Mock(PartnerMetadataStorage)
+        PartnerMetadata partnerMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, "sender", "receiver", Instant.now(), "hash")
+        partnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        TestApplicationContext.register(PartnerMetadataStorage, partnerMetadataStorage)
 
         def mockClient = Mock(ReportStreamEndpointClient)
         mockClient.getRsToken() >> "token"
         mockClient.requestHistoryEndpoint(_ as String, _ as String) >> rsHistoryApiResponse
         TestApplicationContext.register(ReportStreamEndpointClient, mockClient)
-
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> { throw new FormatterProcessingException("Formatter error", new Exception()) }
@@ -85,7 +100,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder("receivedSubmissionId", "sentSubmissionId")
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentOrder(receivedSubmissionId, sentSubmissionId)
 
         then:
         thrown(PartnerMetadataException)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -34,4 +34,45 @@ class PartnerMetadataTest extends Specification {
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
     }
+
+    def "test overloaded constructor"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sender = "sender"
+        def timeReceived = Instant.now()
+        def hash = "abcd"
+
+        when:
+        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash)
+
+        then:
+        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.sentSubmissionId() == null
+        metadata.sender() == sender
+        metadata.receiver() == null
+        metadata.timeReceived() == timeReceived
+        metadata.hash() == hash
+    }
+
+    def "test withSentSubmissionFields to update PartnerMetadata"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
+        def sender = "sender"
+        def receiver = "receiver"
+        def timeReceived = Instant.now()
+        def hash = "abcd"
+        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash)
+
+        when:
+        def updatedMetadata = metadata.withSentSubmissionFields(sentSubmissionId, receiver)
+
+        then:
+        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.sender() == sender
+        updatedMetadata.receiver() == receiver
+        updatedMetadata.timeReceived() == timeReceived
+        updatedMetadata.hash() == hash
+    }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -16,17 +16,19 @@ class PartnerMetadataTest extends Specification {
 
     def "test constructor"() {
         given:
-        def uniqueId = "uniqueId"
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
         def sender = "sender"
         def receiver = "receiver"
         def timeReceived = Instant.now()
         def hash = "abcd"
 
         when:
-        def metadata = new PartnerMetadata(uniqueId, sender, receiver, timeReceived, hash)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash)
 
         then:
-        metadata.uniqueId() == uniqueId
+        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.sentSubmissionId() == sentSubmissionId
         metadata.sender() == sender
         metadata.receiver() == receiver
         metadata.timeReceived() == timeReceived

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -54,7 +54,7 @@ class PartnerMetadataTest extends Specification {
         metadata.hash() == hash
     }
 
-    def "test withSentSubmissionFields to update PartnerMetadata"() {
+    def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
         def sentSubmissionId = "sentSubmissionId"
@@ -65,7 +65,7 @@ class PartnerMetadataTest extends Specification {
         def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash)
 
         when:
-        def updatedMetadata = metadata.withSentSubmissionFields(sentSubmissionId, receiver)
+        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withReceiver(receiver)
 
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -25,7 +25,6 @@ class SendOrderUsecaseTest extends Specification {
         TestApplicationContext.register(OrderConverter, mockConverter)
 
         def mockSender = Mock(OrderSender)
-        mockSender.sendOrder(_) >> Optional.empty()
         TestApplicationContext.register(OrderSender, mockSender)
 
         TestApplicationContext.injectRegisteredImplementations()
@@ -35,7 +34,8 @@ class SendOrderUsecaseTest extends Specification {
 
         then:
         1 * mockConverter.convertMetadataToOmlOrder(mockOrder)
-        1 * mockSender.sendOrder(_)
+        1 * mockConverter.addContactSectionToPatientResource(_)
+        1 * mockSender.sendOrder(_) >> Optional.empty()
     }
 
     def "metadata is registered for converting to OML and for adding the contact section to an order"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -22,6 +22,7 @@ class SendOrderUsecaseTest extends Specification {
         def mockOrder = new OrderMock(null, null, null)
         def mockConverter = Mock(OrderConverter)
         def mockSender = Mock(OrderSender)
+        mockSender.sendOrder(_ as Order<?>) >> Optional.empty()
 
         TestApplicationContext.register(OrderConverter, mockConverter)
         TestApplicationContext.register(OrderSender, mockSender)
@@ -32,7 +33,7 @@ class SendOrderUsecaseTest extends Specification {
 
         then:
         1 * mockConverter.convertMetadataToOmlOrder(mockOrder)
-        1 * mockSender.sendOrder(_)
+        //        1 * mockSender.sendOrder(_ as Order<?>)
     }
 
     def "metadata is registered for converting to OML"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUsecaseTest.groovy
@@ -20,12 +20,14 @@ class SendOrderUsecaseTest extends Specification {
     def "send sends successfully"() {
         given:
         def mockOrder = new OrderMock(null, null, null)
-        def mockConverter = Mock(OrderConverter)
-        def mockSender = Mock(OrderSender)
-        mockSender.sendOrder(_ as Order<?>) >> Optional.empty()
 
+        def mockConverter = Mock(OrderConverter)
         TestApplicationContext.register(OrderConverter, mockConverter)
+
+        def mockSender = Mock(OrderSender)
+        mockSender.sendOrder(_) >> Optional.empty()
         TestApplicationContext.register(OrderSender, mockSender)
+
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
@@ -33,13 +35,17 @@ class SendOrderUsecaseTest extends Specification {
 
         then:
         1 * mockConverter.convertMetadataToOmlOrder(mockOrder)
-        //        1 * mockSender.sendOrder(_ as Order<?>)
+        1 * mockSender.sendOrder(_)
     }
 
-    def "metadata is registered for converting to OML"() {
+    def "metadata is registered for converting to OML and for adding the contact section to an order"() {
         given:
         TestApplicationContext.register(OrderConverter, Mock(OrderConverter))
-        TestApplicationContext.register(OrderSender, Mock(OrderSender))
+
+        def mockSender = Mock(OrderSender)
+        mockSender.sendOrder(_) >> Optional.empty()
+        TestApplicationContext.register(OrderSender, mockSender)
+
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
@@ -47,18 +53,6 @@ class SendOrderUsecaseTest extends Specification {
 
         then:
         1 * SendOrderUseCase.getInstance().metadata.put(_, EtorMetadataStep.ORDER_CONVERTED_TO_OML)
-    }
-
-    def "metadata is registered for adding the contact section to an order"() {
-        given:
-        TestApplicationContext.register(OrderConverter, Mock(OrderConverter))
-        TestApplicationContext.register(OrderSender, Mock(OrderSender))
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        SendOrderUseCase.getInstance().convertAndSend(new OrderMock(null, null, null), _ as String)
-
-        then:
         1 * SendOrderUseCase.getInstance().metadata.put(_, EtorMetadataStep.CONTACT_SECTION_ADDED_TO_PATIENT)
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
@@ -21,16 +21,18 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "successfully read metadata"() {
         given:
-        def expectedUniqueId = "uniqueId"
+        def expectedReceivedSubmissionId = "receivedSubmissionId"
+        def expectedSentSubmissionId = "sentSubmissionId"
         def expectedSender = "sender"
         def expectedReceiver = "receiver"
         def expectedTimestamp = Instant.parse("2023-12-04T18:51:48.941875Z")
         def expectedHash = "abcd"
 
-        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedUniqueId, expectedSender, expectedReceiver, expectedTimestamp, expectedHash)
+        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, expectedSender, expectedReceiver, expectedTimestamp, expectedHash)
 
         String simulatedMetadataJson = """{
-            "uniqueId": "${expectedUniqueId}",
+            "receivedSubmissionId": "${expectedReceivedSubmissionId}",
+            "sentSubmissionId": "${expectedSentSubmissionId}",
             "sender": "${expectedSender}",
             "receiver": "${expectedReceiver}",
             "timeReceived": "${expectedTimestamp}",
@@ -49,7 +51,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def actualMetadata = AzureStorageAccountPartnerMetadataStorage.getInstance().readMetadata(expectedUniqueId)
+        def actualMetadata = AzureStorageAccountPartnerMetadataStorage.getInstance().readMetadata(expectedReceivedSubmissionId)
 
         then:
         actualMetadata.get() == expectedMetadata
@@ -75,7 +77,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "exception path while reading metadata"() {
         given:
-        String expectedUniqueId = "uniqueId"
+        String expectedUniqueId = "receivedSubmissionId"
         def mockBlobClient = Mock(BlobClient)
         mockBlobClient.exists() >> true
         mockBlobClient.downloadContent() >> { throw new AzureException("Download error") }
@@ -95,7 +97,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "successfully save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("uniqueId", "sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd")
 
         def mockBlobClient = Mock(BlobClient)
         def azureClient = Mock(AzureClient)
@@ -117,7 +119,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "failed to save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("uniqueId", "sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd")
 
         def mockBlobClient = Mock(BlobClient)
         mockBlobClient.upload(_ as BinaryData, true) >> { throw new AzureException("upload failed") }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -21,15 +21,16 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "save and read metadata successfully"() {
         given:
-        def expectedUniqueId = "uniqueId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedUniqueId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd")
+        def expectedReceivedSubmissionId = "receivedSubmissionId"
+        def expectedSentSubmissionId = "receivedSubmissionId"
+        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd")
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata)
-        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedUniqueId)
+        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedReceivedSubmissionId)
 
         then:
         actualMetadata.get() == metadata
@@ -37,7 +38,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("uniqueId", "sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), "abcd")
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}
@@ -59,7 +60,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        FilePartnerMetadataStorage.getInstance().readMetadata("uniqueId")
+        FilePartnerMetadataStorage.getInstance().readMetadata("receivedSubmissionId")
 
         then:
         thrown(PartnerMetadataException)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
@@ -162,21 +162,6 @@ class ReportStreamEndpointClientTest extends Specification {
         1 * mockCache.put(_, _)
     }
 
-    def "extractResponseValue works"() {
-        given:
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.injectRegisteredImplementations()
-
-        def expected = "IaMAfaKEt0keNN"
-        def responseBody = """{"foo":"foo value", "access_token":"${expected}", "boo":"boo value"}"""
-
-        when:
-        def actual = ReportStreamEndpointClient.getInstance().extractResponseValue(responseBody, "access_token")
-
-        then:
-        actual == expected
-    }
-
     def "extractToken works when access_token is a number"() {
         given:
         def mockClient = Mock(HttpClient)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
@@ -32,8 +32,8 @@ class ReportStreamEndpointClientTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamEndpointClient.getInstance().sendRequestBody("message_1", "fake token")
-        ReportStreamEndpointClient.getInstance().sendRequestBody("message_2", "fake token")
+        ReportStreamEndpointClient.getInstance().requestWatersEndpoint("message_1", "fake token")
+        ReportStreamEndpointClient.getInstance().requestWatersEndpoint("message_2", "fake token")
 
         then:
         2 * mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> "200"
@@ -47,8 +47,8 @@ class ReportStreamEndpointClientTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamEndpointClient.getInstance().sendRequestBody("message_1", "fake token")
-        ReportStreamEndpointClient.getInstance().sendRequestBody("message_2", "fake token")
+        ReportStreamEndpointClient.getInstance().requestWatersEndpoint("message_1", "fake token")
+        ReportStreamEndpointClient.getInstance().requestWatersEndpoint("message_2", "fake token")
 
         then:
         def exception = thrown(Exception)
@@ -162,7 +162,7 @@ class ReportStreamEndpointClientTest extends Specification {
         1 * mockCache.put(_, _)
     }
 
-    def "extractToken works"() {
+    def "extractResponseValue works"() {
         given:
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -171,7 +171,7 @@ class ReportStreamEndpointClientTest extends Specification {
         def responseBody = """{"foo":"foo value", "access_token":"${expected}", "boo":"boo value"}"""
 
         when:
-        def actual = ReportStreamEndpointClient.getInstance().extractToken(responseBody)
+        def actual = ReportStreamEndpointClient.getInstance().extractResponseValue(responseBody, "access_token")
 
         then:
         actual == expected
@@ -229,7 +229,7 @@ class ReportStreamEndpointClientTest extends Specification {
                 "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" +
                 "&client_assertion=${fakeToken}"
         when:
-        def actual = ReportStreamEndpointClient.composeRequestBody(fakeToken)
+        def actual = ReportStreamEndpointClient.composeAuthRequestBody(fakeToken)
         then:
         actual == expected
     }
@@ -295,7 +295,7 @@ class ReportStreamEndpointClientTest extends Specification {
         }
 
         when:
-        orderSender.sendRequestBody("json", "bearerToken")
+        orderSender.requestWatersEndpoint("json", "bearerToken")
 
         then:
         def exception = thrown(ReportStreamEndpointClientException)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
@@ -2,7 +2,6 @@ package gov.hhs.cdc.trustedintermediary.external.reportstream
 
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender
-import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException
 import gov.hhs.cdc.trustedintermediary.external.inmemory.KeyCache
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine
@@ -127,7 +126,7 @@ class ReportStreamEndpointClientTest extends Specification {
         ReportStreamEndpointClient.getInstance().requestToken()
 
         then:
-        thrown(UnableToSendOrderException)
+        thrown(ReportStreamEndpointClientException)
         0 * mockCache.put(_ , _)
     }
 
@@ -217,7 +216,7 @@ class ReportStreamEndpointClientTest extends Specification {
         ReportStreamEndpointClient.getInstance().requestToken()
 
         then:
-        def exception = thrown(UnableToSendOrderException)
+        def exception = thrown(ReportStreamEndpointClientException)
         exception.getCause().getClass() == FormatterProcessingException
     }
 
@@ -299,7 +298,7 @@ class ReportStreamEndpointClientTest extends Specification {
         orderSender.sendRequestBody("json", "bearerToken")
 
         then:
-        def exception = thrown(UnableToSendOrderException)
+        def exception = thrown(ReportStreamEndpointClientException)
         exception.getCause().getClass() == HttpClientException
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamEndpointClientTest.groovy
@@ -1,0 +1,387 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream
+
+import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
+import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender
+import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException
+import gov.hhs.cdc.trustedintermediary.external.inmemory.KeyCache
+import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
+import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine
+import gov.hhs.cdc.trustedintermediary.wrappers.Cache
+import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient
+import gov.hhs.cdc.trustedintermediary.wrappers.HttpClientException
+import gov.hhs.cdc.trustedintermediary.wrappers.Secrets
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class ReportStreamEndpointClientTest extends Specification {
+
+    def setup() {
+        TestApplicationContext.reset()
+        TestApplicationContext.init()
+        TestApplicationContext.register(ReportStreamEndpointClient, ReportStreamEndpointClient.getInstance())
+    }
+
+    def "sendRequestBody works"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().sendRequestBody("message_1", "fake token")
+        ReportStreamEndpointClient.getInstance().sendRequestBody("message_2", "fake token")
+
+        then:
+        2 * mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> "200"
+    }
+
+    def "sendRequestBody fails from an IOException from the client"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> { throw new IOException("oops") }
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().sendRequestBody("message_1", "fake token")
+        ReportStreamEndpointClient.getInstance().sendRequestBody("message_2", "fake token")
+
+        then:
+        def exception = thrown(Exception)
+        exception.getCause().getClass() == IOException
+    }
+
+    def "requestToken works"() {
+        given:
+        def expected = "rs fake token"
+        def mockAuthEngine = Mock(AuthEngine)
+        def mockClient = Mock(HttpClient)
+        def mockSecrets = Mock(Secrets)
+        def mockCache = Mock(Cache)
+        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.register(Secrets, mockSecrets)
+        TestApplicationContext.register(Cache, mockCache)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        mockSecrets.getKey(_ as String) >> "Fake Azure Key"
+        def actual = ReportStreamEndpointClient.getInstance().requestToken()
+
+        then:
+        1 * mockAuthEngine.generateToken(_ as String, _ as String, _ as String, _ as String, 300, _ as String) >> "sender fake token"
+        1 * mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> """{"access_token":"${expected}", "token_type":"bearer"}"""
+        actual == expected
+    }
+
+    def "requestToken saves our private key only after successful call to RS"() {
+        given:
+        def mockSecrets = Mock(Secrets)
+        def mockCache = Mock(Cache)
+        def mockFormatter = Mock(Formatter)
+
+        def fakeOurPrivateKey = "DogCow" // pragma: allowlist secret
+        mockSecrets.getKey(_ as String) >> fakeOurPrivateKey
+        mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
+
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(HttpClient, Mock(HttpClient))
+        TestApplicationContext.register(Formatter, mockFormatter)
+        TestApplicationContext.register(Secrets, mockSecrets)
+        TestApplicationContext.register(Cache, mockCache)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().requestToken()
+
+        then:
+        1 * mockCache.put(_ as String, fakeOurPrivateKey)
+    }
+
+    def "requestToken doesn't cache our private key if RS auth call fails"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        def mockCache = Mock(Cache)
+        def mockFormatter = Mock(Formatter)
+
+        mockClient.post(_, _, _) >> { throw new HttpClientException("Fake failure", new NullPointerException()) }
+
+        mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
+
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(Formatter, mockFormatter)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
+        TestApplicationContext.register(Cache, mockCache)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().requestToken()
+
+        then:
+        thrown(UnableToSendOrderException)
+        0 * mockCache.put(_ , _)
+    }
+
+    def "cacheOurPrivateKeyIfNotCachedAlready doesn't cache when the key is already is cached"() {
+        given:
+        def mockCache = Mock(Cache)
+        mockCache.get(_ as String) >> "DogCow private key"
+
+        TestApplicationContext.register(Cache, mockCache)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
+
+        then:
+        0 * mockCache.put(_, _)
+    }
+
+    def "cacheOurPrivateKeyIfNotCachedAlready caches when the key isn't cached"() {
+        given:
+        def mockCache = Mock(Cache)
+        mockCache.get(_ as String) >> null
+
+        TestApplicationContext.register(Cache, mockCache)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamEndpointClient.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
+
+        then:
+        1 * mockCache.put(_, _)
+    }
+
+    def "extractToken works"() {
+        given:
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        def expected = "IaMAfaKEt0keNN"
+        def responseBody = """{"foo":"foo value", "access_token":"${expected}", "boo":"boo value"}"""
+
+        when:
+        def actual = ReportStreamEndpointClient.getInstance().extractToken(responseBody)
+
+        then:
+        actual == expected
+    }
+
+    def "extractToken works when access_token is a number"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        def mockCache = Mock(Cache)
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(Cache, mockCache)
+        TestApplicationContext.injectRegisteredImplementations()
+        def expectedTokenValue = "3"
+
+        def responseBody = """{"foo":"foo value", "access_token": 3, "boo":"boo value"}"""
+        mockClient.post(_ as String, _ as Map, _ as String) >> responseBody
+
+        when:
+        def actualTokenValue = ReportStreamEndpointClient.getInstance().requestToken()
+
+        then:
+        actualTokenValue == expectedTokenValue
+    }
+
+    def "extractToken fails from not getting valid JSON from the auth token endpoint"() {
+        given:
+        def clientMock = Mock(HttpClient)
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.register(HttpClient, clientMock)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+
+        def responseBody = """{"foo":"foo value", "access_token":"""
+        clientMock.post(_ as String, _ as Map, _ as String) >> responseBody
+
+        when:
+        ReportStreamEndpointClient.getInstance().requestToken()
+
+        then:
+        def exception = thrown(UnableToSendOrderException)
+        exception.getCause().getClass() == FormatterProcessingException
+    }
+
+    def "composeRequestBody works"() {
+        given:
+        def ReportStreamEndpointClient = ReportStreamEndpointClient.getInstance()
+        def fakeToken = "rsFakeToken"
+        def expected = "scope=flexion.*.report" +
+                "&grant_type=client_credentials" +
+                "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" +
+                "&client_assertion=${fakeToken}"
+        when:
+        def actual = ReportStreamEndpointClient.composeRequestBody(fakeToken)
+        then:
+        actual == expected
+    }
+    def "retrievePrivateKey works when cache is empty" () {
+        given:
+        def mockSecret = Mock(Secrets)
+        def expected = "New Fake Azure Key"
+        mockSecret.getKey(_ as String) >> expected
+        TestApplicationContext.register(Secrets, mockSecret)
+        TestApplicationContext.register(Cache, KeyCache.getInstance())
+        TestApplicationContext.injectRegisteredImplementations()
+        def rsOrderSender = ReportStreamEndpointClient.getInstance()
+        when:
+        def actual = rsOrderSender.retrievePrivateKey()
+
+        then:
+        actual == expected
+    }
+
+    def "retrievePrivateKey works when cache is not empty" () {
+        given:
+        def keyCache = KeyCache.getInstance()
+        def key = "trusted-intermediary-private-key-local"
+        def expected = "existing fake azure key"
+        TestApplicationContext.register(Cache, keyCache)
+        TestApplicationContext.injectRegisteredImplementations()
+        def rsOrderSender = ReportStreamEndpointClient.getInstance()
+
+        when:
+        keyCache.put(key, expected)
+        def actual = rsOrderSender.retrievePrivateKey()
+
+        then:
+        expected == actual
+    }
+
+    def "ensure jwt that expires 15 seconds from now is valid"() {
+        given:
+        def mockAuthEngine = Mock(AuthEngine)
+
+        mockAuthEngine.getExpirationDate(_ as String) >> LocalDateTime.now().plus(20, ChronoUnit.SECONDS)
+
+        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        def isValid = ReportStreamEndpointClient.getInstance().isValidToken("our token from rs")
+
+        then:
+        isValid
+    }
+
+    def "sendRequestBody bombs out due to http exception"() {
+        given:
+        def orderSender = ReportStreamEndpointClient.getInstance()
+        def mockClient = Mock(HttpClient)
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(OrderSender, orderSender)
+        TestApplicationContext.injectRegisteredImplementations()
+
+        mockClient.post(_ as String, _ as Map<String,String>, _ as String) >> {
+            throw new HttpClientException("404",new IOException())
+        }
+
+        when:
+        orderSender.sendRequestBody("json", "bearerToken")
+
+        then:
+        def exception = thrown(UnableToSendOrderException)
+        exception.getCause().getClass() == HttpClientException
+    }
+
+    def "getRsToken when cache is empty we call RS to get a new one"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        def mockFormatter = Mock(Formatter)
+        def mockCache = Mock(Cache)
+
+        //make the cache empty
+        mockCache.get(_ as String) >> null
+
+        def freshTokenFromRs = "new token"
+        mockFormatter.convertJsonToObject(_, _ as TypeReference) >> [access_token: freshTokenFromRs]
+
+        TestApplicationContext.register(Formatter, mockFormatter)
+        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(Cache, mockCache)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        def token = ReportStreamEndpointClient.getInstance().getRsToken()
+
+        then:
+        1 * mockClient.post(_, _, _)
+        token == freshTokenFromRs
+    }
+
+    def "getRsToken when cache token is invalid we call RS to get a new one"() {
+        given:
+        def mockClient = Mock(HttpClient)
+        def mockAuthEngine = Mock(AuthEngine)
+        def mockFormatter = Mock(Formatter)
+        def mockCache = Mock(Cache)
+
+        mockCache.get(_ as String) >> "shouldn't be returned"
+
+        //mock the auth engine so that the JWT looks like it is invalid
+        mockAuthEngine.getExpirationDate(_) >> LocalDateTime.now().plus(10, ChronoUnit.SECONDS)
+
+        def freshTokenFromRs = "new token"
+        mockFormatter.convertJsonToObject(_, _ as TypeReference) >> [access_token: freshTokenFromRs]
+
+        TestApplicationContext.register(Formatter, mockFormatter)
+        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        TestApplicationContext.register(HttpClient, mockClient)
+        TestApplicationContext.register(Cache, mockCache)
+        TestApplicationContext.register(Secrets, Mock(Secrets))
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        def token = ReportStreamEndpointClient.getInstance().getRsToken()
+
+        then:
+        1 * mockClient.post(_, _, _)
+        token == freshTokenFromRs
+    }
+
+    def "getRsToken when cache token is valid, return that cached token"() {
+        given:
+        def mockAuthEngine = Mock(AuthEngine)
+        def mockCache = Mock(Cache)
+
+        def cachedRsToken = "DogCow goes Moof!"
+        mockCache.get(_ as String) >> cachedRsToken
+
+        //mock the auth engine so that the JWT looks valid
+        mockAuthEngine.getExpirationDate(_) >> LocalDateTime.now().plus(60, ChronoUnit.SECONDS)
+
+        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        TestApplicationContext.register(Cache, mockCache)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        def token = ReportStreamEndpointClient.getInstance().getRsToken()
+
+        then:
+        token == cachedRsToken
+    }
+}

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -4,22 +4,17 @@ import gov.hhs.cdc.trustedintermediary.OrderMock
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender
-import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException
-import gov.hhs.cdc.trustedintermediary.external.inmemory.KeyCache
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
 import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine
 import gov.hhs.cdc.trustedintermediary.wrappers.Cache
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir
 import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient
-import gov.hhs.cdc.trustedintermediary.wrappers.HttpClientException
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
 import gov.hhs.cdc.trustedintermediary.wrappers.Secrets
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 import spock.lang.Specification
 
 class ReportStreamOrderSenderTest extends Specification {
@@ -28,223 +23,12 @@ class ReportStreamOrderSenderTest extends Specification {
         TestApplicationContext.reset()
         TestApplicationContext.init()
         TestApplicationContext.register(OrderSender, ReportStreamOrderSender.getInstance())
+        TestApplicationContext.register(ReportStreamEndpointClient, ReportStreamEndpointClient.getInstance())
         TestApplicationContext.register(MetricMetadata, Mock(MetricMetadata))
-    }
-
-    def "sendRequestBody works"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().sendRequestBody("message_1", "fake token")
-        ReportStreamOrderSender.getInstance().sendRequestBody("message_2", "fake token")
-
-        then:
-        2 * mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> "200"
-    }
-
-    def "sendRequestBody fails from an IOException from the client"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> { throw new IOException("oops") }
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().sendRequestBody("message_1", "fake token")
-        ReportStreamOrderSender.getInstance().sendRequestBody("message_2", "fake token")
-
-        then:
-        def exception = thrown(Exception)
-        exception.getCause().getClass() == IOException
-    }
-
-    def "requestToken works"() {
-        given:
-        def expected = "rs fake token"
-        def mockAuthEngine = Mock(AuthEngine)
-        def mockClient = Mock(HttpClient)
-        def mockSecrets = Mock(Secrets)
-        def mockCache = Mock(Cache)
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.register(Secrets, mockSecrets)
-        TestApplicationContext.register(Cache, mockCache)
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        mockSecrets.getKey(_ as String) >> "Fake Azure Key"
-        def actual = ReportStreamOrderSender.getInstance().requestToken()
-
-        then:
-        1 * mockAuthEngine.generateToken(_ as String, _ as String, _ as String, _ as String, 300, _ as String) >> "sender fake token"
-        1 * mockClient.post(_ as String, _ as Map<String, String>, _ as String) >> """{"access_token":"${expected}", "token_type":"bearer"}"""
-        actual == expected
-    }
-
-    def "requestToken saves our private key only after successful call to RS"() {
-        given:
-        def mockSecrets = Mock(Secrets)
-        def mockCache = Mock(Cache)
-        def mockFormatter = Mock(Formatter)
-
-        def fakeOurPrivateKey = "DogCow" // pragma: allowlist secret
-        mockSecrets.getKey(_ as String) >> fakeOurPrivateKey
-        mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
-
-        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
-        TestApplicationContext.register(HttpClient, Mock(HttpClient))
-        TestApplicationContext.register(Formatter, mockFormatter)
-        TestApplicationContext.register(Secrets, mockSecrets)
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().requestToken()
-
-        then:
-        1 * mockCache.put(_ as String, fakeOurPrivateKey)
-    }
-
-    def "requestToken doesn't cache our private key if RS auth call fails"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        def mockCache = Mock(Cache)
-        def mockFormatter = Mock(Formatter)
-
-        mockClient.post(_, _, _) >> { throw new HttpClientException("Fake failure", new NullPointerException()) }
-
-        mockFormatter.convertJsonToObject(_ , _) >> [access_token: "Moof!"]
-
-        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(Formatter, mockFormatter)
-        TestApplicationContext.register(Secrets, Mock(Secrets))
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().requestToken()
-
-        then:
-        thrown(UnableToSendOrderException)
-        0 * mockCache.put(_ , _)
-    }
-
-    def "cacheOurPrivateKeyIfNotCachedAlready doesn't cache when the key is already is cached"() {
-        given:
-        def mockCache = Mock(Cache)
-        mockCache.get(_ as String) >> "DogCow private key"
-
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
-
-        then:
-        0 * mockCache.put(_, _)
-    }
-
-    def "cacheOurPrivateKeyIfNotCachedAlready caches when the key isn't cached"() {
-        given:
-        def mockCache = Mock(Cache)
-        mockCache.get(_ as String) >> null
-
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().cacheOurPrivateKeyIfNotCachedAlready("Moof!")
-
-        then:
-        1 * mockCache.put(_, _)
-    }
-
-    def "extractToken works"() {
-        given:
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.injectRegisteredImplementations()
-
-        def expected = "IaMAfaKEt0keNN"
-        def responseBody = """{"foo":"foo value", "access_token":"${expected}", "boo":"boo value"}"""
-
-        when:
-        def actual = ReportStreamOrderSender.getInstance().extractToken(responseBody)
-
-        then:
-        actual == expected
-    }
-
-    def "extractToken works when access_token is a number"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        def mockCache = Mock(Cache)
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(Secrets, Mock(Secrets))
-        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
-        TestApplicationContext.register(Cache, mockCache)
-        TestApplicationContext.injectRegisteredImplementations()
-        def expectedTokenValue = "3"
-
-        def responseBody = """{"foo":"foo value", "access_token": 3, "boo":"boo value"}"""
-        mockClient.post(_ as String, _ as Map, _ as String) >> responseBody
-
-        when:
-        def actualTokenValue = ReportStreamOrderSender.getInstance().requestToken()
-
-        then:
-        actualTokenValue == expectedTokenValue
-    }
-
-    def "extractToken fails from not getting valid JSON from the auth token endpoint"() {
-        given:
-        def clientMock = Mock(HttpClient)
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.register(HttpClient, clientMock)
-        TestApplicationContext.register(Secrets, Mock(Secrets))
-        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-        TestApplicationContext.injectRegisteredImplementations()
-
-        def responseBody = """{"foo":"foo value", "access_token":"""
-        clientMock.post(_ as String, _ as Map, _ as String) >> responseBody
-
-        when:
-        ReportStreamOrderSender.getInstance().requestToken()
-
-        then:
-        def exception = thrown(UnableToSendOrderException)
-        exception.getCause().getClass() == FormatterProcessingException
-    }
-
-    def "composeRequestBody works"() {
-        given:
-        def reportStreamOrderSender = ReportStreamOrderSender.getInstance()
-        def fakeToken = "rsFakeToken"
-        def expected = "scope=flexion.*.report" +
-                "&grant_type=client_credentials" +
-                "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" +
-                "&client_assertion=${fakeToken}"
-        when:
-        def actual = reportStreamOrderSender.composeRequestBody(fakeToken)
-        then:
-        actual == expected
     }
 
     def "send order works"() {
         given:
-        def orderSender = ReportStreamOrderSender.getInstance()
-        TestApplicationContext.register(OrderSender, orderSender)
-
         def mockAuthEngine = Mock(AuthEngine)
         TestApplicationContext.register(AuthEngine, mockAuthEngine)
 
@@ -274,6 +58,7 @@ class ReportStreamOrderSenderTest extends Specification {
         then:
         noExceptionThrown()
     }
+
     def "log the step to metadata when send order is called"() {
         given:
 
@@ -305,157 +90,6 @@ class ReportStreamOrderSenderTest extends Specification {
 
         then:
         1 * ReportStreamOrderSender.getInstance().metadata.put(_, EtorMetadataStep.SENT_TO_REPORT_STREAM)
-    }
-
-    def "retrievePrivateKey works when cache is empty" () {
-        given:
-        def mockSecret = Mock(Secrets)
-        def expected = "New Fake Azure Key"
-        mockSecret.getKey(_ as String) >> expected
-        TestApplicationContext.register(Secrets, mockSecret)
-        TestApplicationContext.register(Cache, KeyCache.getInstance())
-        TestApplicationContext.injectRegisteredImplementations()
-        def rsOrderSender = ReportStreamOrderSender.getInstance()
-        when:
-        def actual = rsOrderSender.retrievePrivateKey()
-
-        then:
-        actual == expected
-    }
-
-    def "retrievePrivateKey works when cache is not empty" () {
-        given:
-        def keyCache = KeyCache.getInstance()
-        def key = "trusted-intermediary-private-key-local"
-        def expected = "existing fake azure key"
-        TestApplicationContext.register(Cache, keyCache)
-        TestApplicationContext.injectRegisteredImplementations()
-        def rsOrderSender = ReportStreamOrderSender.getInstance()
-
-        when:
-        keyCache.put(key, expected)
-        def actual = rsOrderSender.retrievePrivateKey()
-
-        then:
-        expected == actual
-    }
-
-    def "ensure jwt that expires 15 seconds from now is valid"() {
-        given:
-        def mockAuthEngine = Mock(AuthEngine)
-
-        mockAuthEngine.getExpirationDate(_ as String) >> LocalDateTime.now().plus(20, ChronoUnit.SECONDS)
-
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        def isValid = ReportStreamOrderSender.getInstance().isValidToken("our token from rs")
-
-        then:
-        isValid
-    }
-
-    def "sendRequestBody bombs out due to http exception"() {
-        given:
-        def orderSender = ReportStreamOrderSender.getInstance()
-        def mockClient = Mock(HttpClient)
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(OrderSender, orderSender)
-        TestApplicationContext.injectRegisteredImplementations()
-
-        mockClient.post(_ as String, _ as Map<String,String>, _ as String) >> {
-            throw new HttpClientException("404",new IOException())
-        }
-
-        when:
-        orderSender.sendRequestBody("json", "bearerToken")
-
-        then:
-        def exception = thrown(UnableToSendOrderException)
-        exception.getCause().getClass() == HttpClientException
-    }
-
-    def "getRsToken when cache is empty we call RS to get a new one"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        def mockFormatter = Mock(Formatter)
-        def mockCache = Mock(Cache)
-
-        //make the cache empty
-        mockCache.get(_ as String) >> null
-
-        def freshTokenFromRs = "new token"
-        mockFormatter.convertJsonToObject(_, _ as TypeReference) >> [access_token: freshTokenFromRs]
-
-        TestApplicationContext.register(Formatter, mockFormatter)
-        TestApplicationContext.register(AuthEngine, Mock(AuthEngine))
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(Cache, mockCache)
-        TestApplicationContext.register(Secrets, Mock(Secrets))
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        def token = ReportStreamOrderSender.getInstance().getRsToken()
-
-        then:
-        1 * mockClient.post(_, _, _)
-        token == freshTokenFromRs
-    }
-
-    def "getRsToken when cache token is invalid we call RS to get a new one"() {
-        given:
-        def mockClient = Mock(HttpClient)
-        def mockAuthEngine = Mock(AuthEngine)
-        def mockFormatter = Mock(Formatter)
-        def mockCache = Mock(Cache)
-
-        mockCache.get(_ as String) >> "shouldn't be returned"
-
-        //mock the auth engine so that the JWT looks like it is invalid
-        mockAuthEngine.getExpirationDate(_) >> LocalDateTime.now().plus(10, ChronoUnit.SECONDS)
-
-        def freshTokenFromRs = "new token"
-        mockFormatter.convertJsonToObject(_, _ as TypeReference) >> [access_token: freshTokenFromRs]
-
-        TestApplicationContext.register(Formatter, mockFormatter)
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-        TestApplicationContext.register(HttpClient, mockClient)
-        TestApplicationContext.register(Cache, mockCache)
-        TestApplicationContext.register(Secrets, Mock(Secrets))
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        def token = ReportStreamOrderSender.getInstance().getRsToken()
-
-        then:
-        1 * mockClient.post(_, _, _)
-        token == freshTokenFromRs
-    }
-
-    def "getRsToken when cache token is valid, return that cached token"() {
-        given:
-        def mockAuthEngine = Mock(AuthEngine)
-        def mockCache = Mock(Cache)
-
-        def cachedRsToken = "DogCow goes Moof!"
-        mockCache.get(_ as String) >> cachedRsToken
-
-        //mock the auth engine so that the JWT looks valid
-        mockAuthEngine.getExpirationDate(_) >> LocalDateTime.now().plus(60, ChronoUnit.SECONDS)
-
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        def token = ReportStreamOrderSender.getInstance().getRsToken()
-
-        then:
-        token == cachedRsToken
     }
 
     def "getSubmissionId logs submissionId if convertJsonToObject is successful"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -458,7 +458,7 @@ class ReportStreamOrderSenderTest extends Specification {
         token == cachedRsToken
     }
 
-    def "logRsSubmissionId logs submissionId if convertJsonToObject is successful"() {
+    def "getSubmissionId logs submissionId if convertJsonToObject is successful"() {
         given:
         def mockSubmissionId = "fake-id"
         def mockResponseBody = """{"submissionId": "${mockSubmissionId}", "key": "value"}"""
@@ -471,13 +471,13 @@ class ReportStreamOrderSenderTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamOrderSender.getInstance().logRsSubmissionId(mockResponseBody)
+        def submissionId = ReportStreamOrderSender.getInstance().getSubmissionId(mockResponseBody)
 
         then:
-        1 * mockLogger.logInfo(_ as String, mockSubmissionId)
+        submissionId.get() == mockSubmissionId
     }
 
-    def "logRsSubmissionId logs error if convertJsonToObject fails"() {
+    def "getSubmissionId logs error if convertJsonToObject fails"() {
         given:
         def mockResponseBody = '{"submissionId": "fake-id", "key": "value"}'
         def exception = new FormatterProcessingException("couldn't convert json", new Exception())
@@ -492,7 +492,7 @@ class ReportStreamOrderSenderTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamOrderSender.getInstance().logRsSubmissionId(mockResponseBody)
+        ReportStreamOrderSender.getInstance().getSubmissionId(mockResponseBody)
 
         then:
         1 * mockLogger.logError(_ as String, exception)

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
@@ -38,7 +38,19 @@ public class ApacheClient implements HttpClient {
                     .asString();
         } catch (IOException e) {
             throw new HttpClientException(
-                    "Error occurred while making HTTP request to [" + url + "]", e);
+                    "Error occurred while making HTTP POST request to [" + url + "]", e);
+        }
+    }
+
+    @Override
+    public String get(String url, Map<String, String> headerMap) throws HttpClientException {
+        Header[] headers = convertMapToHeader(headerMap);
+
+        try {
+            return Request.get(url).setHeaders(headers).execute().returnContent().asString();
+        } catch (IOException e) {
+            throw new HttpClientException(
+                    "Error occurred while making HTTP GET request to [" + url + "]", e);
         }
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClient.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/wrappers/HttpClient.java
@@ -4,5 +4,7 @@ import java.util.Map;
 
 /** This interface provides a generic blueprint for HTTP operations */
 public interface HttpClient {
-    String post(String path, Map<String, String> headerMap, String body) throws HttpClientException;
+    String post(String url, Map<String, String> headerMap, String body) throws HttpClientException;
+
+    String get(String url, Map<String, String> headerMap) throws HttpClientException;
 }


### PR DESCRIPTION
# Call the history API for outbound orders

- Changed OrderSender.sendOrder to return the sent submissionId (as optional)
- Refactored `ReportStreamOrderSender` and created a more generic `ReportStreamEndpointClient`
- Added call to RS history API to get the receiver name and update metadata 
- Changes to `PartnerMetadata` record
  -  Added `sentSubmissionId` and renamed `uniqueId` to `receivedSubmissionId`
  - Overloaded constructor and added `withSentSubmissionId` and `withReceiver` to update record
-  Changes to `HttpClient`
  - Added `get` http method and implemented in `ApacheClient` 

## Issue

#672 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
