### PR TITLE
Revisit 990

### DIFF
--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ConsolidatedSummaryTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ConsolidatedSummaryTest.groovy
@@ -19,7 +19,7 @@ class ConsolidatedSummaryTest extends Specification {
 
         def orderClient = new EndpointClient("/v1/etor/orders")
         def labOrderJsonFileString = Files.readString(Path.of("../examples/Test/e2e/orders/002_ORM_O01.fhir"))
-        def senderName = "urn:dns:centracare.com"  //TODO: when story #990 is implemented, update this to be the sender from the 002_ORM_O01.fhir message
+        def senderName = "centracare.com"
 
         when:
         def orderResponse = orderClient.submit(labOrderJsonFileString, inboundSubmissionId, true)

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ConsolidatedSummaryTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/ConsolidatedSummaryTest.groovy
@@ -19,7 +19,7 @@ class ConsolidatedSummaryTest extends Specification {
 
         def orderClient = new EndpointClient("/v1/etor/orders")
         def labOrderJsonFileString = Files.readString(Path.of("../examples/Test/e2e/orders/002_ORM_O01.fhir"))
-        def senderName = "PLACE_HOLDER"  //TODO: when story #990 is implemented, update this to be the sender from the 002_ORM_O01.fhir message
+        def senderName = "urn:dns:centracare.com"  //TODO: when story #990 is implemented, update this to be the sender from the 002_ORM_O01.fhir message
 
         when:
         def orderResponse = orderClient.submit(labOrderJsonFileString, inboundSubmissionId, true)

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
@@ -46,8 +46,8 @@ class MetadataTest extends Specification {
 
         [
             "linked messages",
-            "sender name",
-            "receiver name",
+            "sender universal id",
+            "receiver universal id",
             "ingestion",
             "payload hash",
             "delivery status",

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/MetadataTest.groovy
@@ -90,8 +90,8 @@ class MetadataTest extends Specification {
 
         [
             "linked messages",
-            "sender name",
-            "receiver name",
+            "sender universal id",
+            "receiver universal id",
             "ingestion",
             "payload hash",
             "delivery status",

--- a/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
+++ b/e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/e2e/OrderTest.groovy
@@ -17,7 +17,7 @@ class OrderTest extends Specification {
 
     def "an order response is returned from the ETOR order endpoint"() {
         given:
-        def expectedFhirResourceId  = "Bundle/1696524903034430000.eb38702e-23df-4650-9e4c-c7d4b3b6b92b"
+        def expectedFhirResourceId  = "Bundle/1713991685806650392.f865cc8e-d438-4d5f-9147-05930f25a997"
         def expectedPatientId  = "11102779"
 
         when:
@@ -37,7 +37,7 @@ class OrderTest extends Specification {
         def parsedSentPayload = JsonParser.parse(sentPayload)
 
         then:
-        parsedSentPayload.entry[24].resource.contact.name.text.contains("SADIE S SMITH")
+        parsedSentPayload.entry[3].resource.contact[0].name.family.contains("SMITH")
     }
 
     def "check that ETOR processing code is added to the order before sending to report stream"() {
@@ -72,7 +72,7 @@ class OrderTest extends Specification {
         //test that everything else is the same except the MessageHeader's event, Patient contact, and etor processing tag
         parsedSentPayload.entry[0].resource.remove("eventCoding")
         parsedLabOrderJsonFile.entry[0].resource.remove("eventCoding")
-        parsedSentPayload.entry[24].resource.remove("contact")
+        parsedSentPayload.entry[3].resource.remove("contact")
         parsedSentPayload.entry[0].resource.meta.tag.remove(1)
 
         parsedSentPayload == parsedLabOrderJsonFile

--- a/etor/databaseMigrations/metadata.yml
+++ b/etor/databaseMigrations/metadata.yml
@@ -159,7 +159,7 @@ databaseChangeLog:
       id: 7
       author: Jorge.Lopez
       labels: update-metadata-table
-      context::: metadata
+      context: metadata
       comment: delete sender and receiver columns from metadata table
       changes:
         - dropColumn:

--- a/etor/databaseMigrations/metadata.yml
+++ b/etor/databaseMigrations/metadata.yml
@@ -154,3 +154,17 @@ databaseChangeLog:
             columnName: receiving_facility_details
             newDataType: jsonb
             tableName: metadata
+
+  - changeSet:
+      id: 7
+      author: Jorge.Lopez
+      labels: update-metadata-table
+      context::: metadata
+      comment: delete sender and receiver columns from metadata table
+      changes:
+        - dropColumn:
+            tableName: metadata
+            columnName: sender
+        - dropColumn:
+            tableName: metadata
+            columnName: receiver

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -8,8 +8,6 @@ import java.time.Instant;
  *
  * @param receivedSubmissionId The received submission ID.
  * @param sentSubmissionId The sent submission ID.
- * @param sender The name of the sender of the message.
- * @param receiver The name of the receiver of the message.
  * @param timeReceived The time the message was received.
  * @param timeDelivered The time the message was delivered.
  * @param hash The hash of the message.
@@ -18,8 +16,6 @@ import java.time.Instant;
 public record PartnerMetadata(
         String receivedSubmissionId,
         String sentSubmissionId,
-        String sender,
-        String receiver,
         Instant timeReceived,
         Instant timeDelivered,
         String hash,
@@ -41,7 +37,6 @@ public record PartnerMetadata(
 
     public PartnerMetadata(
             String receivedSubmissionId,
-            String sender,
             Instant timeReceived,
             Instant timeDelivered,
             String hash,
@@ -54,8 +49,6 @@ public record PartnerMetadata(
             String placerOrderNumber) {
         this(
                 receivedSubmissionId,
-                null,
-                sender,
                 null,
                 timeReceived,
                 timeDelivered,
@@ -84,8 +77,6 @@ public record PartnerMetadata(
                 null,
                 null,
                 null,
-                null,
-                null,
                 hash,
                 null,
                 null,
@@ -104,8 +95,6 @@ public record PartnerMetadata(
                 null,
                 null,
                 null,
-                null,
-                null,
                 deliveryStatus,
                 null,
                 null,
@@ -120,46 +109,6 @@ public record PartnerMetadata(
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 sentSubmissionId,
-                this.sender,
-                this.receiver,
-                this.timeReceived,
-                this.timeDelivered,
-                this.hash,
-                this.deliveryStatus,
-                this.failureReason,
-                this.messageType,
-                this.sendingApplicationDetails,
-                this.sendingFacilityDetails,
-                this.receivingApplicationDetails,
-                this.receivingFacilityDetails,
-                this.placerOrderNumber);
-    }
-
-    public PartnerMetadata withSender(String sender) {
-        return new PartnerMetadata(
-                this.receivedSubmissionId,
-                this.sentSubmissionId,
-                sender,
-                this.receiver,
-                this.timeReceived,
-                this.timeDelivered,
-                this.hash,
-                this.deliveryStatus,
-                this.failureReason,
-                this.messageType,
-                this.sendingApplicationDetails,
-                this.sendingFacilityDetails,
-                this.receivingApplicationDetails,
-                this.receivingFacilityDetails,
-                this.placerOrderNumber);
-    }
-
-    public PartnerMetadata withReceiver(String receiver) {
-        return new PartnerMetadata(
-                this.receivedSubmissionId,
-                this.sentSubmissionId,
-                this.sender,
-                receiver,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -177,8 +126,6 @@ public record PartnerMetadata(
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 this.sentSubmissionId,
-                this.sender,
-                this.receiver,
                 timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -196,8 +143,6 @@ public record PartnerMetadata(
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 this.sentSubmissionId,
-                this.sender,
-                this.receiver,
                 this.timeReceived,
                 timeDelivered,
                 this.hash,
@@ -215,8 +160,6 @@ public record PartnerMetadata(
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 this.sentSubmissionId,
-                this.sender,
-                this.receiver,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -234,8 +177,6 @@ public record PartnerMetadata(
         return new PartnerMetadata(
                 this.receivedSubmissionId,
                 this.sentSubmissionId,
-                this.sender,
-                this.receiver,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -37,34 +37,6 @@ public record PartnerMetadata(
 
     public PartnerMetadata(
             String receivedSubmissionId,
-            Instant timeReceived,
-            Instant timeDelivered,
-            String hash,
-            PartnerMetadataStatus deliveryStatus,
-            PartnerMetadataMessageType messageType,
-            MessageHdDataType sendingApplicationDetails,
-            MessageHdDataType sendingFacilityDetails,
-            MessageHdDataType receivingApplicationDetails,
-            MessageHdDataType receivingFacilityDetails,
-            String placerOrderNumber) {
-        this(
-                receivedSubmissionId,
-                null,
-                timeReceived,
-                timeDelivered,
-                hash,
-                deliveryStatus,
-                null,
-                messageType,
-                sendingApplicationDetails,
-                sendingFacilityDetails,
-                receivingApplicationDetails,
-                receivingFacilityDetails,
-                placerOrderNumber);
-    }
-
-    public PartnerMetadata(
-            String receivedSubmissionId,
             String hash,
             PartnerMetadataMessageType messageType,
             MessageHdDataType sendingApplicationDetails,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -88,10 +88,8 @@ public class PartnerMetadataOrchestrator {
                     "Unable to retrieve metadata from RS delivery API", e);
         }
 
-        String sender = "PLACE_HOLDER";
-        logger.logInfo("Updating metadata with sender: {}, timeReceived: {}", sender, timeReceived);
-        PartnerMetadata updatedPartnerMetadata =
-                partnerMetadata.withSender(sender).withTimeReceived(timeReceived);
+        logger.logInfo("Updating metadata with timeReceived: {}", timeReceived);
+        PartnerMetadata updatedPartnerMetadata = partnerMetadata.withTimeReceived(timeReceived);
         partnerMetadataStorage.saveMetadata(updatedPartnerMetadata);
     }
 
@@ -158,7 +156,7 @@ public class PartnerMetadataOrchestrator {
             var ourStatus = ourStatusFromReportStreamStatus(rsStatus);
 
             logger.logInfo("Updating metadata with receiver {} and status {}", receiver, ourStatus);
-            partnerMetadata = partnerMetadata.withReceiver(receiver).withDeliveryStatus(ourStatus);
+            partnerMetadata = partnerMetadata.withDeliveryStatus(ourStatus);
 
             if (ourStatus == PartnerMetadataStatus.FAILED) {
                 partnerMetadata = partnerMetadata.withFailureMessage(rsMessage);
@@ -342,7 +340,7 @@ public class PartnerMetadataOrchestrator {
     }
 
     private boolean metadataIsStale(PartnerMetadata partnerMetadata) {
-        return partnerMetadata.receiver() == null
+        return partnerMetadata.receivingFacilityDetails().universalId() == null
                 || partnerMetadata.deliveryStatus() == PartnerMetadataStatus.PENDING;
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -162,8 +162,6 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
             return new PartnerMetadata(
                     resultSet.getString(METADATA_TABLE_RECEIVED_MESSAGE_ID),
                     resultSet.getString("sent_message_id"),
-                    resultSet.getString("sender"),
-                    resultSet.getString("receiver"),
                     timeReceived,
                     timeDelivered,
                     resultSet.getString("hash_of_message"),
@@ -197,8 +195,16 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                         false,
                         Types.VARCHAR),
                 new DbColumn("sent_message_id", metadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn("sender", metadata.sender(), false, Types.VARCHAR),
-                new DbColumn("receiver", metadata.receiver(), true, Types.VARCHAR),
+                new DbColumn(
+                        "sender",
+                        metadata.sendingFacilityDetails().universalId(),
+                        false,
+                        Types.VARCHAR),
+                new DbColumn(
+                        "receiver",
+                        metadata.receivingFacilityDetails().universalId(),
+                        true,
+                        Types.VARCHAR),
                 new DbColumn("hash_of_message", metadata.hash(), false, Types.VARCHAR),
                 new DbColumn(
                         "time_received",

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -195,16 +195,6 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                         false,
                         Types.VARCHAR),
                 new DbColumn("sent_message_id", metadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn(
-                        "sender",
-                        metadata.sendingFacilityDetails().universalId(),
-                        false,
-                        Types.VARCHAR),
-                new DbColumn(
-                        "receiver",
-                        metadata.receivingFacilityDetails().universalId(),
-                        true,
-                        Types.VARCHAR),
                 new DbColumn("hash_of_message", metadata.hash(), false, Types.VARCHAR),
                 new DbColumn(
                         "time_received",

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMessage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMessage.java
@@ -71,11 +71,7 @@ public class HapiMessage implements Message<Bundle> {
                 .flatMap(patient -> patient.getIdentifier().stream())
                 .filter(
                         identifier ->
-                                identifier
-                                        .getType()
-                                        .hasCoding(
-                                                "http://terminology.hl7.org/CodeSystem/v2-0203",
-                                                "MR"))
+                                "MR".equals(identifier.getType().getCodingFirstRep().getCode()))
                 .map(Identifier::getValue)
                 .findFirst()
                 .orElse("");

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
@@ -30,10 +30,18 @@ public class HapiPartnerMetadataConverter implements PartnerMetadataConverter {
                         createInformationIssueComponent(
                                 "linked messages", messageIdsToLink.toString()));
 
-        operation.getIssue().add(createInformationIssueComponent("sender name", metadata.sender()));
         operation
                 .getIssue()
-                .add(createInformationIssueComponent("receiver name", metadata.receiver()));
+                .add(
+                        createInformationIssueComponent(
+                                "sender universal id",
+                                metadata.sendingFacilityDetails().universalId()));
+        operation
+                .getIssue()
+                .add(
+                        createInformationIssueComponent(
+                                "receiver universal id",
+                                metadata.receivingFacilityDetails().universalId()));
 
         String ingestion = null;
         String delivered = null;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -97,14 +97,19 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
     }
 
     @Override
-    public Set<PartnerMetadata> readMetadataForSender(String sender)
+    public Set<PartnerMetadata> readMetadataForSender(String senderUniversalId)
             throws PartnerMetadataException {
         try {
             return getPartnerMetadata().stream()
-                    .filter(metadata -> metadata.sender().equals(sender))
+                    .filter(
+                            metadata ->
+                                    metadata.sendingFacilityDetails()
+                                            .universalId()
+                                            .equals(senderUniversalId))
                     .collect(Collectors.toSet());
         } catch (Exception e) {
-            throw new PartnerMetadataException("Failed reading metadata for sender: " + sender, e);
+            throw new PartnerMetadataException(
+                    "Failed reading metadata for sender: " + senderUniversalId, e);
         }
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -276,7 +276,7 @@ class EtorDomainRegistrationTest extends Specification {
         given:
         def expectedStatusCode = 200
         def receivedSubmissionId = "receivedSubmissionId"
-        def metadata = new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), null,
+        def metadata = new PartnerMetadata("receivedSubmissionId", Instant.now(), null,
                 "hash", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER,
                 sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
         def linkedMessageIds = new HashSet<>(Set.of(receivedSubmissionId, "Test1", "Test2"))

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -21,7 +21,6 @@ import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataConv
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataException
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataMessageType
 import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataOrchestrator
-import gov.hhs.cdc.trustedintermediary.etor.metadata.partner.PartnerMetadataStatus
 import gov.hhs.cdc.trustedintermediary.etor.operationoutcomes.FhirMetadata
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderController
 import gov.hhs.cdc.trustedintermediary.etor.orders.OrderResponse
@@ -32,11 +31,7 @@ import gov.hhs.cdc.trustedintermediary.etor.results.SendResultUseCase
 import gov.hhs.cdc.trustedintermediary.wrappers.FhirParseException
 import gov.hhs.cdc.trustedintermediary.wrappers.HapiFhir
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger
-
-import java.time.Instant
 import spock.lang.Specification
-
-import java.util.stream.Collectors
 
 class EtorDomainRegistrationTest extends Specification {
 
@@ -276,9 +271,7 @@ class EtorDomainRegistrationTest extends Specification {
         given:
         def expectedStatusCode = 200
         def receivedSubmissionId = "receivedSubmissionId"
-        def metadata = new PartnerMetadata("receivedSubmissionId", Instant.now(), null,
-                "hash", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER,
-                sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
+        def metadata = new PartnerMetadata("receivedSubmissionId", "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
         def linkedMessageIds = Set.of(receivedSubmissionId, "Test1", "Test2")
 
         def connector = new EtorDomainRegistration()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -51,8 +51,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         receivingFacility = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         testMetadata = new PartnerMetadata(receivedSubmissionId,
-                sentSubmissionId
-                ,
+                sentSubmissionId,
                 timeReceived,
                 timeDelivered,
                 hashCode,
@@ -114,9 +113,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         def expectedMetadata = new PartnerMetadata(
                 receivedSubmissionId,
-                sentSubmissionId
-
-                ,
+                sentSubmissionId,
                 Instant.parse(timestamp),
                 timeDelivered,
                 hashCode,
@@ -702,8 +699,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def mockMetadata = [
             new PartnerMetadata(
             "123456789",
-            null
-            ,
+            null,
             Instant.now(),
             null,
             null,

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -53,9 +53,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         receivingFacility = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         testMetadata = new PartnerMetadata(receivedSubmissionId,
-                sentSubmissionId,
-                sender,
-                receiver,
+                sentSubmissionId
+                ,
                 timeReceived,
                 timeDelivered,
                 hashCode,
@@ -117,9 +116,9 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         def expectedMetadata = new PartnerMetadata(
                 receivedSubmissionId,
-                sentSubmissionId,
-                "PLACE_HOLDER",
-                receiver,
+                sentSubmissionId
+
+                ,
                 Instant.parse(timestamp),
                 timeDelivered,
                 hashCode,
@@ -164,7 +163,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentMessage ends when sentSubmissionId matches the one provided by PartnerMetadata"() {
         given:
-        def optional = Optional.of(new PartnerMetadata(receivedSubmissionId, sentSubmissionId,"","",Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
+        def optional = Optional.of(new PartnerMetadata(receivedSubmissionId, sentSubmissionId, Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> optional
 
         when:
@@ -279,7 +278,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sender", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
         def updatedPartnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId)
 
         when:
@@ -303,7 +302,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata throws PartnerMetadataException on client error"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
@@ -319,7 +318,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata throws PartnerMetadataException on formatter error"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
@@ -335,7 +334,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata retrieves metadata successfully with the sender already filled"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", "sender", "receiver", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def metadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         when:
         def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
@@ -349,7 +348,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata skips lookup with stale metadata and missing sentSubmissionId"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, "sender", "receiver", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
 
         when:
         PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
@@ -362,7 +361,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata retrieves metadata successfully when receiver is present and sentSubmissionId is missing"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, "sender", "receiver", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         when:
         def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
@@ -377,8 +376,9 @@ class PartnerMetadataOrchestratorTest extends Specification {
         given:
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "{\"actualCompletionAt\": \"2023-10-24T19:48:26.921Z\",\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, null, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, "org.service", timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def receivingFacilityWithMissingUniversalId = new MessageHdDataType("receiving_app_name", null, "receiving_app_type")
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
@@ -404,8 +404,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata gets status if still pending in metadata"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
@@ -431,8 +431,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         given:
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
@@ -462,7 +462,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata saves pending without delivery time if nobody has delivery times"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
@@ -492,8 +492,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata saves loaded delivered metadata if found"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
@@ -523,7 +523,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "setMetadataStatusToFailed sets status to Failed"() {
         given:
         def submissionId = "13425"
-        def optional = Optional.of(new PartnerMetadata("","","","",Instant.now(),null, "",PartnerMetadataStatus.PENDING, "Bad Message", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
+        def optional = Optional.of(new PartnerMetadata("", "", Instant.now(), null, "", PartnerMetadataStatus.PENDING, "Bad Message", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
         mockPartnerMetadataStorage.readMetadata(submissionId) >> optional
 
         when:
@@ -538,7 +538,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "setMetadataStatusToFailed doesn't update status if status is the same"() {
         given:
         def submissionId = "13425"
-        def optional = Optional.of(new PartnerMetadata("","","","",Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
+        def optional = Optional.of(new PartnerMetadata("", "", Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
         mockPartnerMetadataStorage.readMetadata(submissionId) >> optional
 
         when:
@@ -731,9 +731,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def mockMetadata = [
             new PartnerMetadata(
             "123456789",
-            null,
-            sender,
-            "receiver_name",
+            null
+            ,
             Instant.now(),
             null,
             null,
@@ -768,8 +767,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def partnerMetadata1 = new PartnerMetadata(receivedSubmissionId1, "sender1", Instant.now(), null, "hash1", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
-        def partnerMetadata2 = new PartnerMetadata(receivedSubmissionId2, "sender2", Instant.now(), null, "hash2", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def partnerMetadata1 = new PartnerMetadata(receivedSubmissionId1, Instant.now(), null, "hash1", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def partnerMetadata2 = new PartnerMetadata(receivedSubmissionId2, Instant.now(), null, "hash2", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
         def metadataSetForMessageLinking = Set.of(partnerMetadata1, partnerMetadata2)
         mockPartnerMetadataStorage.readMetadataForMessageLinking(receivedSubmissionId) >> metadataSetForMessageLinking
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -25,7 +25,6 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def sentSubmissionId = "sentSubmissionId"
     def hashCode = "hash"
     def bearerToken = "token"
-    def sender = "sender"
     def placerOrderNumber = "placer_order_number"
     def timeReceived = Instant.now()
     def timeDelivered = null

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -276,7 +276,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
         def updatedPartnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId)
 
         when:
@@ -738,8 +738,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def partnerMetadata1 = new PartnerMetadata(receivedSubmissionId1, Instant.now(), null, "hash1", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
-        def partnerMetadata2 = new PartnerMetadata(receivedSubmissionId2, Instant.now(), null, "hash2", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def partnerMetadata1 = new PartnerMetadata(receivedSubmissionId1, "hash1", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def partnerMetadata2 = new PartnerMetadata(receivedSubmissionId2, "hash2", PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
         def metadataSetForMessageLinking = Set.of(partnerMetadata1, partnerMetadata2)
         mockPartnerMetadataStorage.readMetadataForMessageLinking(receivedSubmissionId) >> metadataSetForMessageLinking
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -717,10 +717,10 @@ class PartnerMetadataOrchestratorTest extends Specification {
             placerOrderNumber
             )
         ]
-        mockPartnerMetadataStorage.readMetadataForSender(sender) >> mockMetadata
+        mockPartnerMetadataStorage.readMetadataForSender(_ as String) >> mockMetadata
 
         when:
-        def result = PartnerMetadataOrchestrator.getInstance().getConsolidatedMetadata(sender)
+        def result = PartnerMetadataOrchestrator.getInstance().getConsolidatedMetadata("sender")
 
         then:
         !result.isEmpty()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
@@ -19,8 +19,6 @@ class PartnerMetadataTest extends Specification {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
         def sentSubmissionId = "sentSubmissionId"
-        def sender = "sender"
-        def receiver = "receiver"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
         def hash = "abcd"
@@ -33,13 +31,11 @@ class PartnerMetadataTest extends Specification {
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
         metadata.sentSubmissionId() == sentSubmissionId
-        metadata.sender() == sender
-        metadata.receiver() == receiver
         metadata.timeDelivered() == timeDelivered
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
@@ -54,7 +50,6 @@ class PartnerMetadataTest extends Specification {
     def "test overloaded constructor"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def sender = "sender"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
         def hash = "abcd"
@@ -65,13 +60,11 @@ class PartnerMetadataTest extends Specification {
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sender, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
         metadata.sentSubmissionId() == null
-        metadata.sender() == sender
-        metadata.receiver() == null
         metadata.timeReceived() == timeReceived
         metadata.timeDelivered() == timeDelivered
         metadata.hash() == hash
@@ -93,20 +86,16 @@ class PartnerMetadataTest extends Specification {
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
         metadata.sentSubmissionId() == null
-        metadata.sender() == null
-        metadata.receiver() == null
         metadata.timeReceived() == null
         metadata.timeDelivered() == null
         metadata.hash() == null
         metadata.deliveryStatus() == deliverStatus
     }
 
-    def "test withSentSubmissionId and withReceiver to update PartnerMetadata"() {
+    def "test withSentSubmissionId to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
         def sentSubmissionId = "sentSubmissionId"
-        def sender = "sender"
-        def receiver = "receiver"
         def messageType = PartnerMetadataMessageType.RESULT
         def timeReceived = Instant.now()
         def hash = "abcd"
@@ -117,16 +106,14 @@ class PartnerMetadataTest extends Specification {
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, sender, null, timeReceived, null, hash, status, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, null, timeReceived, null, hash, status, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
-        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withReceiver(receiver)
+        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId)
 
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
         updatedMetadata.sentSubmissionId() == sentSubmissionId
-        updatedMetadata.sender() == sender
-        updatedMetadata.receiver() == receiver
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.hash() == hash
         updatedMetadata.deliveryStatus() == status
@@ -140,8 +127,6 @@ class PartnerMetadataTest extends Specification {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
         def sentSubmissionId = "sentSubmissionId"
-        def sender = "sender"
-        def receiver = "receiver"
         def timeReceived = Instant.now()
         def timeDelivered = null
         def messageType = PartnerMetadataMessageType.RESULT
@@ -151,7 +136,7 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def newStatus = PartnerMetadataStatus.DELIVERED
@@ -160,8 +145,6 @@ class PartnerMetadataTest extends Specification {
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
         updatedMetadata.sentSubmissionId() == sentSubmissionId
-        updatedMetadata.sender() == sender
-        updatedMetadata.receiver() == receiver
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == null
         updatedMetadata.hash() == hash
@@ -177,8 +160,6 @@ class PartnerMetadataTest extends Specification {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
         def sentSubmissionId = "sentSubmissionId"
-        def sender = "sender"
-        def receiver = "receiver"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
         def messageType = PartnerMetadataMessageType.RESULT
@@ -188,7 +169,7 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, sender, receiver, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def updatedMetadata = metadata.withTimeDelivered(timeDelivered)
@@ -196,8 +177,6 @@ class PartnerMetadataTest extends Specification {
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
         updatedMetadata.sentSubmissionId() == sentSubmissionId
-        updatedMetadata.sender() == sender
-        updatedMetadata.receiver() == receiver
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == timeDelivered
         updatedMetadata.hash() == hash

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
@@ -47,34 +47,6 @@ class PartnerMetadataTest extends Specification {
         metadata.receivingFacilityDetails() == receivingFacilityDetails
     }
 
-    def "test overloaded constructor"() {
-        given:
-        def receivedSubmissionId = "receivedSubmissionId"
-        def timeReceived = Instant.now()
-        def timeDelivered = Instant.now()
-        def hash = "abcd"
-        def status = PartnerMetadataStatus.DELIVERED
-        def sendingAppDetails = new MessageHdDataType("sending_app_name", "sending_app_id", "sending_app_type")
-        def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
-        def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
-        def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-
-        when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
-
-        then:
-        metadata.receivedSubmissionId() == receivedSubmissionId
-        metadata.sentSubmissionId() == null
-        metadata.timeReceived() == timeReceived
-        metadata.timeDelivered() == timeDelivered
-        metadata.hash() == hash
-        metadata.deliveryStatus() == status
-        metadata.sendingApplicationDetails() == sendingAppDetails
-        metadata.sendingFacilityDetails() == sendingFacilityDetails
-        metadata.receivingApplicationDetails() == receivingAppDetails
-        metadata.receivingFacilityDetails() == receivingFacilityDetails
-    }
-
     def "test constructor with only received submission ID and status"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -31,7 +31,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
     def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
     def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
     def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-    def mockMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+    def mockMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
     def setup() {
         TestApplicationContext.reset()
@@ -105,8 +105,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn("sender", mockMetadata.sender(), false, Types.VARCHAR),
-                new DbColumn("receiver", mockMetadata.receiver(), true, Types.VARCHAR),
+                new DbColumn("sender", mockMetadata.sendingFacilityDetails().universalId(), false, Types.VARCHAR),
+                new DbColumn("receiver", mockMetadata.receivingFacilityDetails().universalId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", Timestamp.from(mockMetadata.timeReceived()),false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", Timestamp.from(mockMetadata.timeDelivered()),true, Types.TIMESTAMP),
@@ -203,9 +203,9 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def testMapper = new ObjectMapper()
         def mockMetadata = new PartnerMetadata(
                 "receivedSubmissionId",
-                "sentSubmissionId",
-                "sender",
-                "receiver",
+                "sentSubmissionId"
+
+                ,
                 null,
                 null,
                 "hash",
@@ -223,8 +223,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn("sender", mockMetadata.sender(), false, Types.VARCHAR),
-                new DbColumn("receiver", mockMetadata.receiver(), true, Types.VARCHAR),
+                new DbColumn("sender", mockMetadata.sendingFacilityDetails().universalId(), false, Types.VARCHAR),
+                new DbColumn("receiver", mockMetadata.receivingFacilityDetails().universalId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", null, false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", null,true, Types.TIMESTAMP),
@@ -332,7 +332,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def reason = "It done Goofed"
         def messageType = PartnerMetadataMessageType.RESULT
         def placerOrderNumber = "placer_order_number"
-        def expected = new PartnerMetadata(receivedMessageId, sentMessageId, sender, receiver, timeReceived, timeDelivered, hash, status, reason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def expected = new PartnerMetadata(receivedMessageId, sentMessageId, timeReceived, timeDelivered, hash, status, reason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
 
         def mockResultSet = Mock(ResultSet)
         mockResultSet.next() >> true

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -105,8 +105,6 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn("sender", mockMetadata.sendingFacilityDetails().universalId(), false, Types.VARCHAR),
-                new DbColumn("receiver", mockMetadata.receivingFacilityDetails().universalId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", Timestamp.from(mockMetadata.timeReceived()),false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", Timestamp.from(mockMetadata.timeDelivered()),true, Types.TIMESTAMP),
@@ -223,8 +221,6 @@ class DatabasePartnerMetadataStorageTest extends Specification {
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
-                new DbColumn("sender", mockMetadata.sendingFacilityDetails().universalId(), false, Types.VARCHAR),
-                new DbColumn("receiver", mockMetadata.receivingFacilityDetails().universalId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", null, false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", null,true, Types.TIMESTAMP),

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -201,9 +201,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def testMapper = new ObjectMapper()
         def mockMetadata = new PartnerMetadata(
                 "receivedSubmissionId",
-                "sentSubmissionId"
-
-                ,
+                "sentSubmissionId",
                 null,
                 null,
                 "hash",

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
@@ -28,7 +28,7 @@ class HapiMetadataConverterTest extends Specification {
     def "ExtractPublicMetadata to OperationOutcome returns FHIR metadata"() {
         given:
 
-        def sendingFacilytId = "sending_facility_id"
+        def sendingFacilityId = "sending_facility_id"
         def receivingFacilityId = "receiving_facility_id"
         def time = Instant.now()
         def hash = "hash"
@@ -44,7 +44,7 @@ class HapiMetadataConverterTest extends Specification {
         then:
         result.getId() == "receivedSubmissionId"
         result.getIssue().get(0).diagnostics == messageIds.toString()
-        result.getIssue().get(1).diagnostics == sendingFacilytId
+        result.getIssue().get(1).diagnostics == sendingFacilityId
         result.getIssue().get(2).diagnostics == receivingFacilityId
         result.getIssue().get(3).diagnostics == time.toString()
         result.getIssue().get(4).diagnostics == hash

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
@@ -28,15 +28,15 @@ class HapiMetadataConverterTest extends Specification {
     def "ExtractPublicMetadata to OperationOutcome returns FHIR metadata"() {
         given:
 
-        def sender = "sender"
-        def receiver = "receiver"
+        def sendingFacilytId = "sending_facility_id"
+        def receivingFacilityId = "receiving_facility_id"
         def time = Instant.now()
         def hash = "hash"
         def failureReason = "timed_out"
         def messageType =  PartnerMetadataMessageType.ORDER
         def messageIds = Set.of("TestId")
         PartnerMetadata metadata = new PartnerMetadata(
-                "receivedSubmissionId", "sentSubmissionId", sender, receiver, time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+                "receivedSubmissionId", "sentSubmissionId", time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def result = HapiPartnerMetadataConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata, "receivedSubmissionId", messageIds).getUnderlyingOutcome() as OperationOutcome
@@ -44,8 +44,8 @@ class HapiMetadataConverterTest extends Specification {
         then:
         result.getId() == "receivedSubmissionId"
         result.getIssue().get(0).diagnostics == messageIds.toString()
-        result.getIssue().get(1).diagnostics == sender
-        result.getIssue().get(2).diagnostics == receiver
+        result.getIssue().get(1).diagnostics == sendingFacilytId
+        result.getIssue().get(2).diagnostics == receivingFacilityId
         result.getIssue().get(3).diagnostics == time.toString()
         result.getIssue().get(4).diagnostics == hash
         result.getIssue().get(5).diagnostics == time.toString()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -33,7 +33,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
         def expectedSentSubmissionId = "receivedSubmissionId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"),Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -48,7 +48,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId","sender", "receiver", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}
@@ -67,7 +67,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
         def expectedSentSubmissionId = "sentSubmissionId"
-        PartnerMetadata metadata1 = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, "sender", "receiver", Instant.parse("2023-12-04T18:51:48.941875Z"),Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata1 = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
         PartnerMetadata metadata2 = new PartnerMetadata(expectedReceivedSubmissionId, PartnerMetadataStatus.DELIVERED)
 
 
@@ -93,7 +93,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
         //write something to the hard drive so that the `readMetadata` in the when gets pass the file existence check
         def submissionId = "asljfaskljgalsjgjlas"
-        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata)
 
         when:
@@ -114,8 +114,8 @@ class FilePartnerMetadataStorageTest extends Specification {
     def "readMetadataForSender returns a set of PartnerMetadata"() {
         given:
         def sender = "same_sender"
-        PartnerMetadata metadata2 = new PartnerMetadata("abcdefghi", null, sender, null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
-        PartnerMetadata metadata1 = new PartnerMetadata("123456789", null, sender, null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata2 = new PartnerMetadata("abcdefghi", null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata1 = new PartnerMetadata("123456789", null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -138,8 +138,8 @@ class FilePartnerMetadataStorageTest extends Specification {
         def receivedSubmissionId1 = "receivedSubmissionId1"
         def matchingPlacerOrderNumber1 = "placerOrderNumber1"
         def matchingSendingFacilityDetails1 = new MessageHdDataType("sending_facility_name1", "sending_facility_id1", "sending_facility_type1")
-        def matchingSendingFacilityDetailsMetadata1 = new PartnerMetadata(receivedSubmissionId1, null, null, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
-        def otherMatchingSendingFacilityDetailsMetadata1 = new PartnerMetadata("1", null, null, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
+        def matchingSendingFacilityDetailsMetadata1 = new PartnerMetadata(receivedSubmissionId1, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
+        def otherMatchingSendingFacilityDetailsMetadata1 = new PartnerMetadata("1", null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingSendingFacilityDetailsMetadata1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(otherMatchingSendingFacilityDetailsMetadata1)
         def metadataSetWithMatchingSendingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId1)
@@ -151,8 +151,8 @@ class FilePartnerMetadataStorageTest extends Specification {
         def receivedSubmissionId2 = "receivedSubmissionId2"
         def matchingPlacerOrderNumber2 = "placerOrderNumber2"
         def matchingSendingFacilityDetails2 = new MessageHdDataType("sending_facility_name2", "sending_facility_id2", "sending_facility_type2")
-        def matchingSendingFacilityDetailsMetadata2 = new PartnerMetadata(receivedSubmissionId2, null, null, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails2, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber2)
-        def matchingReceivingFacilityDetailsMetadata2 = new PartnerMetadata("2", null, null, null, null, null, null, null, null, null, null, new MessageHdDataType(null, null, null), null, matchingSendingFacilityDetails2, matchingPlacerOrderNumber2)
+        def matchingSendingFacilityDetailsMetadata2 = new PartnerMetadata(receivedSubmissionId2, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails2, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber2)
+        def matchingReceivingFacilityDetailsMetadata2 = new PartnerMetadata("2", null, null, null, null, null, null, null, null, new MessageHdDataType(null, null, null), null, matchingSendingFacilityDetails2, matchingPlacerOrderNumber2)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingSendingFacilityDetailsMetadata2)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingReceivingFacilityDetailsMetadata2)
         def metadataSetWithMatchingSendingAndReceivingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId2)
@@ -178,7 +178,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         def submissionId = "submissionId"
-        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null, null, null, null, null, null, null, null)
+        PartnerMetadata metadata = new PartnerMetadata(submissionId, null, null, null, null, null, null, null, null, null, null, null, null)
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata)
 
         when:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -113,7 +113,6 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "readMetadataForSender returns a set of PartnerMetadata"() {
         given:
-        def sender = "same_sender"
         PartnerMetadata metadata2 = new PartnerMetadata("abcdefghi", null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
         PartnerMetadata metadata1 = new PartnerMetadata("123456789", null, null, null, null, null, null, null, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
@@ -123,7 +122,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         when:
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata2)
-        def metadataSet = FilePartnerMetadataStorage.getInstance().readMetadataForSender(sender)
+        def metadataSet = FilePartnerMetadataStorage.getInstance().readMetadataForSender(sendingFacilityDetails.universalId())
 
         then:
         metadataSet.containsAll(Set.of(metadata1, metadata2))

--- a/examples/Test/e2e/orders/002_ORM_O01.fhir
+++ b/examples/Test/e2e/orders/002_ORM_O01.fhir
@@ -1,1406 +1,1626 @@
 {
-  "resourceType" : "Bundle",
-  "id" : "1696524903034430000.eb38702e-23df-4650-9e4c-c7d4b3b6b92b",
-  "meta" : {
-    "lastUpdated" : "2023-10-05T12:55:03.058-04:00"
-  },
-  "identifier" : {
-    "system" : "https://reportstream.cdc.gov/prime-router",
-    "value" : "31808297"
-  },
-  "type" : "message",
-  "timestamp" : "2023-05-06T06:29:16.000-04:00",
-  "entry" : [ {
-    "fullUrl" : "MessageHeader/87c2d0db-6f31-3666-b9e2-7152e039c11f",
-    "resource" : {
-      "resourceType" : "MessageHeader",
-      "id" : "87c2d0db-6f31-3666-b9e2-7152e039c11f",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/application-acknowledgement-type",
-        "valueIdentifier" : {
-          "type" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                "valueString" : "identifier"
-              } ],
-              "system" : "http://terminology.hl7.org/CodeSystem/v3-AcknowledgementCondition",
-              "code" : "AL"
-            } ]
-          }
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/accept-acknowledgement-type",
-        "valueIdentifier" : {
-          "type" : {
-            "coding" : [ {
-              "extension" : [ {
-                "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-                "valueString" : "identifier"
-              } ],
-              "system" : "http://terminology.hl7.org/CodeSystem/v3-AcknowledgementCondition",
-              "code" : "AL"
-            } ]
-          }
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-message-profile-id",
-        "valueIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.82"
-          } ],
-          "value" : "LAB_PRU_COMPONENT"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/source-message-profile-id",
-        "valueIdentifier" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-            "valueOid" : "urn:oid:2.16.840.1.113883.9.22"
-          } ],
-          "value" : "LAB_TO_COMPONENT"
-        }
-      } ],
-      "eventCoding" : {
-        "system" : "http://terminology.hl7.org/CodeSystem/v2-0003",
-        "code" : "O01",
-        "display" : "ORM - Order message (also RDE, RDS, RGV, RAS)"
-      },
-      "destination" : [ {
-        "target" : {
-          "reference" : "Device/1696524903179002000.a59db3f2-22e7-4276-9af7-fc1d6b528ef0"
+    "resourceType": "Bundle",
+    "id": "1713991685806650392.f865cc8e-d438-4d5f-9147-05930f25a997",
+    "meta": {
+        "lastUpdated": "2024-04-24T20:48:05.813+00:00"
+    },
+    "identifier": {
+        "system": "https://reportstream.cdc.gov/prime-router",
+        "value": "31808297"
+    },
+    "type": "message",
+    "timestamp": "2023-05-06T10:29:16.000+00:00",
+    "entry": [
+        {
+            "fullUrl": "MessageHeader/87c2d0db-6f31-3666-b9e2-7152e039c11f",
+            "resource": {
+                "resourceType": "MessageHeader",
+                "id": "87c2d0db-6f31-3666-b9e2-7152e039c11f",
+                "meta": {
+                    "tag": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0103",
+                            "code": "P"
+                        }
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+                        "extension": [
+                            {
+                                "url": "MSH.7",
+                                "valueString": "20230506052916-0500"
+                            },
+                            {
+                                "url": "MSH.15",
+                                "valueString": "AL"
+                            },
+                            {
+                                "url": "MSH.16",
+                                "valueString": "AL"
+                            },
+                            {
+                                "url": "MSH.21",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "2.16.840.1.113883.9.82"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "LAB_PRU_COMPONENT"
+                                }
+                            },
+                            {
+                                "url": "MSH.21",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "2.16.840.1.113883.9.22"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "LAB_TO_COMPONENT"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "eventCoding": {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0003",
+                    "code": "O01",
+                    "display": "ORM^O01^ORM_O01"
+                },
+                "destination": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                "valueString": "natus.health.state.mn.us"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                "valueString": "DNS"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "MSH.5"
+                            }
+                        ],
+                        "name": "NATUS",
+                        "receiver": {
+                            "reference": "Organization/1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3"
+                        }
+                    }
+                ],
+                "sender": {
+                    "reference": "Organization/1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494"
+                },
+                "source": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                            "valueString": "Epic"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                            "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                            "valueString": "ISO"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                            "valueString": "MSH.3"
+                        }
+                    ],
+                    "endpoint": "urn:oid:1.2.840.114350.1.13.145.2.7.2.695071"
+                }
+            }
         },
-        "endpoint" : "urn:dns:natus.health.state.mn.us",
-        "receiver" : {
-          "reference" : "Organization/urn-oid-2.16.840.1.114222.4.1.10080"
-        }
-      } ],
-      "sender" : {
-        "reference" : "Organization/1696524904963483000.5567ed19-73ed-4b9d-a340-9f6cb985d512"
-      },
-      "source" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/software-vendor-org",
-          "valueReference" : {
-            "reference" : "Organization/1696524903199973000.d613edeb-6e7d-4345-a4d9-1734a298649d"
-          }
-        } ],
-        "name" : "Epic",
-        "endpoint" : "urn:oid:1.2.840.114350.1.13.145.2.7.2.695071"
-      }
-    }
-  }, {
-    "fullUrl" : "Device/1696524903179002000.a59db3f2-22e7-4276-9af7-fc1d6b528ef0",
-    "resource" : {
-      "resourceType" : "Device",
-      "id" : "1696524903179002000.a59db3f2-22e7-4276-9af7-fc1d6b528ef0",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "identifier" : [ {
-        "value" : "NATUS"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "DNS"
-          } ]
+        {
+            "fullUrl": "Organization/1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "Centracare"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.2,HD.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0301",
+                                    "code": "DNS"
+                                }
+                            ]
+                        },
+                        "value": "centracare.com"
+                    }
+                ]
+            }
         },
-        "value" : "urn:dns:natus.health.state.mn.us"
-      } ]
-    }
-  }, {
-    "fullUrl" : "Organization/urn-oid-2.16.840.1.114222.4.1.10080",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "urn-oid-2.16.840.1.114222.4.1.10080",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "identifier" : [ {
-        "value" : "MN Public Health Lab"
-      }, {
-        "system" : "urn:id:ISO",
-        "value" : "urn:oid:2.16.840.1.114222.4.1.10080"
-      } ],
-      "name" : "MN Public Health Lab"
-    }
-  }, {
-    "fullUrl" : "Organization/1696524903199973000.d613edeb-6e7d-4345-a4d9-1734a298649d",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1696524903199973000.d613edeb-6e7d-4345-a4d9-1734a298649d",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1696524904963483000.5567ed19-73ed-4b9d-a340-9f6cb985d512",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1696524904963483000.5567ed19-73ed-4b9d-a340-9f6cb985d512",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "identifier" : [ {
-        "value" : "Centracare"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0301",
-            "code" : "DNS"
-          } ]
+        {
+            "fullUrl": "Organization/1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                        "valueString": "MSH.6"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "MN Public Health Lab"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.2,HD.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0301",
+                                    "code": "ISO"
+                                }
+                            ]
+                        },
+                        "system": "urn:ietf:rfc:3986",
+                        "value": "2.16.840.1.114222.4.1.10080"
+                    }
+                ]
+            }
         },
-        "value" : "urn:dns:centracare.com"
-      } ]
-    }
-  }, {
-    "fullUrl" : "ServiceRequest/1696524905596070000.982d36d6-9de4-478e-bddf-1ac475969203",
-    "resource" : {
-      "resourceType" : "ServiceRequest",
-      "id" : "1696524905596070000.982d36d6-9de4-478e-bddf-1ac475969203",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/entered-by",
-        "valueReference" : {
-          "reference" : "Practitioner/1696524905590098000.1b15ae2a-294b-4bc2-8833-bd7c092da451"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/collector-identifier",
-        "valueReference" : {
-          "reference" : "Practitioner/1696524905593616000.50d7ff17-4b52-4935-ae59-4252163b4ad7"
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/order-control",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0119",
-            "code" : "NW"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/enterers-location",
-        "valueReference" : {
-          "reference" : "Location/1696524905608195000.86353182-af17-4402-8b01-a8b9be49dd70"
-        }
-      } ],
-      "identifier" : [ {
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "VN",
-            "display" : "Visit number"
-          } ]
+        {
+            "fullUrl": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
+                        "extension": [
+                            {
+                                "url": "PID.8"
+                            },
+                            {
+                                "url": "PID.24",
+                                "valueString": "N"
+                            },
+                            {
+                                "url": "PID.30",
+                                "valueString": "N"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+                        "valueHumanName": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                                    "extension": [
+                                        {
+                                            "url": "XPN.2",
+                                            "valueString": "SADIE"
+                                        },
+                                        {
+                                            "url": "XPN.3",
+                                            "valueString": "S"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "family": "SMITH",
+                            "given": [
+                                "SADIE",
+                                "S"
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cx-identifier",
+                                "extension": [
+                                    {
+                                        "url": "CX.5",
+                                        "valueString": "MR"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "PID.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR"
+                                }
+                            ]
+                        },
+                        "value": "11102779",
+                        "assigner": {
+                            "reference": "Organization/1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                                "extension": [
+                                    {
+                                        "url": "XPN.2",
+                                        "valueString": "BB SARAH"
+                                    },
+                                    {
+                                        "url": "XPN.7",
+                                        "valueString": "L"
+                                    }
+                                ]
+                            }
+                        ],
+                        "use": "official",
+                        "text": "TestValue",
+                        "family": "SMITH",
+                        "given": [
+                            "BB SARAH"
+                        ]
+                    }
+                ],
+                "telecom": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                                "valueString": "763"
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                                "valueString": "5555555"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                                "extension": [
+                                    {
+                                        "url": "XTN.3",
+                                        "valueString": "PH"
+                                    },
+                                    {
+                                        "url": "XTN.7",
+                                        "valueString": "5555555"
+                                    },
+                                    {
+                                        "url": "XTN.9",
+                                        "valueString": "(763)555-5555"
+                                    }
+                                ]
+                            }
+                        ],
+                        "system": "phone",
+                        "use": "home"
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "2023-05-04",
+                "_birthDate": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230504131023-0500"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                            "valueDateTime": "2023-05-04T13:10:23-05:00"
+                        }
+                    ]
+                },
+                "deceasedBoolean": false,
+                "address": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                                        "extension": [
+                                            {
+                                                "url": "SAD.1",
+                                                "valueString": "555 STATE HIGHWAY 13"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "url": "XAD.7",
+                                        "valueCode": "H"
+                                    }
+                                ]
+                            }
+                        ],
+                        "use": "home",
+                        "line": [
+                            "555 STATE HIGHWAY 13"
+                        ],
+                        "city": "DEER CREEK",
+                        "district": "OTTER TAIL",
+                        "state": "MN",
+                        "postalCode": "56527-9657",
+                        "country": "USA"
+                    }
+                ],
+                "multipleBirthInteger": 1
+            }
         },
-        "value" : "20230506052916-0500"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "code" : "CMS"
-          } ]
+        {
+            "fullUrl": "Organization/1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "CRPMRN"
+                    }
+                ]
+            }
         },
-        "value" : "1043269798"
-      }, {
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "code" : "MN Public Health Lab"
-          } ]
+        {
+            "fullUrl": "ServiceRequest/1713991686444544794.4cd34f9e-a7da-489c-8c3a-bd8c3edfaf67",
+            "resource": {
+                "resourceType": "ServiceRequest",
+                "id": "1713991686444544794.4cd34f9e-a7da-489c-8c3a-bd8c3edfaf67",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+                        "valueCode": "NW"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+                        "valueString": "20230506052913-0500"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/orc-common-order",
+                        "extension": [
+                            {
+                                "url": "orc-21-ordering-facility-name",
+                                "valueReference": {
+                                    "reference": "Organization/1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee"
+                                }
+                            },
+                            {
+                                "url": "orc-21-ordering-facility-name",
+                                "valueReference": {
+                                    "reference": "Organization/1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7"
+                                }
+                            },
+                            {
+                                "url": "orc-12-ordering-provider",
+                                "valueReference": {
+                                    "reference": "Practitioner/1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+                        "extension": [
+                            {
+                                "url": "OBR.2",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                                    "valueString": "EPIC"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "421832901"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "ORC.2"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "EPIC"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                        "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                        "valueCode": "ISO"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "PLAC"
+                                }
+                            ]
+                        },
+                        "value": "421832901"
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "authoredOn": "2023-05-06T05:29:13-05:00",
+                "_authoredOn": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506052913-0500"
+                        }
+                    ]
+                },
+                "requester": {
+                    "reference": "PractitionerRole/1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69"
+                }
+            }
         },
-        "value" : "739"
-      }, {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
-          "valueOid" : "urn:oid:1.2.840.114350.1.13.145.2.7.2.695071"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "PLAC",
-            "display" : "Placer Identifier"
-          } ]
+        {
+            "fullUrl": "Organization/1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "NPI"
+                    }
+                ]
+            }
         },
-        "system" : "urn:id:EPIC",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "intent" : "order",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "57717-1",
-          "display" : "Newborn screen card data panel"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "authoredOn" : "2023-05-06T05:29:13-05:00",
-      "requester" : {
-        "reference" : "PractitionerRole/1696524905605919000.526f1b1a-137b-4d92-b7b7-b1bea7c7c206"
-      }
-    }
-  }, {
-    "fullUrl" : "Practitioner/1696524905599676000.ad4c02b2-9fbb-4ced-a8f9-67b393e96297",
-    "resource" : {
-      "resourceType" : "Practitioner",
-      "id" : "1696524905599676000.ad4c02b2-9fbb-4ced-a8f9-67b393e96297",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/identifier-type",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "NPI"
-          } ]
+        {
+            "fullUrl": "Practitioner/1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                "valueString": "NPI"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+                        "extension": [
+                            {
+                                "url": "XCN.3",
+                                "valueString": "JANE"
+                            },
+                            {
+                                "url": "XCN.10",
+                                "valueString": "L"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                        "valueString": "ORC.12"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/codeable-concept-id",
+                                            "valueBoolean": true
+                                        }
+                                    ],
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1265136360",
+                        "assigner": {
+                            "reference": "Organization/1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "JONES",
+                        "given": [
+                            "JANE"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "1043269798"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "CMS"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1043269798"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "PractitionerRole/1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69",
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69",
+                "practitioner": {
+                    "reference": "Practitioner/1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90"
+                },
+                "organization": {
+                    "reference": "Organization/1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92"
+                }
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "1043269798"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "CMS"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1043269798"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "739"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "MN Public Health Lab"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "Submitter ID"
+                                }
+                            ]
+                        },
+                        "value": "739"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "NPI"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Practitioner/1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                "valueString": "NPI"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+                        "extension": [
+                            {
+                                "url": "XCN.3",
+                                "valueString": "JANE"
+                            },
+                            {
+                                "url": "XCN.10",
+                                "valueString": "L"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/codeable-concept-id",
+                                            "valueBoolean": true
+                                        }
+                                    ],
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1265136360",
+                        "assigner": {
+                            "reference": "Organization/1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "JONES",
+                        "given": [
+                            "JANE"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686770356478.1910e6f0-c091-4478-a7f6-ede1f3711b9f",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686770356478.1910e6f0-c091-4478-a7f6-ede1f3711b9f",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "NM"
+                            },
+                            {
+                                "url": "OBX.6"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueQuantity": {
+                    "value": 1769.859285,
+                    "unit": "gram",
+                    "system": "UCUM",
+                    "code": "g"
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686773981137.7654ca2c-c90e-4880-866c-78f7c3d61588",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686773981137.7654ca2c-c90e-4880-866c-78f7c3d61588",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "NM"
+                            },
+                            {
+                                "url": "OBX.6"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueQuantity": {
+                    "value": 32,
+                    "unit": "week",
+                    "system": "UCUM",
+                    "code": "wk"
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686778919180.4f83879b-26ec-45bc-a16f-58e38dd46ea3",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686778919180.4f83879b-26ec-45bc-a16f-58e38dd46ea3",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "LN"
+                                }
+                            ],
+                            "system": "http://loinc.org",
+                            "code": "LA12419-0",
+                            "display": "INFANT IN NICU AT TIME OF SPECIMEN COLLECTION"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686783139235.a7075e17-9502-475c-b90a-0edfda449102",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686783139235.a7075e17-9502-475c-b90a-0edfda449102",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "99MDH"
+                                }
+                            ],
+                            "code": "N",
+                            "display": "No"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686787125753.05d047e1-ecf3-44a0-8841-f62c3ade0387",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686787125753.05d047e1-ecf3-44a0-8841-f62c3ade0387",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "99MDH"
+                                }
+                            ],
+                            "code": "N",
+                            "display": "No"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686791894378.3b7f2442-ace2-4616-b31f-994b86b9d686",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686791894378.3b7f2442-ace2-4616-b31f-994b86b9d686",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "99MDH"
+                                }
+                            ],
+                            "code": "N",
+                            "display": "No"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686796144608.38f07204-4f1c-43fe-a3fa-2648d1096dbc",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686796144608.38f07204-4f1c-43fe-a3fa-2648d1096dbc",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "LN"
+                                }
+                            ],
+                            "system": "http://loinc.org",
+                            "code": "LA12418-2",
+                            "display": "TPN"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686800186780.fc150027-9bcd-4702-b42c-6f59eeb7a76c",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686800186780.fc150027-9bcd-4702-b42c-6f59eeb7a76c",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "2"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                },
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding-system",
+                                    "valueString": "LN"
+                                }
+                            ],
+                            "system": "http://loinc.org",
+                            "code": "LA16914-6",
+                            "display": "BREAST MILK"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686804166695.05121bda-975b-4ce2-a3ba-59474ae6bd9e",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686804166695.05121bda-975b-4ce2-a3ba-59474ae6bd9e",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "CWE"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueCodeableConcept": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueString": "coding"
+                                }
+                            ],
+                            "code": "0516199364"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686807044974.13f12de1-4176-48f9-b77d-9c799016ecad",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686807044974.13f12de1-4176-48f9-b77d-9c799016ecad",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "ST"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueString": "Daniel Davis/218-555-1000"
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686810079127.568c53dc-8759-4dc6-95fb-71d7e2cb852d",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686810079127.568c53dc-8759-4dc6-95fb-71d7e2cb852d",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "ST"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueString": "DAVIS, DANIEL, MD"
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686813383865.7041736d-1b39-4ad4-b661-e4bb140471eb",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686813383865.7041736d-1b39-4ad4-b661-e4bb140471eb",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "ST"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueString": "Lakeridge Health Revere"
+            }
+        },
+        {
+            "fullUrl": "Specimen/1713991686845404556.ccf23f10-1abe-4090-aa7c-c91dd0988c22",
+            "resource": {
+                "resourceType": "Specimen",
+                "id": "1713991686845404556.ccf23f10-1abe-4090-aa7c-c91dd0988c22",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Segment",
+                        "valueString": "SPM"
+                    }
+                ]
+            }
         }
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority-namespace-id",
-          "valueString" : "NPI"
-        } ],
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "NPI",
-            "display" : "National provider identifier"
-          } ]
-        },
-        "system" : "http://hl7.org/fhir/sid/us-npi",
-        "value" : "1265136360"
-      } ],
-      "name" : [ {
-        "use" : "official",
-        "text" : "JANE JONES",
-        "family" : "JONES",
-        "given" : [ "JANE" ]
-      } ]
-    }
-  }, {
-    "fullUrl" : "Location/1696524905603533000.3f6b4881-4a5e-453d-8002-6571bad68864",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1696524905603533000.3f6b4881-4a5e-453d-8002-6571bad68864",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Organization/1696524905605634000.8ae477ca-eb62-435f-b4f8-c839e9b7182b",
-    "resource" : {
-      "resourceType" : "Organization",
-      "id" : "1696524905605634000.8ae477ca-eb62-435f-b4f8-c839e9b7182b",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
-        "valueCoding" : {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0204",
-          "code" : "L",
-          "display" : "Legal name"
-        }
-      } ],
-      "identifier" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
-            "valueString" : "CMS"
-          } ]
-        }, {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-facility",
-          "valueReference" : {
-            "reference" : "Location/1696524905603533000.3f6b4881-4a5e-453d-8002-6571bad68864"
-          }
-        } ],
-        "type" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "NPI"
-          } ]
-        },
-        "value" : "1043269798"
-      } ],
-      "name" : "ST. CLOUD HOSPITAL"
-    }
-  }, {
-    "fullUrl" : "PractitionerRole/1696524905605919000.526f1b1a-137b-4d92-b7b7-b1bea7c7c206",
-    "resource" : {
-      "resourceType" : "PractitionerRole",
-      "id" : "1696524905605919000.526f1b1a-137b-4d92-b7b7-b1bea7c7c206",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "practitioner" : {
-        "reference" : "Practitioner/1696524905599676000.ad4c02b2-9fbb-4ced-a8f9-67b393e96297"
-      },
-      "organization" : {
-        "reference" : "Organization/1696524905605634000.8ae477ca-eb62-435f-b4f8-c839e9b7182b"
-      }
-    }
-  }, {
-    "fullUrl" : "Location/1696524905608195000.86353182-af17-4402-8b01-a8b9be49dd70",
-    "resource" : {
-      "resourceType" : "Location",
-      "id" : "1696524905608195000.86353182-af17-4402-8b01-a8b9be49dd70",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905829540000.9483cd16-e97b-40ef-bac3-c6f761523b55",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905829540000.9483cd16-e97b-40ef-bac3-c6f761523b55",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/units",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://unitsofmeasure.org",
-            "code" : "g",
-            "display" : "gram"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "8339-4",
-          "display" : "BIRTH WEIGHT MEASURED"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueQuantity" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/alternate-value",
-          "valueString" : "1769.859285"
-        } ],
-        "value" : 1769.8593,
-        "unit" : "g",
-        "system" : "http://unitsofmeasure.org",
-        "code" : "g"
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905834983000.0dd4ba16-01a4-4283-8be0-d08960bd97d1",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905834983000.0dd4ba16-01a4-4283-8be0-d08960bd97d1",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/units",
-        "valueCodeableConcept" : {
-          "coding" : [ {
-            "extension" : [ {
-              "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-              "valueString" : "identifier"
-            } ],
-            "system" : "http://unitsofmeasure.org",
-            "code" : "wk",
-            "display" : "week"
-          } ]
-        }
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "57714-8",
-          "display" : "OBSTETRIC ESTIMATION OF GESTATIONAL AGE"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueQuantity" : {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/alternate-value",
-          "valueString" : "32"
-        } ],
-        "value" : 32,
-        "unit" : "wk",
-        "system" : "http://unitsofmeasure.org",
-        "code" : "wk"
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905840262000.18b7e3c1-4f18-4e20-ac21-a9bde6d140e4",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905840262000.18b7e3c1-4f18-4e20-ac21-a9bde6d140e4",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "57713-0",
-          "display" : "INFANT FACTORS THAT AFFECT NEWBORN SCREENING INTERPRETATION"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "LA12419-0",
-          "display" : "INFANT IN NICU AT TIME OF SPECIMEN COLLECTION"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905844987000.414a5d54-f6cb-477c-8b66-0d4970c42d26",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905844987000.414a5d54-f6cb-477c-8b66-0d4970c42d26",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "MNDSIB",
-          "display" : "DOES THE BABY HAVE A DECEASED SIBLING?"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "N",
-          "display" : "No"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905850166000.d5549235-8734-4ba3-bca2-7195310e3cd0",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905850166000.d5549235-8734-4ba3-bca2-7195310e3cd0",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "MNDEFECT",
-          "display" : "DOES THE BABY HAVE BIRTH DEFECTS?"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "N",
-          "display" : "No"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905855558000.9d8997c0-0fc8-44c1-9d57-e972f38dfa56",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905855558000.9d8997c0-0fc8-44c1-9d57-e972f38dfa56",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "MNFAM",
-          "display" : "FAMILY HISTORY OF DISORDER ON MN SCREENING PANEL"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "99MDH",
-          "code" : "N",
-          "display" : "No"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905860288000.7e2df072-32ed-4b48-9b2f-57414fb77159",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905860288000.7e2df072-32ed-4b48-9b2f-57414fb77159",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "67704-7",
-          "display" : "FEEDING TYPES"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "LA12418-2",
-          "display" : "TPN"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905865370000.d8868af5-82d8-409e-a3dc-899f862fdacf",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905865370000.d8868af5-82d8-409e-a3dc-899f862fdacf",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "2"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "67704-7",
-          "display" : "FEEDING TYPES"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "LA16914-6",
-          "display" : "BREAST MILK"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905869656000.e38f991b-6af9-4407-9e10-6e5786b52864",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905869656000.e38f991b-6af9-4407-9e10-6e5786b52864",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "57723-9",
-          "display" : "UNIQUE BAR CODE NUMBER OF CURRENT SAMPLE"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueCodeableConcept" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "code" : "0516199364"
-        } ]
-      }
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905873154000.409b11db-39f2-4afd-9836-d6d9e192bb60",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905873154000.409b11db-39f2-4afd-9836-d6d9e192bb60",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "62328-0",
-          "display" : "DISCHARGE PROVIDER PRACTICE PHONE NUMBER"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueString" : "Daniel Davis/218-555-1000"
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905877244000.23bcd535-0e9c-416c-912f-9ce764c16abb",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905877244000.23bcd535-0e9c-416c-912f-9ce764c16abb",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "62324-9",
-          "display" : "POST-DISCHARGE PROVIDER NAME"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueString" : "DAVIS, DANIEL, MD"
-    }
-  }, {
-    "fullUrl" : "Observation/1696524905881352000.d67ec52b-7fe3-4e20-b223-c429189fe97a",
-    "resource" : {
-      "resourceType" : "Observation",
-      "id" : "1696524905881352000.d67ec52b-7fe3-4e20-b223-c429189fe97a",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
-        "valueString" : "AOE"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-type",
-        "valueString" : "QST"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-status-original-text",
-        "valueString" : "O"
-      }, {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
-        "valueString" : "1"
-      } ],
-      "identifier" : [ {
-        "system" : "urn:id:extID",
-        "value" : "421832901"
-      } ],
-      "status" : "unknown",
-      "code" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://loinc.org",
-          "code" : "62326-4",
-          "display" : "POST-DISCHARGE PROVIDER PRACTICE NAME"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "effectiveDateTime" : "2023-05-06T05:00:00-05:00",
-      "valueString" : "Lakeridge Health Revere"
-    }
-  }, {
-    "fullUrl" : "Specimen/1696524905902577000.39e1c22c-7956-4cc2-8ec8-f40b603383cc",
-    "resource" : {
-      "resourceType" : "Specimen",
-      "id" : "1696524905902577000.39e1c22c-7956-4cc2-8ec8-f40b603383cc",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/specimen-name-or-code",
-        "valueString" : "440500007"
-      } ],
-      "type" : {
-        "coding" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://snomed.info/sct",
-          "code" : "440500007",
-          "display" : "Blood spot specimen"
-        } ]
-      },
-      "subject" : {
-        "reference" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d"
-      },
-      "collection" : {
-        "collectedDateTime" : "2023-05-06T05:00:00Z"
-      }
-    }
-  }, {
-    "fullUrl" : "Patient/1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d",
-    "resource" : {
-      "resourceType" : "Patient",
-      "id" : "1696524905575438000.82c0ac3a-9383-471f-9586-25b2f178919d",
-      "meta" : {
-        "extension" : [ {
-          "url" : "http://ibm.com/fhir/cdm/StructureDefinition/source-data-model-version",
-          "valueString" : "2.5.1"
-        } ],
-        "tag" : [ {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0103",
-          "code" : "P"
-        }, {
-          "extension" : [ {
-            "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
-            "valueString" : "identifier"
-          } ],
-          "system" : "http://terminology.hl7.org/CodeSystem/v2-0207",
-          "code" : "P"
-        } ]
-      },
-      "extension" : [ {
-        "url" : "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
-        "valueHumanName" : {
-          "text" : "SADIE S SMITH",
-          "family" : "SMITH",
-          "given" : [ "SADIE", "S" ]
-        }
-      } ],
-      "identifier" : [ {
-        "type" : {
-          "coding" : [ {
-            "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-            "code" : "MR",
-            "display" : "Medical record number"
-          } ]
-        },
-        "system" : "CRPMRN",
-        "value" : "11102779"
-      } ],
-      "name" : [ {
-        "use" : "official",
-        "text" : "BB SARAH SMITH",
-        "family" : "SMITH",
-        "given" : [ "BB SARAH" ]
-      } ],
-      "telecom" : [ {
-        "extension" : [ {
-          "url" : "https://reportstream.cdc.gov/fhir/StructureDefinition/text",
-          "valueString" : "(763)555-5555"
-        } ],
-        "system" : "phone",
-        "value" : "(763) 555 5555",
-        "use" : "home"
-      } ],
-      "gender" : "male",
-      "birthDate" : "2023-05-04",
-      "_birthDate" : {
-        "extension" : [ {
-          "url" : "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
-          "valueDateTime" : "2023-05-04T13:10:23-05:00"
-        } ]
-      },
-      "deceasedBoolean" : false,
-      "address" : [ {
-        "use" : "home",
-        "line" : [ "555 STATE HIGHWAY 13" ],
-        "city" : "DEER CREEK",
-        "district" : "OTTER TAIL",
-        "state" : "MN",
-        "postalCode" : "56527-9657",
-        "country" : "USA"
-      } ],
-      "multipleBirthBoolean" : false
-    }
-  } ]
+    ]
 }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/jackson/Jackson.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/jackson/Jackson.java
@@ -1,6 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.external.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -38,6 +39,8 @@ public class Jackson implements Formatter, YamlCombiner {
         YAML_OBJECT_MAPPER.registerModule(javaTimeModule);
         JSON_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         YAML_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        JSON_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        YAML_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     private Jackson() {}

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/jackson/Jackson.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/jackson/Jackson.java
@@ -1,7 +1,6 @@
 package gov.hhs.cdc.trustedintermediary.external.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -39,8 +38,6 @@ public class Jackson implements Formatter, YamlCombiner {
         YAML_OBJECT_MAPPER.registerModule(javaTimeModule);
         JSON_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         YAML_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        JSON_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        YAML_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     private Jackson() {}


### PR DESCRIPTION
# Remove Sender and Receiver entities

This PR removes the sender and receiver columns from the database and from our code base. The sender and receiver can be access through the `sendingFacilityDetails` and the `receivingFacilityDetails`. Due to this, the isolated sender and receiver become redundant code.

The main work was to remove these entities from the `PartnertMetadata` class and from the database.

## Issue
#990 


## Checklist

- [x] I have added tests to cover my changes


