### PR TITLE
Destroy PR Environment Only on PR Close

### DIFF
--- a/.github/workflows/terraform-ci-deploy.yml
+++ b/.github/workflows/terraform-ci-deploy.yml
@@ -17,6 +17,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # keep in sync with terraform-ci-destroy.yml
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -74,36 +75,3 @@ jobs:
       - paths-filter
     uses: ./.github/workflows/deploy_reusable-skip.yml
     if: needs.paths-filter.outputs.operations != 'true'
-
-
-  destroy-environment:
-    name: Destroy PR Environment
-    environment:
-      name: pr
-    needs:
-      - pr-deploy
-      - paths-filter
-    if: needs.paths-filter.outputs.operations == 'true' && always()
-    runs-on: ubuntu-latest
-    env:
-      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      ARM_USE_OIDC: true
-    permissions:
-      id-token: write
-      contents: read
-    defaults:
-      run:
-        working-directory: operations/environments/pr
-
-    steps:
-
-      - uses: actions/checkout@v4
-
-      - name: Terraform Init
-        id: init
-        run: terraform init -backend-config="key=pr_${{ github.event.number }}.tfstate"
-
-      - name: Terraform Destroy
-        run: terraform destroy -auto-approve -input=false -var="pr_number=${{ github.event.number }}"

--- a/.github/workflows/terraform-ci-destroy.yml
+++ b/.github/workflows/terraform-ci-destroy.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Terraform Init
-        id: init
         run: terraform init -backend-config="key=pr_${{ github.event.number }}.tfstate"
 
       - name: Terraform Destroy

--- a/.github/workflows/terraform-ci-destroy.yml
+++ b/.github/workflows/terraform-ci-destroy.yml
@@ -1,4 +1,4 @@
-name: Terraform CI Deploy
+name: Terraform CI Destroy
 
 on:
   pull_request:

--- a/.github/workflows/terraform-ci-destroy.yml
+++ b/.github/workflows/terraform-ci-destroy.yml
@@ -1,0 +1,57 @@
+name: Terraform CI Deploy
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      operations: ${{ steps.filter.outputs.operations }}
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      # keep in sync with terraform-ci-deploy.yml
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            operations:
+              - 'operations/environments/pr/**'
+              - 'operations/template/**'
+
+  destroy-environment:
+    name: Destroy PR Environment
+    environment:
+      name: pr
+    needs:
+      - paths-filter
+    if: needs.paths-filter.outputs.operations == 'true'
+    runs-on: ubuntu-latest
+    env:
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC: true
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: operations/environments/pr
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend-config="key=pr_${{ github.event.number }}.tfstate"
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve -input=false -var="pr_number=${{ github.event.number }}"


### PR DESCRIPTION
# Destroy PR Environment Only on PR Close

This will stop the destruction of the PR environment immediately after creation.  It will instead delete it after the PR is closed, whether that was due to it merging or being closed without merging.

This gives us some benefits.

1. We get a passing check of this deploy at the end of the deploy instead of needing to wait for the deletion to also occur.
2. This will speed-up subsequent commits that are made to the branch after the PR is created because only the delta will need to be deployed instead of the entire PR environment needing to be redeployed.
3. This is more realistic with our other deploys.  We don't constantly delete our internal, dev, staging, and prod environments.

## Issue

_None_.