### PR TITLE
Zap scanner image fix

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./health-check.sh
 
       - name: Run ZAP API Scan
-        run: docker run -v $(pwd):/zap/wrk/:rw --user root -t owasp/zap2docker-stable zap-api-scan.py -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):8080/openapi -f openapi -r api-scan-report.html
+        run: docker run -v $(pwd):/zap/wrk/:rw --user root -t ghcr.io/zaproxy/zaproxy:weekly zap-api-scan.py -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):8080/openapi -f openapi -r api-scan-report.html
 
       - name: Upload Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./health-check.sh
 
       - name: Run ZAP API Scan
-        run: docker run -v $(pwd):/zap/wrk/:rw --user root -t owasp/zap2docker-weekly zap-api-scan.py -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):8080/openapi -f openapi -r api-scan-report.html
+        run: docker run -v $(pwd):/zap/wrk/:rw --user root -t owasp/zap2docker-stable zap-api-scan.py -t http://$(ip -f inet -o addr show docker0 | awk '{print $4}' | cut -d '/' -f 1):8080/openapi -f openapi -r api-scan-report.html
 
       - name: Upload Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
In order to fix the below error we're getting in github actions:
```
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
exec /zap/zap-api-scan.py: exec format error
Error: Process completed with exit code 1.
```

we changed zap scanner image from `owasp/zap2docker-weekly` to `ghcr.io/zaproxy/zaproxy:weekly`, which is the recommended in the [zap official docs](https://www.zaproxy.org/download/#docker)