### PR TITLE
611: Better E2E Test for Metadata

### DIFF
--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
@@ -33,6 +33,20 @@ class MetadataTest extends Specification {
         then:
         metadataResponse.getCode() == expectedStatusCode
         parsedJsonBody.get("id") == submissionId
+
+        [
+            "sender name",
+            "receiver name",
+            "order ingestion",
+            "payload hash",
+            "delivery status",
+            "status message"
+        ].each { String metadataKey ->
+            def issue = (parsedJsonBody.issue as List).find( {issue -> issue.details.text == metadataKey })
+            assert issue != null
+            assert issue.diagnostics != null
+            assert !issue.diagnostics.isEmpty()
+        }
     }
 
     def "a 404 is returned when there is no metadata for a given ID"() {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/MockRSEndpointClient.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/MockRSEndpointClient.java
@@ -46,9 +46,15 @@ public class MockRSEndpointClient implements RSEndpointClient {
                 {
                     "timestamp" : "2020-01-01T00:00:00.000Z",
                     "sender" : "flexion.simulated-hospital",
+                    "overallStatus": "Not Delivering",
                     "destinations": [{
                         "organization_id": "flexion",
                         "service": "simulated-lab"
+                    }],
+                    "errors": [{
+                        "message": "The message was not good"
+                    }, {
+                        "message": "The DogCow couldn't Moof!"
                     }]
                  }""";
     }


### PR DESCRIPTION
# Better E2E Test for Metadata

Updated our e2e tests for the Metadata endpoint.  It validates that our metadata endpoint returns appropriate stuff.

For this test to work, I moved the "only save the error messages from the RS history API when the status is a failure" logic up a level into the `getMetadata` method.  This way we don't have to update two areas of our code if RS changes the statuses that result in a failure.  I also added a unit test to test this change.

Lastly, there were just a few minor test updates here and there.

## Issue

#611.

## Checklist

- [x] I have added tests to cover my changes