### PR TITLE
DB_USER needs to be dynamic based on the environment

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -39,7 +39,7 @@ resource "azurerm_linux_web_app" "api" {
     DB_URL                          = azurerm_postgresql_flexible_server.database.fqdn
     DB_PORT                         = "5432"
     DB_NAME                         = "postgres"
-    DB_USER                         = "cdcti-internal-api"
+    DB_USER                         = "cdcti-${var.environment}-api"
     DB_SSL                          = "require"
   }
 


### PR DESCRIPTION
# DB_USER needs to be dynamic based on the environment

We dynamically set the `DB_USER` environment variable based on the environment name.

## Issue

_None._
