### PR TITLE
Set Delivery Status for Internal Failed Order

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -173,7 +173,7 @@ public class EtorDomainRegistration implements DomainConnector {
                 try {
                     partnerMetadataOrchestrator.setMetadataStatus(
                             receivedSubmissionId, PartnerMetadataStatus.FAILED);
-                } catch (PartnerMetadataException innerE) {
+                } catch (PartnerMetadataException | NullPointerException innerE) {
                     logger.logError("Unable to update metadata status", innerE);
                 }
             }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -15,6 +15,7 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataException;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataOrchestrator;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.PartnerMetadataStorage;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus;
 import gov.hhs.cdc.trustedintermediary.etor.operationoutcomes.FhirMetadata;
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController;
@@ -160,11 +161,17 @@ public class EtorDomainRegistration implements DomainConnector {
             sendOrderUseCase.convertAndSend(orders, receivedSubmissionId);
         } catch (FhirParseException e) {
             logger.logError("Unable to parse order request", e);
-            //helper
+            try {
+                partnerMetadataOrchestrator.setMetadataStatus(
+                        receivedSubmissionId, PartnerMetadataStatus.FAILED);
+            } catch (PartnerMetadataException innerE) {
+                logger.logError("Unable to update metadata status", innerE);
+                // possible domain response?
+            }
             return domainResponseHelper.constructErrorResponse(400, e);
         } catch (UnableToSendOrderException e) {
             logger.logError("Unable to send order", e);
-            //helper
+            // setMetadataStatus(receivedSubmissionId)
             return domainResponseHelper.constructErrorResponse(400, e);
         }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -160,9 +160,11 @@ public class EtorDomainRegistration implements DomainConnector {
             sendOrderUseCase.convertAndSend(orders, receivedSubmissionId);
         } catch (FhirParseException e) {
             logger.logError("Unable to parse order request", e);
+            //helper
             return domainResponseHelper.constructErrorResponse(400, e);
         } catch (UnableToSendOrderException e) {
             logger.logError("Unable to send order", e);
+            //helper
             return domainResponseHelper.constructErrorResponse(400, e);
         }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -43,6 +43,10 @@ public record PartnerMetadata(
         this(receivedSubmissionId, null, null, null, null, hash, null);
     }
 
+    public PartnerMetadata(String receivedSubmissionId, PartnerMetadataStatus deliveryStatus) {
+        this(receivedSubmissionId, null, null, null, null, null, deliveryStatus);
+    }
+
     public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadata.java
@@ -64,4 +64,15 @@ public record PartnerMetadata(
                 this.hash,
                 this.deliveryStatus);
     }
+
+    public PartnerMetadata withDeliveryStatus(PartnerMetadataStatus deliveryStatus) {
+        return new PartnerMetadata(
+                this.receivedSubmissionId,
+                this.sentSubmissionId,
+                this.sender,
+                this.receiver,
+                this.timeReceived,
+                this.hash,
+                deliveryStatus);
+    }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -142,6 +142,33 @@ public class PartnerMetadataOrchestrator {
         return Optional.of(partnerMetadata);
     }
 
+    public void setMetadataStatus(String submissionId, PartnerMetadataStatus metadataStatus)
+            throws PartnerMetadataException {
+        if (submissionId == null) {
+            return;
+        }
+
+        Optional<PartnerMetadata> optionalPartnerMetadata =
+                partnerMetadataStorage.readMetadata(submissionId);
+        if (optionalPartnerMetadata.isEmpty()) {
+            logger.logWarning("Metadata not found for submissionId: {}", submissionId);
+            return;
+        }
+
+        PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();
+
+        if (partnerMetadata.deliveryStatus().equals(metadataStatus)) {
+            return;
+        }
+
+        logger.logInfo(
+                "Updating metadata delivery status {} with submissionId: {}",
+                metadataStatus,
+                submissionId);
+        partnerMetadata = partnerMetadata.withDeliveryStatus(metadataStatus);
+        partnerMetadataStorage.saveMetadata(partnerMetadata);
+    }
+
     String getReceiverName(String responseBody) throws FormatterProcessingException {
         // the expected json structure for the response is:
         // {
@@ -173,32 +200,5 @@ public class PartnerMetadataOrchestrator {
         }
 
         return organizationId + "." + service;
-    }
-
-    public void setMetadataStatus(String submissionId, PartnerMetadataStatus metadataStatus)
-            throws PartnerMetadataException {
-        if (submissionId == null) {
-            return;
-        }
-
-        Optional<PartnerMetadata> optionalPartnerMetadata =
-                partnerMetadataStorage.readMetadata(submissionId);
-        if (optionalPartnerMetadata.isEmpty()) {
-            logger.logWarning("Metadata not found for submissionId: {}", submissionId);
-            return;
-        }
-
-        PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();
-
-        if (partnerMetadata.deliveryStatus().equals(metadataStatus)) {
-            return;
-        }
-
-        logger.logInfo(
-                "Updating metadata delivery status {} with submissionId: {}",
-                metadataStatus,
-                submissionId);
-        partnerMetadata = partnerMetadata.withDeliveryStatus(metadataStatus);
-        partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -175,7 +175,8 @@ public class PartnerMetadataOrchestrator {
         return organizationId + "." + service;
     }
 
-    public void setMetadataStatus (String submissionId, PartnerMetadataStatus metadataStatus) throws PartnerMetadataException {
+    public void setMetadataStatus(String submissionId, PartnerMetadataStatus metadataStatus)
+            throws PartnerMetadataException {
         if (submissionId == null) {
             return;
         }
@@ -183,8 +184,7 @@ public class PartnerMetadataOrchestrator {
         Optional<PartnerMetadata> optionalPartnerMetadata =
                 partnerMetadataStorage.readMetadata(submissionId);
         if (optionalPartnerMetadata.isEmpty()) {
-            logger.logWarning(
-                    "Metadata not found for submissionId: {}", submissionId);
+            logger.logWarning("Metadata not found for submissionId: {}", submissionId);
             return;
         }
 
@@ -194,7 +194,10 @@ public class PartnerMetadataOrchestrator {
             return;
         }
 
-        logger.logInfo("Updating metadata delivery status {} with submissionId: {}", metadataStatus, submissionId);
+        logger.logInfo(
+                "Updating metadata delivery status {} with submissionId: {}",
+                metadataStatus,
+                submissionId);
         partnerMetadata = partnerMetadata.withDeliveryStatus(metadataStatus);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -151,8 +151,9 @@ public class PartnerMetadataOrchestrator {
         Optional<PartnerMetadata> optionalPartnerMetadata =
                 partnerMetadataStorage.readMetadata(submissionId);
         if (optionalPartnerMetadata.isEmpty()) {
-            logger.logWarning("Metadata not found for submissionId: {}", submissionId);
-            return;
+            // there wasn't any metadata given the submission ID, so make one with the status
+            optionalPartnerMetadata =
+                    Optional.of(new PartnerMetadata(submissionId, metadataStatus));
         }
 
         PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -174,4 +174,28 @@ public class PartnerMetadataOrchestrator {
 
         return organizationId + "." + service;
     }
+
+    public void setMetadataStatus (String submissionId, PartnerMetadataStatus metadataStatus) throws PartnerMetadataException {
+        if (submissionId == null) {
+            return;
+        }
+
+        Optional<PartnerMetadata> optionalPartnerMetadata =
+                partnerMetadataStorage.readMetadata(submissionId);
+        if (optionalPartnerMetadata.isEmpty()) {
+            logger.logWarning(
+                    "Metadata not found for submissionId: {}", submissionId);
+            return;
+        }
+
+        PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();
+
+        if (partnerMetadata.deliveryStatus().equals(metadataStatus)) {
+            return;
+        }
+
+        logger.logInfo("Updating metadata delivery status {} with submissionId: {}", metadataStatus, submissionId);
+        partnerMetadata = partnerMetadata.withDeliveryStatus(metadataStatus);
+        partnerMetadataStorage.saveMetadata(partnerMetadata);
+    }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataTest.groovy
@@ -78,6 +78,24 @@ class PartnerMetadataTest extends Specification {
         metadata.deliveryStatus() == PartnerMetadataStatus.PENDING
     }
 
+    def "test constructor with only received submission ID and status"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def deliverStatus = PartnerMetadataStatus.DELIVERED
+
+        when:
+        def metadata = new PartnerMetadata(receivedSubmissionId, deliverStatus)
+
+        then:
+        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.sentSubmissionId() == null
+        metadata.sender() == null
+        metadata.receiver() == null
+        metadata.timeReceived() == null
+        metadata.hash() == null
+        metadata.deliveryStatus() == deliverStatus
+    }
+
     def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
@@ -100,5 +118,29 @@ class PartnerMetadataTest extends Specification {
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.hash() == hash
         updatedMetadata.deliveryStatus() == status
+    }
+
+    def "test withDeliveryStatus to update PartnerMetadata"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
+        def sender = "sender"
+        def receiver = "receiver"
+        def timeReceived = Instant.now()
+        def hash = "abcd"
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash, PartnerMetadataStatus.PENDING)
+
+        when:
+        def newStatus = PartnerMetadataStatus.DELIVERED
+        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withDeliveryStatus(newStatus)
+
+        then:
+        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.sender() == sender
+        updatedMetadata.receiver() == receiver
+        updatedMetadata.timeReceived() == timeReceived
+        updatedMetadata.hash() == hash
+        updatedMetadata.deliveryStatus() == newStatus
     }
 }


### PR DESCRIPTION
# Set Delivery Status for Internal Failed Order

These changes implemented code to set an order status to FAILED when it fails for various reasons in the Intermediary.

- added setMetadataStatus method to PartnerMetadata to set order status to Failed when appropriate.
- implemented this method at the handleOrders stage in the EtorDomainRegistration

## Issue #610 

## Checklist

- [x] I have added tests to cover my changes
- [ ] I have added logging where useful (with appropriate log level)
- [ ] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
