### PR TITLE
621: Order/Result Linking Fields Added to Metadata Table

### DIFF
--- a/etor/databaseMigrations/metadata.yml
+++ b/etor/databaseMigrations/metadata.yml
@@ -84,3 +84,28 @@ databaseChangeLog:
               - column:
                   name: message_type
                   type: message_type
+  - changeSet:
+      id: 5
+      author: halprin
+      labels: update-metadata-table
+      context: metadata
+      comment: update partner metadata table for order and result linking
+      changes:
+        - addColumn:
+            tableName: metadata
+            columns:  # the size of the varchars below are based on the field's HL7 spec size
+              - column:
+                  name: placer_order_number
+                  type: varchar(427)
+              - column:
+                  name: sending_application_id
+                  type: varchar(227)
+              - column:
+                  name: sending_facility_id
+                  type: varchar(227)
+              - column:
+                  name: receiving_application_id
+                  type: varchar(227)
+              - column:
+                  name: receiving_facility_id
+                  type: varchar(227)


### PR DESCRIPTION
# Order/Result Linking Fields Added to Metadata Table

Added new columns to the `metadata` table to support our order and result linking.

## Issue

#621.
