### PR TITLE
Add `@Override` to `SendOrderUseCase`

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -24,6 +24,7 @@ public class SendOrderUseCase implements SendMessageUseCase<Order<?>> {
         return INSTANCE;
     }
 
+    @Override
     public void convertAndSend(final Order<?> order, String receivedSubmissionId)
             throws UnableToSendMessageException {
 


### PR DESCRIPTION
# Add `@Override` to `SendOrderUseCase`

CodeQL had a finding that `@Override` was missing from `SendOrderUseCase`.  I added it.

Screenshot:
<img width="240" alt="Screenshot 2024-04-11 at 12 55 07 PM" src="https://github.com/CDCgov/trusted-intermediary/assets/16943066/df5e4c08-dcf6-464c-9f6e-11985a0c8998">


## Issue

_None_.