### PR TITLE
Use Environments Name for All the Different Deploy Steps

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,7 @@ jobs:
     needs: ci
     uses: ./.github/workflows/terraform-deploy_reusable.yml
     with:
+      ENVIRONMENT: stg
       TERRAFORM_DIRECTORY: operations/environments/staging
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CDC_CLIENT_ID }}

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -30,6 +30,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -12,6 +12,7 @@ jobs:
     name: Dev Infrastructure Deploy
     uses: ./.github/workflows/terraform-deploy_reusable.yml
     with:
+      ENVIRONMENT: dev
       TERRAFORM_DIRECTORY: operations/environments/dev
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CDC_CLIENT_ID }}

--- a/.github/workflows/internal-deploy.yml
+++ b/.github/workflows/internal-deploy.yml
@@ -12,6 +12,7 @@ jobs:
     name: Internal Infrastructure Deploy
     uses: ./.github/workflows/terraform-deploy_reusable.yml
     with:
+      ENVIRONMENT: internal
       TERRAFORM_DIRECTORY: operations/environments/internal
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -16,6 +16,7 @@ jobs:
     needs: ci
     uses: ./.github/workflows/terraform-deploy_reusable.yml
     with:
+      ENVIRONMENT: prd
       TERRAFORM_DIRECTORY: operations/environments/prod
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CDC_CLIENT_ID }}
@@ -27,7 +28,7 @@ jobs:
     needs: terraform-deploy
     uses: ./.github/workflows/deploy_reusable.yml
     with:
-      ENVIRONMENT: prod
+      ENVIRONMENT: prd
       REPO: trusted-intermediary-router
       REPO_DOCS: trusted-intermediary-docs
       APP: ${{ needs.terraform-deploy.outputs.APP }}

--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/terraform-deploy_reusable.yml
     if: needs.paths-filter.outputs.operations == 'true'
     with:
+      ENVIRONMENT: pr
       TERRAFORM_DIRECTORY: operations/environments/pr
       TERRAFORM_INIT_PARAMETERS: -backend-config="key=pr_${{ github.event.number }}.tfstate"
       TERRAFORM_APPLY_PARAMETERS: -var="pr_number=${{ github.event.number }}"
@@ -76,6 +77,8 @@ jobs:
 
   destroy-environment:
     name: Destroy PR Environment
+    environment:
+      name: pr
     needs:
       - pr-deploy
       - paths-filter

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -3,6 +3,9 @@ name: Terraform Deploy
 on:
   workflow_call:
     inputs:
+      ENVIRONMENT:
+        required: true
+        type: string
       TERRAFORM_DIRECTORY:
         type: string
         required: true
@@ -32,6 +35,8 @@ on:
 jobs:
   terraform-deploy:
     name: Terraform Deploy
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
     runs-on: ubuntu-latest
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
# Use Environments Name for All the Different Deploy Steps

Our deployments use OIDC to authenticate itself to Azure.  GitHub's OIDC implementation uses a couple of different subjects when talking over OIDC depending on the situation.  During a normal deploy from the `main` branch, it uses the following: `repo:CDCgov/trusted-intermediary:head:main`.  When doing a deploy from a `v1.0.0` tag, it uses the following: `repo:CDCgov/trusted-intermediary:tag:v1.0.0`.

Azure doesn't support wildcards subjects.  For example, I cannot tell Azure to allow `repo:CDCgov/trusted-intermediary:tag:v*`.  Azure is [working](https://github.com/Azure/azure-workload-identity/issues/373) on support.  So we don't need to constantly create new allowed tags in Azure for every new deploy we want to do, we are labeling every job that interacts with Azure as an environment.  This will make GitHub's OIDC handling logic advertise itself to Azure as `repo:CDCgov/trusted-intermediary:environment:stg`, as an example for the staging environment.  This allows us to set Azure to only allow our named environments.

## Issue

#721.
