### PR TITLE
610: Convert RS History API Status to Our Metadata Status

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -221,6 +221,10 @@ public class PartnerMetadataOrchestrator {
     }
 
     PartnerMetadataStatus ourStatusFromReportStreamStatus(String rsStatus) {
+        if (rsStatus == null) {
+            return PartnerMetadataStatus.PENDING;
+        }
+
         return switch (rsStatus) {
             case "Error", "Not Delivering" -> PartnerMetadataStatus.FAILED;
             case "Delivered" -> PartnerMetadataStatus.DELIVERED;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -191,26 +191,33 @@ public class PartnerMetadataOrchestrator {
         //    ...
         // }
 
-        String organizationId;
-        String service;
-        String overallStatus;
+        Map<String, Object> responseObject =
+                formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
+
+        String receiver;
         try {
-            Map<String, Object> responseObject =
-                    formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
             ArrayList<?> destinations = (ArrayList<?>) responseObject.get("destinations");
             Map<?, ?> destination = (Map<?, ?>) destinations.get(0);
-            organizationId = destination.get("organization_id").toString();
-            service = destination.get("service").toString();
-            overallStatus = (String) responseObject.get("overallStatus");
+            String organizationId = destination.get("organization_id").toString();
+            String service = destination.get("service").toString();
+            receiver = organizationId + "." + service;
         } catch (IndexOutOfBoundsException e) {
             // the destinations have not been determined yet by RS
-            return null;
+            receiver = null;
         } catch (Exception e) {
             throw new FormatterProcessingException(
                     "Unable to extract receiver name from response due to unexpected format", e);
         }
 
-        return new String[] {organizationId + "." + service, overallStatus};
+        String overallStatus;
+        try {
+            overallStatus = (String) responseObject.get("overallStatus");
+        } catch (Exception e) {
+            throw new FormatterProcessingException(
+                    "Unable to extract overallStatus from response due to unexpected format", e);
+        }
+
+        return new String[] {receiver, overallStatus};
     }
 
     PartnerMetadataStatus ourStatusFromReportStreamStatus(String rsStatus) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestrator.java
@@ -225,6 +225,8 @@ public class PartnerMetadataOrchestrator {
             return PartnerMetadataStatus.PENDING;
         }
 
+        // based off of the Status enum in the SubmissionHistory.kt code in RS
+        // https://github.com/CDCgov/prime-reportstream/blob/master/prime-router/src/main/kotlin/history/SubmissionHistory.kt
         return switch (rsStatus) {
             case "Error", "Not Delivering" -> PartnerMetadataStatus.FAILED;
             case "Delivered" -> PartnerMetadataStatus.DELIVERED;

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -371,7 +371,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         parsedResponse[1] == status
     }
 
-    def "getReceiverName throws FormatterProcessingException or returns null for unexpected format response"() {
+    def "getReceiverAndStatus throws FormatterProcessingException or returns null for unexpected format response"() {
         given:
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -400,10 +400,18 @@ class PartnerMetadataOrchestratorTest extends Specification {
         when:
 
         def jsonWithEmptyDestinations = "{\"destinations\": []}"
-        def receiverName = PartnerMetadataOrchestrator.getInstance().getReceiverAndStatus(jsonWithEmptyDestinations)
+        def parsedData = PartnerMetadataOrchestrator.getInstance().getReceiverAndStatus(jsonWithEmptyDestinations)
 
         then:
-        receiverName == null
+        parsedData[0] == null
+
+        when:
+
+        def jsonWithNoStatus = "{\"destinations\": []}"
+        parsedData = PartnerMetadataOrchestrator.getInstance().getReceiverAndStatus(jsonWithNoStatus)
+
+        then:
+        parsedData[1] == null
 
         when:
         def jsonWithoutOrgId = "{\"destinations\":[{\"service\":\"service\"}]}"

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -462,5 +462,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         then:
         ourStatus == PartnerMetadataStatus.PENDING
+
+        when:
+        ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus(null)
+
+        then:
+        ourStatus == PartnerMetadataStatus.PENDING
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -251,7 +251,9 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
-        mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [destinations: [
+        mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
+            overallStatus: "Delivered",
+            destinations: [
                 [organization_id: "org", service: "service"]
             ]]
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/PartnerMetadataOrchestratorTest.groovy
@@ -427,4 +427,40 @@ class PartnerMetadataOrchestratorTest extends Specification {
         then:
         thrown(FormatterProcessingException)
     }
+
+    def "ourStatusFromReportStreamStatus returns FAILED"() {
+        when:
+        def ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus("Error")
+
+        then:
+        ourStatus == PartnerMetadataStatus.FAILED
+
+        when:
+        ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus("Not Delivering")
+
+        then:
+        ourStatus == PartnerMetadataStatus.FAILED
+    }
+
+    def "ourStatusFromReportStreamStatus returns DELIVERED"() {
+        when:
+        def ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus("Delivered")
+
+        then:
+        ourStatus == PartnerMetadataStatus.DELIVERED
+    }
+
+    def "ourStatusFromReportStreamStatus returns PENDING"() {
+        when:
+        def ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus("Waiting to Deliver")
+
+        then:
+        ourStatus == PartnerMetadataStatus.PENDING
+
+        when:
+        ourStatus = PartnerMetadataOrchestrator.getInstance().ourStatusFromReportStreamStatus("DogCow")
+
+        then:
+        ourStatus == PartnerMetadataStatus.PENDING
+    }
 }


### PR DESCRIPTION
# Convert RS History API Status to Our Metadata Status

We call the RS history API for outbound orders when the metadata has a status of `PENDING`.  We convert from their status to our status.

## Issue

#610.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
