### PR TITLE
Refactor readMetadataForMessageLinking so it doesn't return itself

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -231,10 +231,6 @@ public class EtorDomainRegistration implements DomainConnector {
             Set<String> messageIdsToLink =
                     partnerMetadataOrchestrator.findMessagesIdsToLink(metadataId);
 
-            // Remove the metadataId from the set of messageIdsToLink to avoid showing it in the
-            // partner metadata's linked ids
-            messageIdsToLink.remove(metadataId);
-
             FhirMetadata<?> responseObject =
                     partnerMetadataConverter.extractPublicMetadataToOperationOutcome(
                             metadata.get(), metadataId, messageIdsToLink);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
@@ -70,6 +70,10 @@ public class SendMessageHelper {
             if (messageIdsToLink == null || messageIdsToLink.isEmpty()) {
                 return;
             }
+
+            // Add receivedSubmissionId to complete the list of messageIds to link
+            messageIdsToLink.add(receivedSubmissionId);
+
             logger.logInfo(
                     "Found messages to link for receivedSubmissionId {}: {}",
                     receivedSubmissionId,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -128,6 +128,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                                         ON m1.placer_order_number = m2.placer_order_number
                                             AND (m1.sending_facility_details = m2.sending_facility_details
                                                 OR m1.sending_facility_details = m2.receiving_facility_details)
+                                            AND m1.received_message_id <> m2.received_message_id
                                     WHERE m1.received_message_id = ?;
                                     """);
                                     statement.setString(1, submissionId);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -138,7 +138,9 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
                                                     || metadata.sendingFacilityDetails()
                                                             .equals(
                                                                     match
-                                                                            .receivingFacilityDetails())))
+                                                                            .receivingFacilityDetails()))
+                                            && !metadata.receivedSubmissionId()
+                                                    .equals(receivedSubmissionId))
                     .collect(Collectors.toSet());
         } catch (Exception e) {
             throw new PartnerMetadataException(

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -279,8 +279,7 @@ class EtorDomainRegistrationTest extends Specification {
         def metadata = new PartnerMetadata("receivedSubmissionId", "sender", Instant.now(), null,
                 "hash", PartnerMetadataStatus.DELIVERED, PartnerMetadataMessageType.ORDER,
                 sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
-        def linkedMessageIds = new HashSet<>(Set.of(receivedSubmissionId, "Test1", "Test2"))
-        def relevantMessageIds = linkedMessageIds.findAll { it != receivedSubmissionId }
+        def linkedMessageIds = Set.of(receivedSubmissionId, "Test1", "Test2")
 
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
@@ -311,7 +310,7 @@ class EtorDomainRegistrationTest extends Specification {
         actualStatusCode == expectedStatusCode
         1 * mockPartnerMetadataOrchestrator.getMetadata(receivedSubmissionId) >> Optional.ofNullable(metadata)
         1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> linkedMessageIds
-        1 * mockPartnerMetadataConverter.extractPublicMetadataToOperationOutcome(_ as PartnerMetadata, _ as String, relevantMessageIds) >> Mock(FhirMetadata)
+        1 * mockPartnerMetadataConverter.extractPublicMetadataToOperationOutcome(_ as PartnerMetadata, _ as String, linkedMessageIds) >> Mock(FhirMetadata)
         1 * mockResponseHelper.constructOkResponseFromString(_ as String) >> new DomainResponse(expectedStatusCode)
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
@@ -36,21 +36,11 @@ class SendOrderUseCaseTest extends Specification {
         given:
         def receivedSubmissionId = "receivedId"
         def sentSubmissionId = "sentId"
-        def messagesIdsToLink = Set.of("messageId1", "messageId2")
+        def messagesIdsToLink = new HashSet<>(Set.of("messageId1", "messageId2"))
 
         def sendOrder = SendOrderUseCase.getInstance()
         def mockOrder = new OrderMock(null, null, null, null, null, null, null, null)
         def mockOmlOrder = Mock(Order)
-
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId,
-                _ as String,
-                PartnerMetadataMessageType.ORDER,
-                mockOrder.getSendingApplicationDetails(),
-                mockOrder.getSendingFacilityDetails(),
-                mockOrder.getReceivingApplicationDetails(),
-                mockOrder.getReceivingFacilityDetails(),
-                mockOrder.getPlacerOrderNumber()
-                )
 
         TestApplicationContext.injectRegisteredImplementations()
 
@@ -68,7 +58,7 @@ class SendOrderUseCaseTest extends Specification {
         1 * mockOrchestrator.updateMetadataForReceivedMessage(_ as PartnerMetadata)
         1 * mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
         1 * mockOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> messagesIdsToLink
-        1 * mockOrchestrator.linkMessages(messagesIdsToLink)
+        1 * mockOrchestrator.linkMessages(messagesIdsToLink + receivedSubmissionId)
     }
 
     def "send fails to send"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -145,7 +145,8 @@ class FilePartnerMetadataStorageTest extends Specification {
         def metadataSetWithMatchingSendingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId1)
 
         then:
-        metadataSetWithMatchingSendingFacilityDetails.containsAll(Set.of(matchingSendingFacilityDetailsMetadata1, otherMatchingSendingFacilityDetailsMetadata1))
+        metadataSetWithMatchingSendingFacilityDetails.contains(otherMatchingSendingFacilityDetailsMetadata1)
+        !metadataSetWithMatchingSendingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata1)
 
         when:
         def receivedSubmissionId2 = "receivedSubmissionId2"
@@ -158,7 +159,8 @@ class FilePartnerMetadataStorageTest extends Specification {
         def metadataSetWithMatchingSendingAndReceivingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId2)
 
         then:
-        metadataSetWithMatchingSendingAndReceivingFacilityDetails.containsAll(Set.of(matchingSendingFacilityDetailsMetadata2, matchingReceivingFacilityDetailsMetadata2))
+        metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingReceivingFacilityDetailsMetadata2)
+        !metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata2)
     }
 
     def "readMetadataForMessageLinking returns an empty set when no metadata is found"() {


### PR DESCRIPTION
# Refactor readMetadataForMessageLinking so it doesn't return itself

This is a fix in the linking logic so it only matches when there's at least one pair

## Issue

#621 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly
