### PR TITLE
Only Do PR Environment Deploys When Something Directly Impacts It

### DIFF
--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           filters: |
             operations:
-              - 'operations/**'
+              - 'operations/environments/pr/**'
+              - 'operations/template/**'
 
 
   terraform-deploy:


### PR DESCRIPTION
# Only Do PR Environment Deploys When Something Directly Impacts It

Instead of triggering the PR deploy when anything under `/operations/` is changed, only trigger it when something in `/operations/environments/pr/` or `/operations/template/` changes.

## Issue

_None_.