### PR TITLE
Story/989/ingestion time fix

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -62,7 +62,7 @@ public class PartnerMetadataOrchestrator {
             List<Map<String, String>> originalIngestion =
                     (List<Map<String, String>>) responseObject.get("originalIngestion");
 
-            if (originalIngestion == null) {
+            if (originalIngestion == null || originalIngestion.isEmpty()) {
                 throw new PartnerMetadataException(
                         "Ingestion time not found from RS delivery API response");
             }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -62,6 +62,11 @@ public class PartnerMetadataOrchestrator {
             List<Map<String, String>> originalIngestion =
                     (List<Map<String, String>>) responseObject.get("originalIngestion");
 
+            if (originalIngestion == null) {
+                throw new PartnerMetadataException(
+                        "Ingestion time not found from RS delivery API response");
+            }
+
             if (originalIngestion.size() > 1) {
                 logger.logWarning(
                         "More than 1 report ids found in originalIngestion,"

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -217,6 +217,23 @@ class PartnerMetadataOrchestratorTest extends Specification {
         thrown(PartnerMetadataException)
     }
 
+    def "updateMetadataForReceivedMessage throws PartnerMetadataException due to empty originalIngestion"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def wrongFormatResponse = "{\"originalIngestion\": {}}"
+        def messageType = PartnerMetadataMessageType.RESULT
+
+        mockClient.getRsToken() >> "token"
+        mockClient.requestDeliveryEndpoint(_ as String, _ as String) >> wrongFormatResponse
+        mockFormatter.convertJsonToObject(wrongFormatResponse, _ as TypeReference) >> [originalIngestion:[]]
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForReceivedMessage(receivedSubmissionId, "hash", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+
+        then:
+        thrown(PartnerMetadataException)
+    }
+
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -200,6 +200,23 @@ class PartnerMetadataOrchestratorTest extends Specification {
         thrown(PartnerMetadataException)
     }
 
+    def "updateMetadataForReceivedMessage throws PartnerMetadataException due to null originalIngestion"() {
+        given:
+        def receivedSubmissionId = "receivedSubmissionId"
+        def wrongFormatResponse = "{\"someOtherKey\": {}}"
+        def messageType = PartnerMetadataMessageType.RESULT
+
+        mockClient.getRsToken() >> "token"
+        mockClient.requestDeliveryEndpoint(_ as String, _ as String) >> wrongFormatResponse
+        mockFormatter.convertJsonToObject(wrongFormatResponse, _ as TypeReference) >> [someOtherKey:{}]
+
+        when:
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForReceivedMessage(receivedSubmissionId, "hash", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+
+        then:
+        thrown(PartnerMetadataException)
+    }
+
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"


### PR DESCRIPTION
# Add a PR title
When the ingestion time is not found, we were getting a null pointer exception. This PR adds a check that the `originalIngestion` time is not null and is not empty before trying to use it

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/989

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)

**Note**: You may remove items that are not applicable
