### PR TITLE
Remove `metadata` from Name of `OrderConverter` Method

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderConverter.java
@@ -8,7 +8,7 @@ import gov.hhs.cdc.trustedintermediary.etor.operationoutcomes.FhirMetadata;
 public interface OrderConverter {
     Order<?> convertToOrder(Demographics<?> demographics);
 
-    Order<?> convertMetadataToOmlOrder(Order<?> order);
+    Order<?> convertToOmlOrder(Order<?> order);
 
     Order<?> addContactSectionToPatientResource(Order<?> order);
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -27,7 +27,7 @@ public class SendOrderUseCase {
 
         savePartnerMetadataForReceivedOrder(receivedSubmissionId, order);
 
-        var omlOrder = converter.convertMetadataToOmlOrder(order);
+        var omlOrder = converter.convertToOmlOrder(order);
         metadata.put(order.getFhirResourceId(), EtorMetadataStep.ORDER_CONVERTED_TO_OML);
 
         omlOrder = converter.addContactSectionToPatientResource(omlOrder);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -94,7 +94,7 @@ public class HapiOrderConverter implements OrderConverter {
     }
 
     @Override
-    public Order<?> convertMetadataToOmlOrder(Order<?> order) {
+    public Order<?> convertToOmlOrder(Order<?> order) {
         logger.logInfo("Converting order to have OML metadata");
 
         var hapiOrder = (Order<Bundle>) order;

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
@@ -42,7 +42,7 @@ class SendOrderUseCaseTest extends Specification {
         sendOrder.convertAndSend(mockOrder, receivedSubmissionId)
 
         then:
-        1 * mockConverter.convertMetadataToOmlOrder(mockOrder) >> mockOmlOrder
+        1 * mockConverter.convertToOmlOrder(mockOrder) >> mockOmlOrder
         1 * mockConverter.addContactSectionToPatientResource(mockOmlOrder) >> mockOmlOrder
         1 * mockSender.sendOrder(mockOmlOrder) >> Optional.of(sentSubmissionId)
         1 * sendOrder.metadata.put(_, EtorMetadataStep.ORDER_CONVERTED_TO_OML)
@@ -89,7 +89,7 @@ class SendOrderUseCaseTest extends Specification {
 
         then:
         1 * mockLogger.logError(_, _)
-        1 * mockConverter.convertMetadataToOmlOrder(order) >> omlOrder
+        1 * mockConverter.convertToOmlOrder(order) >> omlOrder
         1 * mockConverter.addContactSectionToPatientResource(omlOrder) >> omlOrder
         1 * mockSender.sendOrder(omlOrder) >> Optional.of("sentId")
     }
@@ -106,7 +106,7 @@ class SendOrderUseCaseTest extends Specification {
         SendOrderUseCase.getInstance().convertAndSend(order, "receivedId")
 
         then:
-        1 * mockConverter.convertMetadataToOmlOrder(order) >> omlOrder
+        1 * mockConverter.convertToOmlOrder(order) >> omlOrder
         1 * mockConverter.addContactSectionToPatientResource(omlOrder) >> omlOrder
         1 * mockSender.sendOrder(omlOrder) >> Optional.of("sentId")
         1 * mockLogger.logError(_, partnerMetadataException)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
@@ -159,7 +159,7 @@ class HapiOrderConverterTest extends Specification {
                 "ORM"))))
 
         when:
-        def convertedOrderBundle = HapiOrderConverter.getInstance().convertMetadataToOmlOrder(mockOrder).getUnderlyingOrder() as Bundle
+        def convertedOrderBundle = HapiOrderConverter.getInstance().convertToOmlOrder(mockOrder).getUnderlyingOrder() as Bundle
 
         then:
         def convertedMessageHeader = convertedOrderBundle.getEntry().get(1).getResource() as MessageHeader
@@ -170,7 +170,7 @@ class HapiOrderConverterTest extends Specification {
 
     def "adds the message header to specify OML"() {
         when:
-        def convertedOrderBundle = HapiOrderConverter.getInstance().convertMetadataToOmlOrder(mockOrder).getUnderlyingOrder() as Bundle
+        def convertedOrderBundle = HapiOrderConverter.getInstance().convertToOmlOrder(mockOrder).getUnderlyingOrder() as Bundle
 
         then:
         def convertedMessageHeader = convertedOrderBundle.getEntry().get(1).getResource() as MessageHeader


### PR DESCRIPTION
# Remove `metadata` from Name of `OrderConverter` Method

Literally just removed `Metadata` from the `OrderConverter#convertMetadataToOmlOrder` method because I feel it will get confusing with all the "metadata" names flying around.

## Issue

_None._
