### PR TITLE
Run the DB Locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,9 @@ ext.jacoco_excludes = [
         '**/apache/ApacheClient*',
         '**/azure/AzureSecrets*',
         '**/database/EtorSqlDriverManager*',
-        '**/azure/AzureClient*'
+        '**/azure/AzureClient*',
+        '**/azure/AzureDatabaseCredentialsProvider*',
+        '**/localfile/EnvironmentDatabaseCredentialsProvider*',
 ]
 
 tasks.register('allUnitTests') {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -24,12 +24,15 @@ import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender;
 import gov.hhs.cdc.trustedintermediary.etor.orders.SendOrderUseCase;
 import gov.hhs.cdc.trustedintermediary.etor.orders.UnableToSendOrderException;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient;
+import gov.hhs.cdc.trustedintermediary.external.azure.AzureDatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.external.azure.AzureStorageAccountPartnerMetadataStorage;
+import gov.hhs.cdc.trustedintermediary.external.database.DatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.external.database.DatabasePartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.database.DbDao;
 import gov.hhs.cdc.trustedintermediary.external.database.EtorSqlDriverManager;
 import gov.hhs.cdc.trustedintermediary.external.database.PostgresDao;
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiOrderConverter;
+import gov.hhs.cdc.trustedintermediary.external.localfile.EnvironmentDatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.external.localfile.FilePartnerMetadataStorage;
 import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient;
@@ -94,6 +97,15 @@ public class EtorDomainRegistration implements DomainConnector {
             ApplicationContext.register(DbDao.class, PostgresDao.getInstance());
             ApplicationContext.register(
                     PartnerMetadataStorage.class, DatabasePartnerMetadataStorage.getInstance());
+            if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
+                ApplicationContext.register(
+                        DatabaseCredentialsProvider.class,
+                        EnvironmentDatabaseCredentialsProvider.getInstance());
+            } else {
+                ApplicationContext.register(
+                        DatabaseCredentialsProvider.class,
+                        AzureDatabaseCredentialsProvider.getInstance());
+            }
         } else if (ApplicationContext.getEnvironment().equalsIgnoreCase("local")) {
             ApplicationContext.register(
                     PartnerMetadataStorage.class, FilePartnerMetadataStorage.getInstance());

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
@@ -1,0 +1,23 @@
+package gov.hhs.cdc.trustedintermediary.external.azure;
+
+import gov.hhs.cdc.trustedintermediary.external.database.DatabaseCredentialsProvider;
+import javax.inject.Inject;
+
+public class AzureDatabaseCredentialsProvider implements DatabaseCredentialsProvider {
+
+    private static final AzureDatabaseCredentialsProvider INSTANCE =
+            new AzureDatabaseCredentialsProvider();
+
+    @Inject AzureClient azureClient;
+
+    public static AzureDatabaseCredentialsProvider getInstance() {
+        return INSTANCE;
+    }
+
+    private AzureDatabaseCredentialsProvider() {}
+
+    @Override
+    public String getPassword() {
+        return azureClient.getScopedToken("https://ossrdbms-aad.database.windows.net/.default");
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
@@ -3,6 +3,10 @@ package gov.hhs.cdc.trustedintermediary.external.azure;
 import gov.hhs.cdc.trustedintermediary.external.database.DatabaseCredentialsProvider;
 import javax.inject.Inject;
 
+/**
+ * AzureDatabaseCredentialsProvider is a class responsible for providing credentials for a database
+ * deployed in Azure.
+ */
 public class AzureDatabaseCredentialsProvider implements DatabaseCredentialsProvider {
 
     private static final AzureDatabaseCredentialsProvider INSTANCE =

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabaseCredentialsProvider.java
@@ -1,5 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.external.database;
 
+/** This interface represents a provider for retrieving database credentials. */
 public interface DatabaseCredentialsProvider {
     String getPassword();
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabaseCredentialsProvider.java
@@ -1,0 +1,5 @@
+package gov.hhs.cdc.trustedintermediary.external.database;
+
+public interface DatabaseCredentialsProvider {
+    String getPassword();
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/EnvironmentDatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/EnvironmentDatabaseCredentialsProvider.java
@@ -1,0 +1,21 @@
+package gov.hhs.cdc.trustedintermediary.external.localfile;
+
+import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
+import gov.hhs.cdc.trustedintermediary.external.database.DatabaseCredentialsProvider;
+
+public class EnvironmentDatabaseCredentialsProvider implements DatabaseCredentialsProvider {
+
+    private static final EnvironmentDatabaseCredentialsProvider INSTANCE =
+            new EnvironmentDatabaseCredentialsProvider();
+
+    public static EnvironmentDatabaseCredentialsProvider getInstance() {
+        return INSTANCE;
+    }
+
+    private EnvironmentDatabaseCredentialsProvider() {}
+
+    @Override
+    public String getPassword() {
+        return ApplicationContext.getProperty("DB_PASS");
+    }
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/EnvironmentDatabaseCredentialsProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/EnvironmentDatabaseCredentialsProvider.java
@@ -3,6 +3,11 @@ package gov.hhs.cdc.trustedintermediary.external.localfile;
 import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
 import gov.hhs.cdc.trustedintermediary.external.database.DatabaseCredentialsProvider;
 
+/**
+ * The EnvironmentDatabaseCredentialsProvider class is an implementation of the
+ * DatabaseCredentialsProvider interface. It retrieves the database credentials from environment
+ * variables.
+ */
 public class EnvironmentDatabaseCredentialsProvider implements DatabaseCredentialsProvider {
 
     private static final EnvironmentDatabaseCredentialsProvider INSTANCE =

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/PostgresDaoTest.groovy
@@ -3,18 +3,15 @@ package gov.hhs.cdc.trustedintermediary.external.database
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadata
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
-import gov.hhs.cdc.trustedintermediary.external.azure.AzureClient
 import gov.hhs.cdc.trustedintermediary.wrappers.SqlDriverManager
-import java.sql.Types
-import spock.lang.Specification
-
-import java.sql.Timestamp
-import java.time.Instant
-
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.SQLException
+import java.sql.Timestamp
+import java.sql.Types
+import java.time.Instant
+import spock.lang.Specification
 
 class PostgresDaoTest extends Specification {
 
@@ -31,10 +28,10 @@ class PostgresDaoTest extends Specification {
         mockConn = Mock(Connection)
         mockPreparedStatement = Mock(PreparedStatement)
         mockResultSet = Mock(ResultSet)
-        def mockAzureClient = Mock(AzureClient)
-        mockAzureClient.getScopedToken(_ as String) >> "DogCow password"
+        def mockCredentialsProvider = Mock(DatabaseCredentialsProvider)
+        mockCredentialsProvider.getPassword() >> "DogCow password"
 
-        TestApplicationContext.register(AzureClient, mockAzureClient)
+        TestApplicationContext.register(DatabaseCredentialsProvider, mockCredentialsProvider)
         TestApplicationContext.register(PostgresDao, PostgresDao.getInstance())
     }
 


### PR DESCRIPTION
# Run the DB Locally

If we wanted to run the DB locally and supply the `DB_URL` environment variable so that the DB would be used, we'd run into an exception being thrown during bootstrap that we didn't have an implementation of `AzureClient` to inject.  And rightfully so, we didn't register an `AzureClient` implementation.

The concept of running a database and running the database in Azure are different, but our `PostgresDao` combined those concepts by also depending on the `AzureClient`.  We tried to get around this by using `if`/`then` to only get the password through an environment variable or through Azure's functionality, but that approach didn't fully work (because we'd still get the bootstrap exception) and improperly combined two concepts.

So, now we hide how we get our credentials behind an abstraction: `DatabaseCredentialsProvider`.  If we're running locally, we use the `EnvironmentDatabaseCredentialsProvider`.  If we're running in a deployed environment, we use the `AzureDatabaseCredentialsProvider`.

## Issue

_None_.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly

