### PR TITLE
Refactoring and convertAndSend implementation

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -173,7 +173,7 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleOrders(DomainRequest request) {
         return handleMessageRequest(
                 request,
-                (receivedSubmissionId) -> {
+                receivedSubmissionId -> {
                     Order<?> orders = orderController.parseOrders(request);
                     sendOrderUseCase.convertAndSend(orders, receivedSubmissionId);
                     return domainResponseHelper.constructOkResponse(new OrderResponse(orders));
@@ -185,7 +185,7 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleResults(DomainRequest request) {
         return handleMessageRequest(
                 request,
-                (receivedSubmissionId) -> {
+                receivedSubmissionId -> {
                     Result<?> results = resultController.parseResults(request);
                     sendResultUseCase.convertAndSend(results);
                     return domainResponseHelper.constructOkResponse(new ResultResponse(results));

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
@@ -1,0 +1,8 @@
+package gov.hhs.cdc.trustedintermediary.etor.messages;
+
+import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
+
+@FunctionalInterface
+public interface MessageRequestHandler<T> {
+    T handle(String receivedSubmissionId) throws FhirParseException, UnableToSendMessageException;
+}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
@@ -2,7 +2,20 @@ package gov.hhs.cdc.trustedintermediary.etor.messages;
 
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException;
 
+/**
+ * Functional interface for handling message requests.
+ *
+ * @param <T> the type of the response
+ */
 @FunctionalInterface
 public interface MessageRequestHandler<T> {
+    /**
+     * Parses the request, converts and sends the message
+     *
+     * @param receivedSubmissionId the ID for the submission returned from ReportStream
+     * @return the response
+     * @throws FhirParseException if there is an error parsing the FHIR data
+     * @throws UnableToSendMessageException if there is an error sending the message
+     */
     T handle(String receivedSubmissionId) throws FhirParseException, UnableToSendMessageException;
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
@@ -3,6 +3,7 @@ package gov.hhs.cdc.trustedintermediary.etor.results;
 import gov.hhs.cdc.trustedintermediary.etor.messages.SendMessageUseCase;
 import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException;
 import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
 import javax.inject.Inject;
 
@@ -13,6 +14,7 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
     @Inject ResultConverter converter;
     @Inject ResultSender sender;
     @Inject MetricMetadata metadata;
+    @Inject Logger logger;
 
     private SendResultUseCase() {}
 
@@ -23,6 +25,7 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
     @Override
     public void convertAndSend(Result<?> result) throws UnableToSendMessageException {
 
+        // todo: for story #650 (results metadata)
         // savePartnerMetadataForReceivedResult(receivedSubmissionId, result)
 
         var convertedResult = converter.addEtorProcessingTag(result);
@@ -31,7 +34,9 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
                 EtorMetadataStep.ETOR_PROCESSING_TAG_ADDED_TO_MESSAGE_HEADER);
 
         String sentSubmissionId = sender.send(convertedResult).orElse(null);
+        logger.logInfo("Sent result submissionId: {}", sentSubmissionId);
 
+        // todo: for story #650 (results metadata)
         // saveSentResultSubmissionId(receivedSubmissionId, bundleId)
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
@@ -2,6 +2,8 @@ package gov.hhs.cdc.trustedintermediary.etor.results;
 
 import gov.hhs.cdc.trustedintermediary.etor.messages.SendMessageUseCase;
 import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException;
+import gov.hhs.cdc.trustedintermediary.etor.metadata.EtorMetadataStep;
+import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata;
 import javax.inject.Inject;
 
 /** Use case for converting and sending a lab result message. */
@@ -9,8 +11,8 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
     private static final SendResultUseCase INSTANCE = new SendResultUseCase();
 
     @Inject ResultConverter converter;
-
     @Inject ResultSender sender;
+    @Inject MetricMetadata metadata;
 
     private SendResultUseCase() {}
 
@@ -22,11 +24,14 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
     public void convertAndSend(Result<?> result) throws UnableToSendMessageException {
 
         // savePartnerMetadataForReceivedResult(receivedSubmissionId, result)
+
         var convertedResult = converter.addEtorProcessingTag(result);
-        // metadata.put(result.getFhirResourceId(),
-        // EtorMetadataStep.ETOR_PROCESSING_TAG_ADDED_TO_MESSAGE_HEADER);
-        sender.send(convertedResult); // var bundleId = sender.send(convertedResult).orElse(null),
-        // thoughts?
+        metadata.put(
+                result.getFhirResourceId(),
+                EtorMetadataStep.ETOR_PROCESSING_TAG_ADDED_TO_MESSAGE_HEADER);
+
+        String sentSubmissionId = sender.send(convertedResult).orElse(null);
+
         // saveSentResultSubmissionId(receivedSubmissionId, bundleId)
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -422,7 +422,7 @@ class EtorDomainRegistrationTest extends Specification {
         1 * mockLogger.logError(_ as String, _ as Exception)
 
         when:
-        requestHandler.handle(_ as String) >> { throw new FhirParseException("DogCow", new NullPointerException()) }
+        requestHandler.handle(_ as String) >> { throw new UnableToSendMessageException("DogCow", new NullPointerException()) }
         response = connector.handleMessageRequest(request, requestHandler, _ as String, false)
 
         then:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
@@ -4,6 +4,7 @@ import gov.hhs.cdc.trustedintermediary.ResultMock
 import gov.hhs.cdc.trustedintermediary.context.TestApplicationContext
 import gov.hhs.cdc.trustedintermediary.etor.messages.SendMessageUseCase
 import gov.hhs.cdc.trustedintermediary.etor.messages.UnableToSendMessageException
+import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
 import spock.lang.Specification
 
 class SendResultUseCaseTest extends Specification {
@@ -17,6 +18,7 @@ class SendResultUseCaseTest extends Specification {
         TestApplicationContext.register(SendMessageUseCase, SendResultUseCase.getInstance())
         TestApplicationContext.register(ResultConverter, mockConverter)
         TestApplicationContext.register(ResultSender, mockSender)
+        TestApplicationContext.register(MetricMetadata, Mock(MetricMetadata))
         TestApplicationContext.injectRegisteredImplementations()
     }
 
@@ -29,8 +31,7 @@ class SendResultUseCaseTest extends Specification {
 
         then:
         1 * mockConverter.addEtorProcessingTag(mockResult) >> mockResult
-        1 * mockSender.send(mockResult) >> Optional.empty()
-        noExceptionThrown()
+        1 * mockSender.send(mockResult) >> Optional.of("sentSubmissionId")
     }
 
     def "convertAndSend throws exception when send fails"() {


### PR DESCRIPTION
# Refactoring and convertAndSend implementation

- Refactored to reuse code from handleOrders in handleResults and for clarity
- Updated tests and added test coverage
- Added logging for `convertAndSend`

## Issue

#616 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required