### PR TITLE
Adding logging for getting a token from Azure 

### DIFF
--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
@@ -2,7 +2,9 @@ package gov.hhs.cdc.trustedintermediary.external.azure;
 
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.database.DatabaseCredentialsProvider;
+import javax.inject.Inject;
 
 /**
  * AzureDatabaseCredentialsProvider is a class responsible for providing credentials for a database
@@ -19,8 +21,13 @@ public class AzureDatabaseCredentialsProvider implements DatabaseCredentialsProv
 
     private AzureDatabaseCredentialsProvider() {}
 
+    @Inject Logger logger;
+
     @Override
     public String getPassword() {
+
+        logger.logInfo("Fetching credentials from Azure");
+
         return new DefaultAzureCredentialBuilder()
                 .build()
                 .getTokenSync(


### PR DESCRIPTION
We are having some connection issues when the app calls the database in Azure.  These issues are intermittent and seemingly random.  Adding some logging to where the Azure token is requested to verify that the connection pool is renewing connections with new tokens over time. 


If we don't see this logging over the course of a few days then we know that we need to adjust our HikariCP implementation