### PR TITLE
HikariCP Lifetime Handling fix

### DIFF
--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPool.java
@@ -49,7 +49,7 @@ public class HikariConnectionPool implements ConnectionPool {
 
         try {
             String maxLife = ApplicationContext.getProperty("DB_MAX_LIFETIME");
-            if (!maxLife.isEmpty()) {
+            if (maxLife != null && !maxLife.isEmpty()) {
                 config.setMaxLifetime(Long.parseLong(maxLife));
             }
         } catch (NumberFormatException e) {

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPoolTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/HikariConnectionPoolTest.groovy
@@ -5,6 +5,8 @@ import gov.hhs.cdc.trustedintermediary.wrappers.database.DatabaseCredentialsProv
 import spock.lang.Specification
 
 class HikariConnectionPoolTest extends Specification {
+    def defaultLifetime = 1800000L
+
     def setup() {
         TestApplicationContext.reset()
         TestApplicationContext.init()
@@ -14,7 +16,6 @@ class HikariConnectionPoolTest extends Specification {
         TestApplicationContext.addEnvironmentVariable("DB_NAME", "test_name")
         TestApplicationContext.addEnvironmentVariable("DB_PORT", "1234")
         TestApplicationContext.addEnvironmentVariable("DB_PASS", "test_pass")
-        TestApplicationContext.addEnvironmentVariable("DB_MAX_LIFETIME", "9001")
 
         credProviders.getPassword() >> "test_pass"
         TestApplicationContext.register(DatabaseCredentialsProvider, credProviders)
@@ -23,6 +24,7 @@ class HikariConnectionPoolTest extends Specification {
 
     def "connection pool works" () {
         when:
+        TestApplicationContext.addEnvironmentVariable("DB_MAX_LIFETIME", "9001")
         def result = HikariConnectionPool.constructHikariConfig()
 
         then:
@@ -45,7 +47,7 @@ class HikariConnectionPoolTest extends Specification {
         result.getDataSourceProperties().get("serverName") == "test_url"
         result.getDataSourceProperties().get("databaseName") == "test_name"
         result.getDataSourceProperties().get("portNumber") == "1234"
-        result.getMaxLifetime() == 1800000L
+        result.getMaxLifetime() == defaultLifetime
     }
 
     def "connection pool uses default DB_MAX_LIFETIME when a NumberFormatException is thrown" () {
@@ -59,6 +61,19 @@ class HikariConnectionPoolTest extends Specification {
         result.getDataSourceProperties().get("serverName") == "test_url"
         result.getDataSourceProperties().get("databaseName") == "test_name"
         result.getDataSourceProperties().get("portNumber") == "1234"
-        result.getMaxLifetime() == 1800000L
+        result.getMaxLifetime() == defaultLifetime
+    }
+
+    def "connection pool uses default DB_MAX_LIFETIME if an override value is not set" () {
+        when:
+        def result = HikariConnectionPool.constructHikariConfig()
+
+        then:
+        result.getDataSourceProperties().get("user") == "test_user"
+        result.getDataSourceProperties().get("password") == "test_pass"
+        result.getDataSourceProperties().get("serverName") == "test_url"
+        result.getDataSourceProperties().get("databaseName") == "test_name"
+        result.getDataSourceProperties().get("portNumber") == "1234"
+        result.getMaxLifetime() == defaultLifetime
     }
 }


### PR DESCRIPTION
# HikariCP Lifetime Handling fix

Remove the requirement of defining a `DB_MAX_LIFETIME` in an environment.

## Issue

#1001 

## Checklist

- [x] I have added tests to cover my changes
