### PR TITLE
Story 610 metadata order status

### DIFF
--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Db migration
         run: |
           export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
-          psql "host=$(terraform output -raw database_hostname) port=5432 dbname=postgres user=cdcti-github sslmode=require" -c "CREATE TABLE IF NOT EXISTS metadata (received_message_id varchar(40) PRIMARY KEY, sent_message_id varchar(40), sender varchar(30), receiver varchar(30), hash_of_order varchar(1000), time_received timestamptz); GRANT ALL ON metadata TO azure_pg_admin; ALTER TABLE metadata OWNER TO azure_pg_admin;"
+          psql "host=$(terraform output -raw database_hostname) port=5432 dbname=postgres user=cdcti-github sslmode=require" -c "CREATE TYPE message_status AS ENUM ('PENDING', 'DELIVERED', 'FAILED'); CREATE TABLE IF NOT EXISTS metadata (received_message_id varchar(40) PRIMARY KEY, sent_message_id varchar(40), sender varchar(30), receiver varchar(30), hash_of_order varchar(1000), time_received timestamptz, delivery_status message_status); GRANT ALL ON metadata TO azure_pg_admin; ALTER TABLE metadata OWNER TO azure_pg_admin;"
 
       - id: export-terraform-output
         name: Export Terraform Output

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -108,8 +108,9 @@ public class EtorDomainRegistration implements DomainConnector {
         } else {
             ApplicationContext.register(
                     RSEndpointClient.class, ReportStreamEndpointClient.getInstance());
+
+            ApplicationContext.register(AzureClient.class, AzureClient.getInstance());
         }
-        ApplicationContext.register(AzureClient.class, AzureClient.getInstance());
         return endpoints;
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -108,9 +108,8 @@ public class EtorDomainRegistration implements DomainConnector {
         } else {
             ApplicationContext.register(
                     RSEndpointClient.class, ReportStreamEndpointClient.getInstance());
-            ApplicationContext.register(AzureClient.class, AzureClient.getInstance());
         }
-
+        ApplicationContext.register(AzureClient.class, AzureClient.getInstance());
         return endpoints;
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -26,6 +26,7 @@ import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureStorageAccountPartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.database.DatabasePartnerMetadataStorage;
+import gov.hhs.cdc.trustedintermediary.external.database.DbDao;
 import gov.hhs.cdc.trustedintermediary.external.database.EtorSqlDriverManager;
 import gov.hhs.cdc.trustedintermediary.external.database.PostgresDao;
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiOrderConverter;
@@ -33,7 +34,6 @@ import gov.hhs.cdc.trustedintermediary.external.localfile.FilePartnerMetadataSto
 import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamOrderSender;
-import gov.hhs.cdc.trustedintermediary.external.database.DbDao;
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -33,7 +33,7 @@ import gov.hhs.cdc.trustedintermediary.external.localfile.FilePartnerMetadataSto
 import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamOrderSender;
-import gov.hhs.cdc.trustedintermediary.wrappers.DbDao;
+import gov.hhs.cdc.trustedintermediary.external.database.DbDao;
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -23,6 +23,13 @@ public record PartnerMetadata(
         String hash,
         PartnerMetadataStatus deliveryStatus) {
 
+    // Below is for defaulting status when null
+    public PartnerMetadata {
+        if (deliveryStatus == null) {
+            deliveryStatus = PartnerMetadataStatus.PENDING;
+        }
+    }
+
     public PartnerMetadata(
             String receivedSubmissionId,
             String sender,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -12,6 +12,7 @@ import java.time.Instant;
  * @param receiver The name of the receiver of the message.
  * @param timeReceived The time the message was received.
  * @param hash The hash of the message.
+ * @param deliveryStatus the status of the message based on an enum
  */
 public record PartnerMetadata(
         String receivedSubmissionId,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -1,5 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 import java.time.Instant;
 
 /**
@@ -18,15 +19,20 @@ public record PartnerMetadata(
         String sender,
         String receiver,
         Instant timeReceived,
-        String hash) {
+        String hash,
+        PartnerMetadataStatus deliveryStatus) {
 
     public PartnerMetadata(
-            String receivedSubmissionId, String sender, Instant timeReceived, String hash) {
-        this(receivedSubmissionId, null, sender, null, timeReceived, hash);
+            String receivedSubmissionId,
+            String sender,
+            Instant timeReceived,
+            String hash,
+            PartnerMetadataStatus deliveryStatus) {
+        this(receivedSubmissionId, null, sender, null, timeReceived, hash, deliveryStatus);
     }
 
     public PartnerMetadata(String receivedSubmissionId, String hash) {
-        this(receivedSubmissionId, null, null, null, null, hash);
+        this(receivedSubmissionId, null, null, null, null, hash, null);
     }
 
     public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
@@ -36,7 +42,8 @@ public record PartnerMetadata(
                 this.sender,
                 this.receiver,
                 this.timeReceived,
-                this.hash);
+                this.hash,
+                this.deliveryStatus);
     }
 
     public PartnerMetadata withReceiver(String receiver) {
@@ -46,6 +53,7 @@ public record PartnerMetadata(
                 this.sender,
                 receiver,
                 this.timeReceived,
-                this.hash);
+                this.hash,
+                this.deliveryStatus);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -72,7 +72,12 @@ public class PartnerMetadataOrchestrator {
                 sender,
                 timeReceived);
         PartnerMetadata partnerMetadata =
-                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, orderHash, PartnerMetadataStatus.PENDING);
+                new PartnerMetadata(
+                        receivedSubmissionId,
+                        sender,
+                        timeReceived,
+                        orderHash,
+                        PartnerMetadataStatus.PENDING);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -1,6 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata;
 
 import gov.hhs.cdc.trustedintermediary.etor.RSEndpointClient;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClientException;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
@@ -71,7 +72,7 @@ public class PartnerMetadataOrchestrator {
                 sender,
                 timeReceived);
         PartnerMetadata partnerMetadata =
-                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, orderHash, null);
+                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, orderHash, PartnerMetadataStatus.PENDING);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -71,7 +71,7 @@ public class PartnerMetadataOrchestrator {
                 sender,
                 timeReceived);
         PartnerMetadata partnerMetadata =
-                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, orderHash);
+                new PartnerMetadata(receivedSubmissionId, sender, timeReceived, orderHash, null);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStatus.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStatus.java
@@ -1,0 +1,7 @@
+package gov.hhs.cdc.trustedintermediary.etor.metadata.partner;
+
+public enum PartnerMetadataStatus {
+    PENDING,
+    DELIVERED,
+    FAILED
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStatus.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStatus.java
@@ -1,5 +1,9 @@
 package gov.hhs.cdc.trustedintermediary.etor.metadata.partner;
 
+/**
+ * Enum for tracking the status of a message for diagnostic purposes. We store the status in our
+ * database
+ */
 public enum PartnerMetadataStatus {
     PENDING,
     DELIVERED,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -44,7 +44,8 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                     metadata.sender(),
                     metadata.receiver(),
                     metadata.hash(),
-                    metadata.timeReceived());
+                    metadata.timeReceived(),
+                    metadata.deliveryStatus());
         } catch (SQLException e) {
             throw new PartnerMetadataException("Error saving metadata", e);
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -3,7 +3,6 @@ package gov.hhs.cdc.trustedintermediary.external.database;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
-import gov.hhs.cdc.trustedintermediary.wrappers.DbDao;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import java.sql.SQLException;
 import java.util.Optional;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.external.database;
 
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
-
 import java.sql.SQLException;
 import java.time.Instant;
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
@@ -1,4 +1,6 @@
-package gov.hhs.cdc.trustedintermediary.wrappers;
+package gov.hhs.cdc.trustedintermediary.external.database;
+
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 
 import java.sql.SQLException;
 import java.time.Instant;
@@ -11,7 +13,8 @@ public interface DbDao {
             String sender,
             String receiver,
             String hash,
-            Instant timeReceived)
+            Instant timeReceived,
+            PartnerMetadataStatus deliveryStatus)
             throws SQLException;
 
     Object fetchMetadata(String uniqueId) throws SQLException;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
@@ -143,11 +143,6 @@ public class PostgresDao implements DbDao {
                 timeReceived = timestamp.toInstant();
             }
 
-            String status =
-                    result.getString("delivery_status") != null
-                            ? result.getString("delivery_status")
-                            : "PENDING";
-
             return new PartnerMetadata(
                     result.getString("received_message_id"),
                     result.getString("sent_message_id"),
@@ -155,7 +150,7 @@ public class PostgresDao implements DbDao {
                     result.getString("receiver"),
                     timeReceived,
                     result.getString("hash_of_order"),
-                    PartnerMetadataStatus.valueOf(status));
+                    PartnerMetadataStatus.valueOf(result.getString("delivery_status")));
         }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
@@ -4,7 +4,6 @@ import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient;
-import gov.hhs.cdc.trustedintermediary.wrappers.DbDao;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.SqlDriverManager;
 import java.sql.Connection;
@@ -87,14 +86,15 @@ public class PostgresDao implements DbDao {
             String sender,
             String receiver,
             String hash,
-            Instant timeReceived)
+            Instant timeReceived,
+            PartnerMetadataStatus deliveryStatus)
             throws SQLException {
 
         try (Connection conn = connect();
                 PreparedStatement statement =
                         conn.prepareStatement(
                                 """
-                                INSERT INTO metadata VALUES (?, ?, ?, ?, ?, ?)
+                                INSERT INTO metadata VALUES (?, ?, ?, ?, ?, ?, ?)
                                 ON CONFLICT (received_message_id) DO UPDATE SET receiver = EXCLUDED.receiver, sent_message_id = EXCLUDED.sent_message_id
                                 """)) {
 
@@ -109,6 +109,7 @@ public class PostgresDao implements DbDao {
                 timestamp = Timestamp.from(timeReceived);
             }
             statement.setTimestamp(6, timestamp);
+            statement.setString(7, deliveryStatus.toString());
 
             statement.executeUpdate();
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.database;
 
 import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient;
 import gov.hhs.cdc.trustedintermediary.wrappers.DbDao;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
@@ -135,13 +136,19 @@ public class PostgresDao implements DbDao {
                 timeReceived = timestamp.toInstant();
             }
 
+            String status =
+                    result.getString("delivery_status") != null
+                            ? result.getString("delivery_status")
+                            : "PENDING";
+
             return new PartnerMetadata(
                     result.getString("received_message_id"),
                     result.getString("sent_message_id"),
                     result.getString("sender"),
                     result.getString("receiver"),
                     timeReceived,
-                    result.getString("hash_of_order"));
+                    result.getString("hash_of_order"),
+                    PartnerMetadataStatus.valueOf(status));
         }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
@@ -109,7 +109,13 @@ public class PostgresDao implements DbDao {
                 timestamp = Timestamp.from(timeReceived);
             }
             statement.setTimestamp(6, timestamp);
-            statement.setString(7, deliveryStatus.toString());
+
+            String deliveryStatusString = null;
+            if (deliveryStatus != null) {
+                deliveryStatusString = deliveryStatus.toString();
+            }
+
+            statement.setString(7, deliveryStatusString);
 
             statement.executeUpdate();
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -225,6 +225,12 @@ public class HapiOrderConverter implements OrderConverter {
                 .add(createInformationIssueComponent("order ingestion", orderIngestion));
         operation.getIssue().add(createInformationIssueComponent("payload hash", metadata.hash()));
 
+        operation
+                .getIssue()
+                .add(
+                        createInformationIssueComponent(
+                                "delivery status", metadata.deliveryStatus().toString()));
+
         return new HapiFhirMetadata(operation);
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -14,6 +14,7 @@ import gov.hhs.cdc.trustedintermediary.etor.demographics.PatientDemographicsResp
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataOrchestrator
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import gov.hhs.cdc.trustedintermediary.etor.operationoutcomes.FhirMetadata
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController
@@ -324,7 +325,7 @@ class EtorDomainRegistrationTest extends Specification {
         request.setPathParams(["id": "metadataId"])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
-        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), "hash"))
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), "hash", PartnerMetadataStatus.DELIVERED))
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -74,7 +74,8 @@ class PartnerMetadataTest extends Specification {
         metadata.receiver() == null
         metadata.timeReceived() == null
         metadata.hash() == hash
-        metadata.deliveryStatus() == null
+        //Status should default to PENDING
+        metadata.deliveryStatus() == PartnerMetadataStatus.PENDING
     }
 
     def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -2,6 +2,8 @@ package gov.hhs.cdc.trustedintermediary.etor.metadata
 
 
 import gov.hhs.cdc.trustedintermediary.PojoTestUtils
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
+
 import java.time.Instant
 import spock.lang.Specification
 
@@ -22,9 +24,10 @@ class PartnerMetadataTest extends Specification {
         def receiver = "receiver"
         def timeReceived = Instant.now()
         def hash = "abcd"
+        def status = PartnerMetadataStatus.DELIVERED
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash, PartnerMetadataStatus.DELIVERED)
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
@@ -33,6 +36,7 @@ class PartnerMetadataTest extends Specification {
         metadata.receiver() == receiver
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
+        metadata.deliveryStatus() == status
     }
 
     def "test overloaded constructor"() {
@@ -41,9 +45,9 @@ class PartnerMetadataTest extends Specification {
         def sender = "sender"
         def timeReceived = Instant.now()
         def hash = "abcd"
-
+        def status = PartnerMetadataStatus.DELIVERED
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash, PartnerMetadataStatus.DELIVERED)
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
@@ -52,6 +56,7 @@ class PartnerMetadataTest extends Specification {
         metadata.receiver() == null
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
+        metadata.deliveryStatus() == status
     }
 
     def "test constructor with only received submission ID and hash"() {
@@ -69,6 +74,7 @@ class PartnerMetadataTest extends Specification {
         metadata.receiver() == null
         metadata.timeReceived() == null
         metadata.hash() == hash
+        metadata.deliveryStatus() == null
     }
 
     def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {
@@ -79,7 +85,8 @@ class PartnerMetadataTest extends Specification {
         def receiver = "receiver"
         def timeReceived = Instant.now()
         def hash = "abcd"
-        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash)
+        def status = PartnerMetadataStatus.DELIVERED
+        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash, status)
 
         when:
         def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withReceiver(receiver)
@@ -91,5 +98,6 @@ class PartnerMetadataTest extends Specification {
         updatedMetadata.receiver() == receiver
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.hash() == hash
+        updatedMetadata.deliveryStatus() == status
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
@@ -6,6 +6,7 @@ import com.azure.storage.blob.BlobClient
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
 import java.time.Instant
@@ -27,8 +28,9 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
         def expectedReceiver = "receiver"
         def expectedTimestamp = Instant.parse("2023-12-04T18:51:48.941875Z")
         def expectedHash = "abcd"
+        PartnerMetadataStatus status = PartnerMetadataStatus.PENDING
 
-        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, expectedSender, expectedReceiver, expectedTimestamp, expectedHash)
+        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, expectedSender, expectedReceiver, expectedTimestamp, expectedHash, status)
 
         String simulatedMetadataJson = """{
             "receivedSubmissionId": "${expectedReceivedSubmissionId}",
@@ -36,7 +38,8 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
             "sender": "${expectedSender}",
             "receiver": "${expectedReceiver}",
             "timeReceived": "${expectedTimestamp}",
-            "hash": "${expectedHash}"
+            "hash": "${expectedHash}",
+            "deliveryStatus": "${status}"
         }"""
 
         def mockBlobClient = Mock(BlobClient)
@@ -97,7 +100,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "successfully save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED)
 
         def mockBlobClient = Mock(BlobClient)
         def azureClient = Mock(AzureClient)
@@ -119,7 +122,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "failed to save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED)
 
         def mockBlobClient = Mock(BlobClient)
         mockBlobClient.upload(_ as BinaryData, true) >> { throw new AzureException("upload failed") }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -4,6 +4,7 @@ import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import spock.lang.Specification
 
 import java.sql.SQLException
@@ -27,7 +28,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
     def "readMetadata happy path works"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def mockMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), "hash")
+        def mockMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), "hash", PartnerMetadataStatus.PENDING)
         def expectedResult = Optional.of(mockMetadata)
 
         mockDao.fetchMetadata(_ as String) >> mockMetadata
@@ -60,7 +61,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 "sender",
                 "receiver",
                 Instant.now(),
-                "hash"
+                "hash",
+                PartnerMetadataStatus.PENDING
                 )
 
         when:
@@ -73,7 +75,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 mockMetadata.sender(),
                 mockMetadata.receiver(),
                 mockMetadata.hash(),
-                mockMetadata.timeReceived()
+                mockMetadata.timeReceived(),
+                mockMetadata.deliveryStatus()
                 )
     }
 
@@ -86,7 +89,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 "sender",
                 "receiver",
                 Instant.now(),
-                "hash"
+                "hash",
+                PartnerMetadataStatus.FAILED
                 )
 
         mockDao.upsertMetadata(
@@ -95,7 +99,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 mockMetadata.sender(),
                 mockMetadata.receiver(),
                 mockMetadata.hash(),
-                mockMetadata.timeReceived()
+                mockMetadata.timeReceived(),
+                mockMetadata.deliveryStatus()
                 ) >> { throw new SQLException("Something went wrong!") }
 
         when:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -4,7 +4,6 @@ import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage
-import gov.hhs.cdc.trustedintermediary.wrappers.DbDao
 import spock.lang.Specification
 
 import java.sql.SQLException

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
@@ -73,7 +73,7 @@ class PostgresDaoTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", Instant.now())
+        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", Instant.now(), PartnerMetadataStatus.PENDING)
 
         then:
         1 * mockPreparedStatement.executeUpdate()
@@ -88,7 +88,7 @@ class PostgresDaoTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", Instant.now())
+        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", Instant.now(), PartnerMetadataStatus.DELIVERED)
 
         then:
         thrown(SQLException)
@@ -103,7 +103,7 @@ class PostgresDaoTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", null)
+        PostgresDao.getInstance().upsertMetadata("mock_id_receiver", "mock_id_sender", "mock_sender", "mock_receiver", "mock_hash", null, PartnerMetadataStatus.DELIVERED)
 
         then:
         mockPreparedStatement.setTimestamp(_ as Integer, _) >> { Integer parameterIndex, Timestamp timestamp ->

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
@@ -171,7 +171,7 @@ class PostgresDaoTest extends Specification {
         Timestamp timestampForMock = Timestamp.from(Instant.parse("2024-01-03T15:45:33.30Z"))
         Instant timeReceived = timestampForMock.toInstant()
         def hash = sender.hashCode().toString()
-        def status = PartnerMetadataStatus.DELIVERED
+        def status = PartnerMetadataStatus.PENDING
         def expected = new PartnerMetadata(receivedMessageId, sentMessageId, sender, null, timeReceived, hash, status)
 
         mockDriver.getConnection(_ as String, _ as Properties) >> mockConn

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
@@ -2,6 +2,7 @@ package gov.hhs.cdc.trustedintermediary.external.database
 
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient
 import gov.hhs.cdc.trustedintermediary.wrappers.SqlDriverManager
 import spock.lang.Specification
@@ -117,7 +118,7 @@ class PostgresDaoTest extends Specification {
         mockPreparedStatement.executeQuery() >> mockResultSet
         mockResultSet.next() >> true
         mockResultSet.getTimestamp(_ as String) >> Timestamp.from(Instant.now())
-
+        mockResultSet.getString("delivery_status") >> "DELIVERED"
         TestApplicationContext.register(SqlDriverManager, mockDriver)
         TestApplicationContext.injectRegisteredImplementations()
 
@@ -170,7 +171,8 @@ class PostgresDaoTest extends Specification {
         Timestamp timestampForMock = Timestamp.from(Instant.parse("2024-01-03T15:45:33.30Z"))
         Instant timeReceived = timestampForMock.toInstant()
         def hash = sender.hashCode().toString()
-        def expected = new PartnerMetadata(receivedMessageId, sentMessageId, sender, null, timeReceived, hash)
+        def status = PartnerMetadataStatus.DELIVERED
+        def expected = new PartnerMetadata(receivedMessageId, sentMessageId, sender, null, timeReceived, hash, status)
 
         mockDriver.getConnection(_ as String, _ as Properties) >> mockConn
         mockConn.prepareStatement(_ as String) >>  mockPreparedStatement
@@ -181,6 +183,7 @@ class PostgresDaoTest extends Specification {
         mockResultSet.getString("receiver") >> null
         mockResultSet.getTimestamp("time_received") >> timestampForMock
         mockResultSet.getString("hash_of_order") >> hash
+        mockResultSet.getString("delivery_status") >> status.toString()
         mockPreparedStatement.executeQuery() >> mockResultSet
 
         TestApplicationContext.register(SqlDriverManager, mockDriver)
@@ -200,7 +203,7 @@ class PostgresDaoTest extends Specification {
         mockPreparedStatement.executeQuery() >> mockResultSet
         mockResultSet.next() >> true
         mockResultSet.getTimestamp("time_received") >> null
-
+        mockResultSet.getString("delivery_status") >> "DELIVERED"
         TestApplicationContext.register(SqlDriverManager, mockDriver)
         TestApplicationContext.injectRegisteredImplementations()
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
@@ -5,6 +5,7 @@ import gov.hhs.cdc.trustedintermediary.OrderMock
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderConverter
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import org.hl7.fhir.r4.model.Address
 import org.hl7.fhir.r4.model.ContactPoint
 import org.hl7.fhir.r4.model.Extension
@@ -296,5 +297,27 @@ class HapiOrderConverterTest extends Specification {
         patient.addAddress(address)
 
         return patient
+    }
+
+    def "ExtractPublicMetadata to OperationOutcome returns FHIR metadata"() {
+        given:
+
+        def sender = "sender"
+        def receiver = "receiver"
+        def time = Instant.now()
+        def hash = "hash"
+        PartnerMetadata metadata = new PartnerMetadata(
+                "receivedSubmissionId", "sentSubmissionId", sender, receiver, time, hash, PartnerMetadataStatus.DELIVERED)
+
+        when:
+        def result = HapiOrderConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata).getUnderlyingOutcome() as OperationOutcome
+
+        then:
+        result.getId() == "receivedSubmissionId"
+        result.getIssue().get(0).diagnostics == sender
+        result.getIssue().get(1).diagnostics == receiver
+        result.getIssue().get(2).diagnostics == time.toString()
+        result.getIssue().get(3).diagnostics == hash
+        result.getIssue().get(4).diagnostics == PartnerMetadataStatus.DELIVERED.toString()
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -3,6 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.localfile
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
@@ -23,7 +24,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
         def expectedSentSubmissionId = "receivedSubmissionId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd")
+        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED)
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -38,7 +39,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), "abcd")
+        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED)
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}


### PR DESCRIPTION
# Adding message status to database and ReST endpoint

This PR adds the Order status data to both the database and the ReST endpoint.  We will need to discover the statuses ReportStream uses and add the logic to determine the status as needed to complete the story.

## Issue
#610 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
