### PR TITLE
Make the public IP address used by the VPN a standard static IP

### DIFF
--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -3,7 +3,7 @@ resource "azurerm_public_ip" "vpn" {
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
 
-  sku = "Standard"
+  sku               = "Standard"
   allocation_method = "Static"
 }
 

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -3,7 +3,8 @@ resource "azurerm_public_ip" "vpn" {
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
 
-  allocation_method = "Dynamic"
+  sku = "Standard"
+  allocation_method = "Static"
 }
 
 resource "azurerm_virtual_network_gateway" "vpn" {


### PR DESCRIPTION
Apparently we need this update.

The creation of VPNs now suddenly require a "standard" (and therefore "static") public IP address.