### PR TITLE
672: Write Metadata Even If RS History API Fails

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -25,6 +25,10 @@ public record PartnerMetadata(
         this(receivedSubmissionId, null, sender, null, timeReceived, hash);
     }
 
+    public PartnerMetadata(String receivedSubmissionId, String hash) {
+        this(receivedSubmissionId, null, null, null, null, hash);
+    }
+
     public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -54,6 +54,14 @@ public class PartnerMetadataOrchestrator {
             timeReceived = Instant.parse(timestamp);
 
         } catch (Exception e) {
+            // write the received submission ID so that the rest of the metadata flow works even if
+            // some data is missing
+            logger.logWarning(
+                    "Unable to retrieve metadata from RS history API, but writing basic metadata entry anyway for received submission ID {}",
+                    receivedSubmissionId);
+            PartnerMetadata partnerMetadata = new PartnerMetadata(receivedSubmissionId, orderHash);
+            partnerMetadataStorage.saveMetadata(partnerMetadata);
+
             throw new PartnerMetadataException(
                     "Unable to retrieve metadata from RS history API", e);
         }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -101,6 +101,9 @@ class PartnerMetadataOrchestratorTest extends Specification {
         PartnerMetadataOrchestrator.getInstance().updateMetadataForReceivedOrder(receivedSubmissionId, "hash")
 
         then:
+        1 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata) >> { PartnerMetadata metadata ->
+            assert metadata.receivedSubmissionId() == receivedSubmissionId
+        }
         thrown(PartnerMetadataException)
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -54,6 +54,23 @@ class PartnerMetadataTest extends Specification {
         metadata.hash() == hash
     }
 
+    def "test constructor with only received submission ID and hash"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def hash = "abcd"
+
+        when:
+        def metadata = new PartnerMetadata(receivedSubmissionId, hash)
+
+        then:
+        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.sentSubmissionId() == null
+        metadata.sender() == null
+        metadata.receiver() == null
+        metadata.timeReceived() == null
+        metadata.hash() == hash
+    }
+
     def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"


### PR DESCRIPTION
# Write Metadata Even If RS History API Fails

Because the RS history API always fails given the submission ID we are given, we never write a metadata entry.  That then makes the subsequent updates fail that happen later on.  We don't want them to fail, so we should write at least what we do know: the submission ID and hash.

## Issue

#672.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
