### PR TITLE
Use a (local) test DB for load tests so it doesn't wipe out the regular local DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ running...
 ```
 
 This will run the API for you, so no need to run it manually.
+**If you are already running the API, stop it before running the load tests or the cleanup steps won't work.**
+The load tests will also spin up (and clean up) a local test DB on port 5434 that should not interfere with the local dev DB.
 
 The `locustfile.py` that specifies the load test is located at
 [`./operations/locustfile.py`](./operations/locustfile.py).

--- a/docker-compose.postgres-test.yml
+++ b/docker-compose.postgres-test.yml
@@ -1,0 +1,23 @@
+# Run the following to migrate...
+# liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary --username intermediary --password 'changeIT!' --label-filter '!azure'
+
+# Run the following to rollback...
+# liquibase rollback-count --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary --username intermediary --password 'changeIT!' --count 2
+
+version: "3.7"
+
+services:
+  postgresql:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "intermediary-test"
+      POSTGRES_PASSWORD: "changeIT!" # pragma: allowlist secret
+      POSTGRES_USER: "intermediary"
+    ports:
+      - 5433:5432
+    volumes:
+      - ti_postgres_data:/var/lib/postgresql/data
+
+volumes:
+  ti_postgres_data:

--- a/docker-compose.postgres-test.yml
+++ b/docker-compose.postgres-test.yml
@@ -1,13 +1,7 @@
-# Run the following to migrate...
-# liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary --username intermediary --password 'changeIT!' --label-filter '!azure'
-
-# Run the following to rollback...
-# liquibase rollback-count --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary --username intermediary --password 'changeIT!' --count 2
-
 version: "3.7"
 
 services:
-  postgresql:
+  postgresql-test:
     image: postgres:16
     restart: unless-stopped
     environment:
@@ -15,9 +9,9 @@ services:
       POSTGRES_PASSWORD: "changeIT!" # pragma: allowlist secret
       POSTGRES_USER: "intermediary"
     ports:
-      - 5433:5432
+      - 5434:5432
     volumes:
-      - ti_postgres_data:/var/lib/postgresql/data
+      - ti_postgres_test_data:/var/lib/postgresql/data
 
 volumes:
-  ti_postgres_data:
+  ti_postgres_test_data:

--- a/load-execute.sh
+++ b/load-execute.sh
@@ -5,7 +5,7 @@ start_api() {
     echo 'Starting API'
     export DB_URL=localhost
     export DB_PORT=5433
-    export DB_NAME=intermediary
+    export DB_NAME=intermediary-test
     export DB_USER=intermediary
     export DB_PASS=changeIT!
     export DB_SSL=require
@@ -16,14 +16,14 @@ start_api() {
 
 start_database() {
     echo 'Starting database'
-    docker compose -f docker-compose.postgres.yml up -d
+    docker compose -f docker-compose.postgres-test.yml up -d
     sleep 2
     echo "Database started"
 }
 
 migrate_database() {
     echo 'Migrating database'
-    liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary --username intermediary --password 'changeIT!' --label-filter '!azure'
+    liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary-test --username intermediary --password 'changeIT!' --label-filter '!azure'
     echo "Database migrated"
 }
 

--- a/load-execute.sh
+++ b/load-execute.sh
@@ -4,7 +4,7 @@ set -e
 start_api() {
     echo 'Starting API'
     export DB_URL=localhost
-    export DB_PORT=5433
+    export DB_PORT=5434
     export DB_NAME=intermediary-test
     export DB_USER=intermediary
     export DB_PASS=changeIT!
@@ -23,7 +23,7 @@ start_database() {
 
 migrate_database() {
     echo 'Migrating database'
-    liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5433/intermediary-test --username intermediary --password 'changeIT!' --label-filter '!azure'
+    liquibase update --changelog-file ./etor/databaseMigrations/root.yml --url jdbc:postgresql://localhost:5434/intermediary-test --username intermediary --password 'changeIT!' --label-filter '!azure'
     echo "Database migrated"
 }
 
@@ -54,9 +54,9 @@ cleanup() {
     kill "${API_PID}"
     echo "PID ${API_PID} killed"
     echo "Stopping and deleting database"
-    docker stop trusted-intermediary-postgresql-1
-    docker rm -f trusted-intermediary-postgresql-1
-    docker volume rm trusted-intermediary_ti_postgres_data
+    docker stop trusted-intermediary-postgresql-test-1
+    docker rm -f trusted-intermediary-postgresql-test-1
+    docker volume rm trusted-intermediary_ti_postgres_test_data
     echo "Database stopped and deleted"
 }
 


### PR DESCRIPTION
# Use a (local) test DB for load tests so it doesn't wipe out the regular local DB
Add a `docker-compose.postgres-test.yml` file that sets up an `intermediary-test` DB and have the load tests use that DB - then the regular local `intermediary` DB won't be wiped out by running load tests

## Issue

#1044.

## Checklist
- [x] I have updated the documentation accordingly
