### PR TITLE
Aggregate All the Metadata Requests Under One Entry in Load Tests

### DIFF
--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -82,6 +82,7 @@ class SampleUser(FastHttpUser):
             self.client.get(
                 f"{METADATA_ENDPOINT}/{self.submission_id}",
                 headers={"Authorization": self.access_token},
+                name=f"{METADATA_ENDPOINT}/{{id}}"
             )
 
     @task(1)


### PR DESCRIPTION
# Aggregate All the Metadata Requests Under One Entry in Load Tests

Previous, Locust would give stats for each of our metadata requests because each request had a unique URL.  This change aggregates all the metadata requests under one entry which gives us one set of aggregate stats for all the metadata calls.

## Issue

_None._