### PR TITLE
HikariCP maxLifetime settings update

### DIFF
--- a/generate_env.sh
+++ b/generate_env.sh
@@ -14,7 +14,8 @@ DB_PORT=5432      # for gradlew: DB_PORT=5433
 DB_NAME=intermediary
 DB_USER=intermediary
 DB_PASS=changeIT!
-DB_SSL=require"
+DB_SSL=require
+DB_MAX_LIFETIME=86220000"
 
 # Get directory of script file
 script_dir="$(dirname "$0")"

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -68,6 +68,7 @@ resource "azurerm_linux_web_app" "api" {
     DB_NAME                         = "postgres"
     DB_USER                         = "cdcti-${var.environment}-api"
     DB_SSL                          = "require"
+    DB_MAX_LIFETIME					= "86220000"
   }
 
   identity {

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
@@ -41,6 +41,7 @@ public class HikariConnectionPool implements ConnectionPool {
         String serverName = ApplicationContext.getProperty("DB_URL", "");
         String dbName = ApplicationContext.getProperty("DB_NAME", "");
         String dbPort = ApplicationContext.getProperty("DB_PORT", "");
+        String connectionLifetime = ApplicationContext.getProperty("DB_MAX_LIFETIME", "");
 
         HikariConfig config = new HikariDataSource();
 
@@ -50,6 +51,7 @@ public class HikariConnectionPool implements ConnectionPool {
         config.addDataSourceProperty("serverName", serverName);
         config.addDataSourceProperty("databaseName", dbName);
         config.addDataSourceProperty("portNumber", dbPort);
+        config.addDataSourceProperty("maxLifetime", connectionLifetime);
 
         return config;
     }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
@@ -41,7 +41,7 @@ public class HikariConnectionPool implements ConnectionPool {
         String serverName = ApplicationContext.getProperty("DB_URL", "");
         String dbName = ApplicationContext.getProperty("DB_NAME", "");
         String dbPort = ApplicationContext.getProperty("DB_PORT", "");
-        String connectionLifetime = ApplicationContext.getProperty("DB_MAX_LIFETIME", "");
+        String connectionLifetime = ApplicationContext.getProperty("DB_MAX_LIFETIME", "1800000");
 
         HikariConfig config = new HikariDataSource();
 


### PR DESCRIPTION
# HikariCP maxLifetime settings update

- Updates hikariCP to invalidate sessions after 23 hours and 57 minutes.
- Question: Do we need different max lifetime settings for other environments?

## Issue

Add a link to the issue here.  Consider using
[closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
if the this PR isn't for a story (stories will be closed through different means).

## Checklist

- [ ] I have added tests to cover my changes
- [ ] I have added logging where useful (with appropriate log level)
- [ ] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
