### PR TITLE
Fix Load Tests Due to Multiple `ResultSet`s

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -130,8 +130,9 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                                                 OR m1.sending_facility_details = m2.receiving_facility_details)
                                             AND m1.received_message_id <> m2.received_message_id
                                     WHERE m1.received_message_id = ?;
-                                    -- LIMIT 50 This is a potential fix for load test failures since they link all the ids together;
                                     """);
+                                    // -- LIMIT 50 This is a potential fix for load test failures
+                                    // since they link all the ids together;
                                     statement.setString(1, submissionId);
                                     return statement;
                                 } catch (SQLException e) {


### PR DESCRIPTION
# Fix Load Tests Due to Multiple `ResultSet`s

The load tests started failing (and perhaps outside load tests too) due to multiple `ResultSet`s being returned when getting linked message IDs.

This is due to multiple SQL statements (separated by `;`) in the SQL string.  So, even though that second SQL statement was just a SQL comment (notice the `--`), the API throws an exception because it wants to return multiple `ResultSet`s when we are using an API that only allows one `ResultSet`.

## Issue

#1044.

