### PR TITLE
Add time of delivery to metadata endpoint

### DIFF
--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Db migration
         run: |
           export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
-          psql "host=$(terraform output -raw database_hostname) port=5432 dbname=postgres user=cdcti-github sslmode=require" -c "DO \$\$ BEGIN CREATE TYPE message_status AS ENUM ('PENDING', 'DELIVERED', 'FAILED'); EXCEPTION WHEN duplicate_object THEN null; END \$\$; CREATE TABLE IF NOT EXISTS metadata (received_message_id varchar(40) PRIMARY KEY, sent_message_id varchar(40), sender varchar(30), receiver varchar(30), hash_of_order varchar(1000), time_received timestamptz, delivery_status message_status, failure_reason varchar(1000)); GRANT ALL ON metadata TO azure_pg_admin; ALTER TABLE metadata OWNER TO azure_pg_admin; ALTER TYPE message_status OWNER TO azure_pg_admin"
+          psql "host=$(terraform output -raw database_hostname) port=5432 dbname=postgres user=cdcti-github sslmode=require" -c "DO \$\$ BEGIN CREATE TYPE message_status AS ENUM ('PENDING', 'DELIVERED', 'FAILED'); EXCEPTION WHEN duplicate_object THEN null; END \$\$; CREATE TABLE IF NOT EXISTS metadata (received_message_id varchar(40) PRIMARY KEY, sent_message_id varchar(40), sender varchar(30), receiver varchar(30), hash_of_order varchar(1000), time_received timestamptz, time_delivered timestamptz, delivery_status message_status, failure_reason varchar(1000)); GRANT ALL ON metadata TO azure_pg_admin; ALTER TABLE metadata OWNER TO azure_pg_admin; ALTER TYPE message_status OWNER TO azure_pg_admin"
 
       - id: export-terraform-output
         name: Export Terraform Output

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ResultTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ResultTest.groovy
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 class ResultTest extends Specification {
     def resultClient = new EndpointClient("/v1/etor/results")
-    def labResultJsonFileString = Files.readString(Path.of("../examples/MN/004_MN_ORU_R01_NBS_translation_from_initial_hl7_ingestion.fhir"))
+    def labResultJsonFileString = Files.readString(Path.of("../examples/MN/004_MN_ORU_R01_NBS_1_translation_from_initial_hl7_ingestion.fhir"))
     def submissionId = "submissionId"
 
     def setup() {

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ResultTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ResultTest.groovy
@@ -7,7 +7,9 @@ import java.nio.file.Path
 
 class ResultTest extends Specification {
     def resultClient = new EndpointClient("/v1/etor/results")
+
     def labResultJsonFileString = Files.readString(Path.of("../examples/MN/004_MN_ORU_R01_NBS_1_translation_from_initial_hl7_ingestion.fhir"))
+
     def submissionId = "submissionId"
 
     def setup() {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -10,6 +10,7 @@ import java.time.Instant;
  * @param sender The name of the sender of the message.
  * @param receiver The name of the receiver of the message.
  * @param timeReceived The time the message was received.
+ * @param timeDelivered The time the message was delivered.
  * @param hash The hash of the message.
  * @param deliveryStatus the status of the message based on an enum
  */
@@ -19,6 +20,7 @@ public record PartnerMetadata(
         String sender,
         String receiver,
         Instant timeReceived,
+        Instant timeDelivered,
         String hash,
         PartnerMetadataStatus deliveryStatus,
         String failureReason) {
@@ -34,17 +36,27 @@ public record PartnerMetadata(
             String receivedSubmissionId,
             String sender,
             Instant timeReceived,
+            Instant timeDelivered,
             String hash,
             PartnerMetadataStatus deliveryStatus) {
-        this(receivedSubmissionId, null, sender, null, timeReceived, hash, deliveryStatus, null);
+        this(
+                receivedSubmissionId,
+                null,
+                sender,
+                null,
+                timeReceived,
+                timeDelivered,
+                hash,
+                deliveryStatus,
+                null);
     }
 
     public PartnerMetadata(String receivedSubmissionId, String hash) {
-        this(receivedSubmissionId, null, null, null, null, hash, null, null);
+        this(receivedSubmissionId, null, null, null, null, null, hash, null, null);
     }
 
     public PartnerMetadata(String receivedSubmissionId, PartnerMetadataStatus deliveryStatus) {
-        this(receivedSubmissionId, null, null, null, null, null, deliveryStatus, null);
+        this(receivedSubmissionId, null, null, null, null, null, null, deliveryStatus, null);
     }
 
     public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
@@ -54,6 +66,7 @@ public record PartnerMetadata(
                 this.sender,
                 this.receiver,
                 this.timeReceived,
+                this.timeDelivered,
                 this.hash,
                 this.deliveryStatus,
                 this.failureReason);
@@ -66,6 +79,20 @@ public record PartnerMetadata(
                 this.sender,
                 receiver,
                 this.timeReceived,
+                this.timeDelivered,
+                this.hash,
+                this.deliveryStatus,
+                this.failureReason);
+    }
+
+    public PartnerMetadata withTimeDelivered(Instant timeDelivered) {
+        return new PartnerMetadata(
+                this.receivedSubmissionId,
+                this.sentSubmissionId,
+                this.sender,
+                this.receiver,
+                this.timeReceived,
+                timeDelivered,
                 this.hash,
                 this.deliveryStatus,
                 this.failureReason);
@@ -78,6 +105,7 @@ public record PartnerMetadata(
                 this.sender,
                 this.receiver,
                 this.timeReceived,
+                this.timeDelivered,
                 this.hash,
                 deliveryStatus,
                 this.failureReason);
@@ -90,6 +118,7 @@ public record PartnerMetadata(
                 this.sender,
                 this.receiver,
                 this.timeReceived,
+                this.timeDelivered,
                 this.hash,
                 this.deliveryStatus,
                 failureMessage);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -44,8 +44,6 @@ public class PartnerMetadataOrchestrator {
 
         String sender;
         Instant timeReceived;
-        Instant timeDelivered = null;
-
         try {
             String bearerToken = rsclient.getRsToken();
             String responseBody =

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -46,6 +46,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                     metadata.receiver(),
                     metadata.hash(),
                     metadata.timeReceived(),
+                    metadata.timeDelivered(),
                     metadata.deliveryStatus(),
                     metadata.failureReason());
         } catch (SQLException e) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DbDao.java
@@ -15,6 +15,7 @@ public interface DbDao {
             String receiver,
             String hash,
             Instant timeReceived,
+            Instant timeDelivered,
             PartnerMetadataStatus deliveryStatus,
             String failureReason)
             throws SQLException;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/PostgresDao.java
@@ -88,7 +88,7 @@ public class PostgresDao implements DbDao {
                         conn.prepareStatement(
                                 """
                                 INSERT INTO metadata VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                                ON CONFLICT (received_message_id) DO UPDATE SET receiver = EXCLUDED.receiver, sent_message_id = EXCLUDED.sent_message_id, delivery_status = EXCLUDED.delivery_status, failure_reason = EXCLUDED.failure_reason
+                                ON CONFLICT (received_message_id) DO UPDATE SET receiver = EXCLUDED.receiver, sent_message_id = EXCLUDED.sent_message_id, time_delivered = EXCLUDED.time_delivered, delivery_status = EXCLUDED.delivery_status, failure_reason = EXCLUDED.failure_reason
                                 """)) {
 
             statement.setString(1, receivedSubmissionId);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverter.java
@@ -217,15 +217,22 @@ public class HapiOrderConverter implements OrderConverter {
                 .add(createInformationIssueComponent("receiver name", metadata.receiver()));
 
         String orderIngestion = null;
+        String orderDelivered = null;
         if (metadata.timeReceived() != null) {
             orderIngestion = metadata.timeReceived().toString();
+        }
+        if (metadata.timeDelivered() != null) {
+            orderDelivered = metadata.timeDelivered().toString();
         }
 
         operation
                 .getIssue()
                 .add(createInformationIssueComponent("order ingestion", orderIngestion));
-        operation.getIssue().add(createInformationIssueComponent("payload hash", metadata.hash()));
 
+        operation.getIssue().add(createInformationIssueComponent("payload hash", metadata.hash()));
+        operation
+                .getIssue()
+                .add(createInformationIssueComponent("order delivered", orderDelivered));
         operation
                 .getIssue()
                 .add(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/MockRSEndpointClient.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/MockRSEndpointClient.java
@@ -46,6 +46,7 @@ public class MockRSEndpointClient implements RSEndpointClient {
                 {
                     "timestamp" : "2020-01-01T00:00:00.000Z",
                     "sender" : "flexion.simulated-hospital",
+                    "actualCompletionAt" : "2023-10-24T19:48:26.921Z",
                     "overallStatus": "Not Delivering",
                     "destinations": [{
                         "organization_id": "flexion",

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -381,7 +381,7 @@ class EtorDomainRegistrationTest extends Specification {
         request.setPathParams(["id": "metadataId"])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
-        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), "hash", PartnerMetadataStatus.DELIVERED))
+        mockPartnerMetadataOrchestrator.getMetadata(_ as String) >> Optional.ofNullable(new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED))
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
 
         def mockResponseHelper = Mock(DomainResponseHelper)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -480,6 +480,17 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         then:
         thrown(FormatterProcessingException)
+
+        when:
+        def jsonWithBadCompletionDate = "{\"actualCompletionAt\": 123, \"destinations\":[{\"organization_id\":\"org_id\", \"service\":\"service\"}], \"overallStatus\": \"Error\"}"
+        PartnerMetadataOrchestrator.getInstance().getDataFromReportStream(jsonWithBadCompletionDate)
+        then:
+        thrown(FormatterProcessingException)
+        when:
+        def jsonWithBadStatus = "{\"overallStatus\": 123, \"destinations\":[{\"organization_id\":\"org_id\", \"service\":\"service\"}]}"
+        PartnerMetadataOrchestrator.getInstance().getDataFromReportStream(jsonWithBadStatus)
+        then:
+        thrown(FormatterProcessingException)
     }
 
     def "ourStatusFromReportStreamStatus returns FAILED"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
@@ -24,19 +24,21 @@ class PartnerMetadataTest extends Specification {
         def sender = "sender"
         def receiver = "receiver"
         def timeReceived = Instant.now()
+        def timeDelivered = Instant.now()
         def hash = "abcd"
         def status = PartnerMetadataStatus.DELIVERED
         def failureReason = "failure reason"
 
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash, PartnerMetadataStatus.DELIVERED, failureReason)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason)
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
         metadata.sentSubmissionId() == sentSubmissionId
         metadata.sender() == sender
         metadata.receiver() == receiver
+        metadata.timeDelivered() == timeDelivered
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
         metadata.deliveryStatus() == status
@@ -48,11 +50,12 @@ class PartnerMetadataTest extends Specification {
         def receivedSubmissionId = "receivedSubmissionId"
         def sender = "sender"
         def timeReceived = Instant.now()
+        def timeDelivered = Instant.now()
         def hash = "abcd"
         def status = PartnerMetadataStatus.DELIVERED
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, hash, PartnerMetadataStatus.DELIVERED)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED)
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
@@ -60,6 +63,7 @@ class PartnerMetadataTest extends Specification {
         metadata.sender() == sender
         metadata.receiver() == null
         metadata.timeReceived() == timeReceived
+        metadata.timeDelivered() == timeDelivered
         metadata.hash() == hash
         metadata.deliveryStatus() == status
     }
@@ -78,6 +82,7 @@ class PartnerMetadataTest extends Specification {
         metadata.sender() == null
         metadata.receiver() == null
         metadata.timeReceived() == null
+        metadata.timeDelivered() == null
         metadata.hash() == hash
         //Status should default to PENDING
         metadata.deliveryStatus() == PartnerMetadataStatus.PENDING
@@ -97,6 +102,7 @@ class PartnerMetadataTest extends Specification {
         metadata.sender() == null
         metadata.receiver() == null
         metadata.timeReceived() == null
+        metadata.timeDelivered() == null
         metadata.hash() == null
         metadata.deliveryStatus() == deliverStatus
     }
@@ -111,7 +117,7 @@ class PartnerMetadataTest extends Specification {
         def hash = "abcd"
         def status = PartnerMetadataStatus.DELIVERED
         def failureReason = "DogCow goes boom"
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, sender, null, timeReceived, hash, status, failureReason)
+        def metadata = new PartnerMetadata(receivedSubmissionId, null, sender, null, timeReceived, null, hash, status, failureReason)
 
         when:
         def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withReceiver(receiver)
@@ -133,9 +139,10 @@ class PartnerMetadataTest extends Specification {
         def sender = "sender"
         def receiver = "receiver"
         def timeReceived = Instant.now()
+        def timeDelivered = null
         def hash = "abcd"
         def failureReason = "DogCow goes boom"
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, hash, PartnerMetadataStatus.PENDING, failureReason)
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason)
 
         when:
         def newStatus = PartnerMetadataStatus.DELIVERED
@@ -147,8 +154,35 @@ class PartnerMetadataTest extends Specification {
         updatedMetadata.sender() == sender
         updatedMetadata.receiver() == receiver
         updatedMetadata.timeReceived() == timeReceived
+        updatedMetadata.timeDelivered() == null
         updatedMetadata.hash() == hash
         updatedMetadata.deliveryStatus() == newStatus
+        updatedMetadata.failureReason() == failureReason
+    }
+
+    def "test withTimeDelivered to update PartnerMetadata"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def sentSubmissionId = "sentSubmissionId"
+        def sender = "sender"
+        def receiver = "receiver"
+        def timeReceived = Instant.now()
+        def timeDelivered = Instant.now()
+        def hash = "abcd"
+        def failureReason = "DogCow goes boom"
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason)
+
+        when:
+        def updatedMetadata = metadata.withTimeDelivered(timeDelivered)
+
+        then:
+        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.sender() == sender
+        updatedMetadata.receiver() == receiver
+        updatedMetadata.timeReceived() == timeReceived
+        updatedMetadata.timeDelivered() == timeDelivered
+        updatedMetadata.hash() == hash
         updatedMetadata.failureReason() == failureReason
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/azure/AzureStorageAccountPartnerMetadataStorageTest.groovy
@@ -30,7 +30,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
         def expectedHash = "abcd"
         PartnerMetadataStatus status = PartnerMetadataStatus.PENDING
 
-        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, expectedSender, expectedReceiver, expectedTimestamp, expectedHash, status, null)
+        PartnerMetadata expectedMetadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, expectedSender, expectedReceiver, expectedTimestamp, null, expectedHash, status, null)
 
         String simulatedMetadataJson = """{
             "receivedSubmissionId": "${expectedReceivedSubmissionId}",
@@ -100,7 +100,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "successfully save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null)
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), null, "abcd", PartnerMetadataStatus.DELIVERED, null)
 
         def mockBlobClient = Mock(BlobClient)
         def azureClient = Mock(AzureClient)
@@ -122,7 +122,7 @@ class AzureStorageAccountPartnerMetadataStorageTest extends Specification {
 
     def "failed to save metadata"() {
         given:
-        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null)
+        PartnerMetadata partnerMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", "sender", "receiver", Instant.now(), null, "abcd", PartnerMetadataStatus.DELIVERED, null)
 
         def mockBlobClient = Mock(BlobClient)
         mockBlobClient.upload(_ as BinaryData, true) >> { throw new AzureException("upload failed") }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -28,7 +28,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
     def "readMetadata happy path works"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def mockMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), "hash", PartnerMetadataStatus.PENDING, null)
+        def mockMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.PENDING, null)
         def expectedResult = Optional.of(mockMetadata)
 
         mockDao.fetchMetadata(_ as String) >> mockMetadata
@@ -61,6 +61,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 "sender",
                 "receiver",
                 Instant.now(),
+                Instant.now(),
                 "hash",
                 PartnerMetadataStatus.PENDING,
                 "DogCow failure"
@@ -77,6 +78,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 mockMetadata.receiver(),
                 mockMetadata.hash(),
                 mockMetadata.timeReceived(),
+                mockMetadata.timeDelivered(),
                 mockMetadata.deliveryStatus(),
                 mockMetadata.failureReason()
                 )
@@ -91,6 +93,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 "sender",
                 "receiver",
                 Instant.now(),
+                Instant.now(),
                 "hash",
                 PartnerMetadataStatus.FAILED,
                 "DogCow failure"
@@ -103,6 +106,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 mockMetadata.receiver(),
                 mockMetadata.hash(),
                 mockMetadata.timeReceived(),
+                mockMetadata.timeDelivered(),
                 mockMetadata.deliveryStatus(),
                 mockMetadata.failureReason()
                 ) >> { throw new SQLException("Something went wrong!") }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiOrderConverterTest.groovy
@@ -308,7 +308,7 @@ class HapiOrderConverterTest extends Specification {
         def hash = "hash"
         def failureReason = "timed_out"
         PartnerMetadata metadata = new PartnerMetadata(
-                "receivedSubmissionId", "sentSubmissionId", sender, receiver, time, hash, PartnerMetadataStatus.DELIVERED, failureReason)
+                "receivedSubmissionId", "sentSubmissionId", sender, receiver, time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason)
 
         when:
         def result = HapiOrderConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata, "receivedSubmissionId").getUnderlyingOutcome() as OperationOutcome
@@ -319,7 +319,8 @@ class HapiOrderConverterTest extends Specification {
         result.getIssue().get(1).diagnostics == receiver
         result.getIssue().get(2).diagnostics == time.toString()
         result.getIssue().get(3).diagnostics == hash
-        result.getIssue().get(4).diagnostics == PartnerMetadataStatus.DELIVERED.toString()
-        result.getIssue().get(5).diagnostics == failureReason
+        result.getIssue().get(4).diagnostics == time.toString()
+        result.getIssue().get(5).diagnostics == PartnerMetadataStatus.DELIVERED.toString()
+        result.getIssue().get(6).diagnostics == failureReason
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -26,7 +26,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
         def expectedSentSubmissionId = "receivedSubmissionId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null)
+        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"),Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null)
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -41,7 +41,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null)
+        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null)
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}
@@ -65,7 +65,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
         //write something to the hard drive so that the `readMetadata` in the when gets pass the file existence check
         def submissionId = "asljfaskljgalsjgjlas"
-        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null)
+        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null, null)
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata)
 
         when:
@@ -86,8 +86,8 @@ class FilePartnerMetadataStorageTest extends Specification {
     def "readMetadataForSender returns a set of PartnerMetadata"() {
         given:
         def sender = "same_sender"
-        PartnerMetadata metadata2 = new PartnerMetadata("abcdefghi", null, sender, null, null, null, null, null)
-        PartnerMetadata metadata1 = new PartnerMetadata("123456789", null, sender, null, null, null, null, null)
+        PartnerMetadata metadata2 = new PartnerMetadata("abcdefghi", null, sender, null, null, null, null, null, null)
+        PartnerMetadata metadata1 = new PartnerMetadata("123456789", null, sender, null, null, null, null, null, null)
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
 


### PR DESCRIPTION
# Add time of delivery to metadata endpoint

We need to be able to verify what time orders were delivered.  This is achieved by querying the reportstream history API for a submission and extracting the actualCompletionAt field from the RS history API response. 

## Issue
#796 

## Checklist

- [x] I have added tests to cover my changes

