### PR TITLE
Better Database Instance when Deployed in Higher Level Environment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,7 +244,7 @@
         "filename": "operations/template/db.tf",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 16,
         "is_secret": false
       }
     ],
@@ -269,6 +269,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-09T23:44:14Z"
-
+  "generated_at": "2024-02-16T15:55:01Z"
 }

--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -6,9 +6,10 @@ resource "azurerm_postgresql_flexible_server" "database" {
   name                  = "cdcti-${var.environment}-database"
   resource_group_name   = data.azurerm_resource_group.group.name
   location              = data.azurerm_resource_group.group.location
-  sku_name              = "B_Standard_B1ms"
+  sku_name              = local.higher_environment_level ? "B_Standard_B2ms" : "B_Standard_B1ms"
   version               = "16"
   storage_mb            = "32768"
+  auto_grow_enabled     = true
   backup_retention_days = "14"
 
   authentication {

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -6,6 +6,7 @@ locals {
   }
   selected_rs_environment_prefix = lookup(local.environment_to_rs_environment_prefix_mapping, var.environment, "staging")
   rs_domain_prefix               = "${local.selected_rs_environment_prefix}${length(local.selected_rs_environment_prefix) == 0 ? "" : "."}"
+  higher_environment_level       = var.environment == "stg" || var.environment == "prd"
 }
 
 data "azurerm_resource_group" "group" {


### PR DESCRIPTION
# Better Database Instance when Deployed in Higher Level Environment

When we are deploying to `stg` or `prd`, use a better, more powerful database.

## Issue

_None for now_.