### PR TITLE
Ignore the `e2e` Helper Classes in our Code Coverage in SonarCloud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ subprojects {
 }
 
 ext.jacoco_excludes = [
+        '**/e2e/**',
         '**/javalin/App*',
         '**/jackson/Jackson*',
         '**/slf4j/LocalLogger*',


### PR DESCRIPTION
# Ignore the `e2e` Helper Classes in our Code Coverage in SonarCloud

Added a code coverage ignore line for our end-to-end helper classes.  These aren't calculated already in our CI process, but they seem to be included in SonarCloud.  This change will now make SonarCloud also not count these classes.

## Issue

_None._