### PR TITLE
Implementation to send the FHIR result to RS Waters endpoint

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -17,6 +17,7 @@ import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson;
 import gov.hhs.cdc.trustedintermediary.external.jjwt.JjwtEngine;
 import gov.hhs.cdc.trustedintermediary.external.localfile.EnvironmentDatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalSecrets;
+import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamSenderHelper;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger;
 import gov.hhs.cdc.trustedintermediary.organizations.OrganizationsSettings;
@@ -103,6 +104,8 @@ public class App {
                         AzureDatabaseCredentialsProvider.getInstance());
             }
             ApplicationContext.register(ConnectionPool.class, HikariConnectionPool.getInstance());
+            ApplicationContext.register(
+                    ReportStreamSenderHelper.class, ReportStreamSenderHelper.getInstance());
         }
     }
 }

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -17,7 +17,6 @@ import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson;
 import gov.hhs.cdc.trustedintermediary.external.jjwt.JjwtEngine;
 import gov.hhs.cdc.trustedintermediary.external.localfile.EnvironmentDatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.external.localfile.LocalSecrets;
-import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamSenderHelper;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.DeployedLogger;
 import gov.hhs.cdc.trustedintermediary.external.slf4j.LocalLogger;
 import gov.hhs.cdc.trustedintermediary.organizations.OrganizationsSettings;
@@ -104,8 +103,6 @@ public class App {
                         AzureDatabaseCredentialsProvider.getInstance());
             }
             ApplicationContext.register(ConnectionPool.class, HikariConnectionPool.getInstance());
-            ApplicationContext.register(
-                    ReportStreamSenderHelper.class, ReportStreamSenderHelper.getInstance());
         }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -37,6 +37,7 @@ import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamEndpointClient;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamOrderSender;
 import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamResultSender;
+import gov.hhs.cdc.trustedintermediary.external.reportstream.ReportStreamSenderHelper;
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
@@ -104,6 +105,8 @@ public class EtorDomainRegistration implements DomainConnector {
         ApplicationContext.register(ResultSender.class, ReportStreamResultSender.getInstance());
         ApplicationContext.register(ResultController.class, ResultController.getInstance());
         ApplicationContext.register(SendResultUseCase.class, SendResultUseCase.getInstance());
+        ApplicationContext.register(
+                ReportStreamSenderHelper.class, ReportStreamSenderHelper.getInstance());
 
         if (ApplicationContext.getProperty("DB_URL") != null) {
             ApplicationContext.register(DbDao.class, PostgresDao.getInstance());

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -1,17 +1,10 @@
 package gov.hhs.cdc.trustedintermediary.external.reportstream;
 
-import gov.hhs.cdc.trustedintermediary.etor.RSEndpointClient;
 import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException;
-import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
 import gov.hhs.cdc.trustedintermediary.etor.orders.Order;
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender;
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
-import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException;
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
-import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -20,11 +13,9 @@ public class ReportStreamOrderSender implements OrderSender {
 
     private static final ReportStreamOrderSender INSTANCE = new ReportStreamOrderSender();
 
-    @Inject private RSEndpointClient rsclient;
-    @Inject private Formatter formatter;
+    @Inject private ReportStreamSenderHelper sender;
     @Inject private HapiFhir fhir;
     @Inject private Logger logger;
-    @Inject MetricMetadata metadata;
 
     public static ReportStreamOrderSender getInstance() {
         return INSTANCE;
@@ -35,40 +26,7 @@ public class ReportStreamOrderSender implements OrderSender {
     @Override
     public Optional<String> send(final Order<?> order) throws UnableToSendMessageException {
         logger.logInfo("Sending the order to ReportStream");
-
         String json = fhir.encodeResourceToJson(order.getUnderlyingOrder());
-        String bearerToken;
-        String rsResponseBody;
-
-        try {
-            bearerToken = rsclient.getRsToken();
-            rsResponseBody = rsclient.requestWatersEndpoint(json, bearerToken);
-        } catch (ReportStreamEndpointClientException e) {
-            throw new UnableToSendMessageException("Unable to send order to ReportStream", e);
-        }
-
-        logger.logInfo("Order successfully sent to ReportStream");
-        metadata.put(order.getFhirResourceId(), EtorMetadataStep.SENT_TO_REPORT_STREAM);
-
-        Optional<String> sentSubmissionId = getSubmissionId(rsResponseBody);
-        if (sentSubmissionId.isEmpty()) {
-            logger.logError("Unable to retrieve sentSubmissionId from ReportStream response");
-        } else {
-            logger.logInfo("ReportStream response's sentSubmissionId={}", sentSubmissionId);
-        }
-
-        return sentSubmissionId;
-    }
-
-    protected Optional<String> getSubmissionId(String rsResponseBody) {
-        try {
-            Map<String, Object> rsResponse =
-                    formatter.convertJsonToObject(rsResponseBody, new TypeReference<>() {});
-            return Optional.ofNullable(rsResponse.get("submissionId").toString());
-        } catch (FormatterProcessingException e) {
-            logger.logError("Unable to get the submissionId", e);
-        }
-
-        return Optional.empty();
+        return sender.sendToReportStream(json, order.getFhirResourceId(), "order");
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSender.java
@@ -13,9 +13,9 @@ public class ReportStreamOrderSender implements OrderSender {
 
     private static final ReportStreamOrderSender INSTANCE = new ReportStreamOrderSender();
 
-    @Inject private ReportStreamSenderHelper sender;
-    @Inject private HapiFhir fhir;
-    @Inject private Logger logger;
+    @Inject ReportStreamSenderHelper sender;
+    @Inject HapiFhir fhir;
+    @Inject Logger logger;
 
     public static ReportStreamOrderSender getInstance() {
         return INSTANCE;
@@ -27,6 +27,6 @@ public class ReportStreamOrderSender implements OrderSender {
     public Optional<String> send(final Order<?> order) throws UnableToSendMessageException {
         logger.logInfo("Sending the order to ReportStream");
         String json = fhir.encodeResourceToJson(order.getUnderlyingOrder());
-        return sender.sendToReportStream(json, order.getFhirResourceId(), "order");
+        return sender.sendOrderToReportStream(json, order.getFhirResourceId());
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamResultSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamResultSender.java
@@ -3,7 +3,10 @@ package gov.hhs.cdc.trustedintermediary.external.reportstream;
 import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException;
 import gov.hhs.cdc.trustedintermediary.etor.results.Result;
 import gov.hhs.cdc.trustedintermediary.etor.results.ResultSender;
+import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import java.util.Optional;
+import javax.inject.Inject;
 
 /**
  * This class is responsible for sending results to the ReportStream service and receiving a
@@ -13,6 +16,10 @@ public class ReportStreamResultSender implements ResultSender {
 
     private static final ReportStreamResultSender INSTANCE = new ReportStreamResultSender();
 
+    @Inject private ReportStreamSenderHelper sender;
+    @Inject private HapiFhir fhir;
+    @Inject private Logger logger;
+
     public static ReportStreamResultSender getInstance() {
         return INSTANCE;
     }
@@ -21,7 +28,8 @@ public class ReportStreamResultSender implements ResultSender {
 
     @Override
     public Optional<String> send(Result<?> result) throws UnableToSendMessageException {
-        // todo: implement in #616
-        return Optional.empty();
+        logger.logInfo("Sending results to ReportStream");
+        String json = fhir.encodeResourceToJson(result.getUnderlyingResult());
+        return sender.sendToReportStream(json, result.getFhirResourceId(), "result");
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamResultSender.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamResultSender.java
@@ -16,9 +16,9 @@ public class ReportStreamResultSender implements ResultSender {
 
     private static final ReportStreamResultSender INSTANCE = new ReportStreamResultSender();
 
-    @Inject private ReportStreamSenderHelper sender;
-    @Inject private HapiFhir fhir;
-    @Inject private Logger logger;
+    @Inject ReportStreamSenderHelper sender;
+    @Inject HapiFhir fhir;
+    @Inject Logger logger;
 
     public static ReportStreamResultSender getInstance() {
         return INSTANCE;
@@ -30,6 +30,6 @@ public class ReportStreamResultSender implements ResultSender {
     public Optional<String> send(Result<?> result) throws UnableToSendMessageException {
         logger.logInfo("Sending results to ReportStream");
         String json = fhir.encodeResourceToJson(result.getUnderlyingResult());
-        return sender.sendToReportStream(json, result.getFhirResourceId(), "result");
+        return sender.sendResultToReportStream(json, result.getFhirResourceId());
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
@@ -36,7 +36,7 @@ public class ReportStreamSenderHelper {
         return sendToReportStream(body, fhirResourceId, "order");
     }
 
-    public Optional<String> sendToReportStream(
+    protected Optional<String> sendToReportStream(
             String body, String fhirResourceId, String messageType)
             throws UnableToSendMessageException {
         String bearerToken;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
@@ -15,15 +15,25 @@ import javax.inject.Inject;
 public class ReportStreamSenderHelper {
     private static final ReportStreamSenderHelper INSTANCE = new ReportStreamSenderHelper();
 
-    @Inject private RSEndpointClient rsclient;
-    @Inject private Formatter formatter;
-    @Inject private Logger logger;
+    @Inject RSEndpointClient rsclient;
+    @Inject Formatter formatter;
+    @Inject Logger logger;
     @Inject MetricMetadata metadata;
 
     private ReportStreamSenderHelper() {}
 
     public static ReportStreamSenderHelper getInstance() {
         return INSTANCE;
+    }
+
+    public Optional<String> sendResultToReportStream(String body, String fhirResourceId)
+            throws UnableToSendMessageException {
+        return sendToReportStream(body, fhirResourceId, "result");
+    }
+
+    public Optional<String> sendOrderToReportStream(String body, String fhirResourceId)
+            throws UnableToSendMessageException {
+        return sendToReportStream(body, fhirResourceId, "order");
     }
 
     public Optional<String> sendToReportStream(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
@@ -27,14 +27,14 @@ public class ReportStreamSenderHelper {
         return INSTANCE;
     }
 
-    public Optional<String> sendResultToReportStream(String body, String fhirResourceId)
-            throws UnableToSendMessageException {
-        return sendToReportStream(body, fhirResourceId, "result");
-    }
-
     public Optional<String> sendOrderToReportStream(String body, String fhirResourceId)
             throws UnableToSendMessageException {
         return sendToReportStream(body, fhirResourceId, "order");
+    }
+
+    public Optional<String> sendResultToReportStream(String body, String fhirResourceId)
+            throws UnableToSendMessageException {
+        return sendToReportStream(body, fhirResourceId, "result");
     }
 
     protected Optional<String> sendToReportStream(

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 
+/** Helper class for sending messages to ReportStream */
 public class ReportStreamSenderHelper {
     private static final ReportStreamSenderHelper INSTANCE = new ReportStreamSenderHelper();
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelper.java
@@ -1,0 +1,67 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream;
+
+import gov.hhs.cdc.trustedintermediary.etor.RSEndpointClient;
+import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
+import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException;
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+
+public class ReportStreamSenderHelper {
+    private static final ReportStreamSenderHelper INSTANCE = new ReportStreamSenderHelper();
+
+    @Inject private RSEndpointClient rsclient;
+    @Inject private Formatter formatter;
+    @Inject private Logger logger;
+    @Inject MetricMetadata metadata;
+
+    private ReportStreamSenderHelper() {}
+
+    public static ReportStreamSenderHelper getInstance() {
+        return INSTANCE;
+    }
+
+    public Optional<String> sendToReportStream(
+            String body, String fhirResourceId, String messageType)
+            throws UnableToSendMessageException {
+        String bearerToken;
+        String rsResponseBody;
+
+        try {
+            bearerToken = rsclient.getRsToken();
+            rsResponseBody = rsclient.requestWatersEndpoint(body, bearerToken);
+        } catch (ReportStreamEndpointClientException e) {
+            throw new UnableToSendMessageException(
+                    "Unable to send " + messageType + " to ReportStream", e);
+        }
+
+        logger.logInfo("{} successfully sent to ReportStream", messageType);
+        metadata.put(fhirResourceId, EtorMetadataStep.SENT_TO_REPORT_STREAM);
+
+        Optional<String> sentSubmissionId = getSubmissionId(rsResponseBody);
+        if (sentSubmissionId.isEmpty()) {
+            logger.logError("Unable to retrieve sentSubmissionId from ReportStream response");
+        } else {
+            logger.logInfo("ReportStream response's sentSubmissionId={}", sentSubmissionId);
+        }
+
+        return sentSubmissionId;
+    }
+
+    protected Optional<String> getSubmissionId(String rsResponseBody) {
+        try {
+            Map<String, Object> rsResponse =
+                    formatter.convertJsonToObject(rsResponseBody, new TypeReference<>() {});
+            return Optional.ofNullable(rsResponse.get("submissionId").toString());
+        } catch (FormatterProcessingException e) {
+            logger.logError("Unable to get the submissionId", e);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/ResultMock.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/ResultMock.groovy
@@ -10,9 +10,9 @@ class ResultMock<T> implements Result<T> {
     private String fhirResourceId
     private T underlyingResult
 
-    ResultMock(String fhirResourceId, T underlyingOrders) {
+    ResultMock(String fhirResourceId, T underlyingResult) {
         this.fhirResourceId = fhirResourceId
-        this.underlyingResult = underlyingOrders
+        this.underlyingResult = underlyingResult
     }
 
     @Override

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamOrderSenderTest.groovy
@@ -3,20 +3,10 @@ package gov.hhs.cdc.trustedintermediary.external.reportstream
 import gov.hhs.cdc.trustedintermediary.OrderMock
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.RSEndpointClient
-import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderSender
-import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
 import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient
-import gov.hhs.cdc.trustedintermediary.wrappers.AuthEngine
-import gov.hhs.cdc.trustedintermediary.wrappers.Cache
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir
-import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient
-import gov.hhs.cdc.trustedintermediary.wrappers.Logger
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
-import gov.hhs.cdc.trustedintermediary.wrappers.Secrets
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
-import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference
 import spock.lang.Specification
 
 class ReportStreamOrderSenderTest extends Specification {
@@ -31,106 +21,24 @@ class ReportStreamOrderSenderTest extends Specification {
 
     def "send order works"() {
         given:
-        def mockAuthEngine = Mock(AuthEngine)
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
+        def fhirResourceId = null
+        def underlyingOrder = "Mock order"
+        def mockOrder = new OrderMock(fhirResourceId, "patient-id", underlyingOrder)
 
-        def mockSecrets = Mock(Secrets)
-        TestApplicationContext.register(Secrets, mockSecrets)
-
-        def mockClient = Mock(HttpClient)
-        mockClient.post(_ as String, _ as Map, _ as String) >> """{"submissionId": "fake-id", "key": "value"}"""
-        TestApplicationContext.register(HttpClient, mockClient)
+        def senderHelper = Mock(ReportStreamSenderHelper)
+        senderHelper.sendOrderToReportStream(underlyingOrder, fhirResourceId) >> Optional.of("fake-id")
+        TestApplicationContext.register(ReportStreamSenderHelper, senderHelper)
 
         def mockFhir = Mock(HapiFhir)
-        mockFhir.encodeResourceToJson(_ as String) >> "Mock order"
+        mockFhir.encodeResourceToJson(_ as String) >> underlyingOrder
         TestApplicationContext.register(HapiFhir, mockFhir)
-
-        def mockFormatter = Mock(Formatter)
-        mockFormatter.convertJsonToObject(_ as String, _ as TypeReference) >> Map.of("submissionId", "fake-id")
-        TestApplicationContext.register(Formatter, mockFormatter)
-
-        def mockCache = Mock(Cache)
-        TestApplicationContext.register(Cache, mockCache)
 
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        ReportStreamOrderSender.getInstance().send(new OrderMock(null, null, "Mock order"))
+        ReportStreamOrderSender.getInstance().send(mockOrder)
 
         then:
         noExceptionThrown()
-    }
-
-    def "log the step to metadata when send order is called"() {
-        given:
-
-        def mockAuthEngine = Mock(AuthEngine)
-        TestApplicationContext.register(AuthEngine, mockAuthEngine)
-
-        def mockSecrets = Mock(Secrets)
-        TestApplicationContext.register(Secrets, mockSecrets)
-
-        def mockClient = Mock(HttpClient)
-        mockClient.post(_ as String, _ as Map, _ as String) >> """{"submissionId": "fake-id", "key": "value"}"""
-        TestApplicationContext.register(HttpClient, mockClient)
-
-        def mockFhir = Mock(HapiFhir)
-        mockFhir.encodeResourceToJson(_ as String) >> "Mock order"
-        TestApplicationContext.register(HapiFhir, mockFhir)
-
-        def mockFormatter = Mock(Formatter)
-        mockFormatter.convertJsonToObject(_ as String, _ as TypeReference) >> Map.of("submissionId", "fake-id")
-        TestApplicationContext.register(Formatter, mockFormatter)
-
-        def mockCache = Mock(Cache)
-        TestApplicationContext.register(Cache, mockCache)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().send(new OrderMock(null, null, "Mock order"))
-
-        then:
-        1 * ReportStreamOrderSender.getInstance().metadata.put(_, EtorMetadataStep.SENT_TO_REPORT_STREAM)
-    }
-
-    def "getSubmissionId logs submissionId if convertJsonToObject is successful"() {
-        given:
-        def mockSubmissionId = "fake-id"
-        def mockResponseBody = """{"submissionId": "${mockSubmissionId}", "key": "value"}"""
-
-        TestApplicationContext.register(Formatter, Jackson.getInstance())
-
-        def mockLogger = Mock(Logger)
-        TestApplicationContext.register(Logger, mockLogger)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        def submissionId = ReportStreamOrderSender.getInstance().getSubmissionId(mockResponseBody)
-
-        then:
-        submissionId.get() == mockSubmissionId
-    }
-
-    def "getSubmissionId logs error if convertJsonToObject fails"() {
-        given:
-        def mockResponseBody = '{"submissionId": "fake-id", "key": "value"}'
-        def exception = new FormatterProcessingException("couldn't convert json", new Exception())
-
-        def mockFormatter = Mock(Formatter)
-        mockFormatter.convertJsonToObject(_ as String, _ as TypeReference) >> { throw exception }
-        TestApplicationContext.register(Formatter, mockFormatter)
-
-        def mockLogger = Mock(Logger)
-        TestApplicationContext.register(Logger, mockLogger)
-
-        TestApplicationContext.injectRegisteredImplementations()
-
-        when:
-        ReportStreamOrderSender.getInstance().getSubmissionId(mockResponseBody)
-
-        then:
-        1 * mockLogger.logError(_ as String, exception)
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelperTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/reportstream/ReportStreamSenderHelperTest.groovy
@@ -1,0 +1,81 @@
+package gov.hhs.cdc.trustedintermediary.external.reportstream
+
+import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
+import gov.hhs.cdc.trustedintermediary.etor.RSEndpointClient
+import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep
+import gov.hhs.cdc.trustedintermediary.external.jackson.Jackson
+import gov.hhs.cdc.trustedintermediary.external.localfile.MockRSEndpointClient
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger
+import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.FormatterProcessingException
+import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference
+import spock.lang.Specification
+
+class ReportStreamSenderHelperTest extends Specification {
+
+    def setup() {
+        TestApplicationContext.reset()
+        TestApplicationContext.init()
+        TestApplicationContext.register(ReportStreamSenderHelper, ReportStreamSenderHelper.getInstance())
+        TestApplicationContext.register(RSEndpointClient, MockRSEndpointClient.getInstance())
+        TestApplicationContext.register(MetricMetadata, Mock(MetricMetadata))
+    }
+
+    def "sendToReportStream works"() {
+        given:
+        def mockFormatter = Mock(Formatter)
+        mockFormatter.convertJsonToObject(_ as String, _ as TypeReference) >> Map.of("submissionId", "fake-id")
+        TestApplicationContext.register(Formatter, mockFormatter)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamSenderHelper.getInstance().sendToReportStream(_ as String, _ as String, _ as String)
+
+        then:
+        noExceptionThrown()
+        1 * ReportStreamSenderHelper.getInstance().metadata.put(_, EtorMetadataStep.SENT_TO_REPORT_STREAM)
+    }
+
+    def "getSubmissionId logs submissionId if convertJsonToObject is successful"() {
+        given:
+        def mockSubmissionId = "fake-id"
+        def mockResponseBody = """{"submissionId": "${mockSubmissionId}", "key": "value"}"""
+
+        TestApplicationContext.register(Formatter, Jackson.getInstance())
+
+        def mockLogger = Mock(Logger)
+        TestApplicationContext.register(Logger, mockLogger)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        def submissionId = ReportStreamSenderHelper.getInstance().getSubmissionId(mockResponseBody)
+
+        then:
+        noExceptionThrown()
+        submissionId.get() == mockSubmissionId
+    }
+
+    def "getSubmissionId logs error if convertJsonToObject fails"() {
+        given:
+        def mockResponseBody = '{"submissionId": "fake-id", "key": "value"}'
+        def exception = new FormatterProcessingException("couldn't convert json", new Exception())
+
+        def mockFormatter = Mock(Formatter)
+        mockFormatter.convertJsonToObject(_ as String, _ as TypeReference) >> { throw exception }
+        TestApplicationContext.register(Formatter, mockFormatter)
+
+        def mockLogger = Mock(Logger)
+        TestApplicationContext.register(Logger, mockLogger)
+
+        TestApplicationContext.injectRegisteredImplementations()
+
+        when:
+        ReportStreamSenderHelper.getInstance().getSubmissionId(mockResponseBody)
+
+        then:
+        1 * mockLogger.logError(_ as String, exception)
+    }
+}


### PR DESCRIPTION
# Implementation to send the FHIR result to RS Waters endpoint

- Implemented `ReportStreamResultSender.send` to call RS water API
- Refactored to extract common code for `ReportStreamOrderSender` and `ReportStreamResultSender` into helper class: `ReportStreamSenderHelper`
- Added test coverage

## Issue

#616 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
