### PR TITLE
Retrieve Linked Metadata for Outbound Report ID

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistration.java
@@ -182,20 +182,23 @@ public class EtorDomainRegistration implements DomainConnector {
     DomainResponse handleMetadata(DomainRequest request) {
         try {
             String metadataId = request.getPathParams().get("id");
-            Optional<PartnerMetadata> metadata =
+            Optional<PartnerMetadata> metadataOptional =
                     partnerMetadataOrchestrator.getMetadata(metadataId);
 
-            if (metadata.isEmpty()) {
+            if (metadataOptional.isEmpty()) {
                 return domainResponseHelper.constructErrorResponse(
                         404, "Metadata not found for ID: " + metadataId);
             }
 
+            var metadata = metadataOptional.get();
+
             Set<String> messageIdsToLink =
-                    partnerMetadataOrchestrator.findMessagesIdsToLink(metadataId);
+                    partnerMetadataOrchestrator.findMessagesIdsToLink(
+                            metadata.receivedSubmissionId());
 
             FhirMetadata<?> responseObject =
                     partnerMetadataConverter.extractPublicMetadataToOperationOutcome(
-                            metadata.get(), metadataId, messageIdsToLink);
+                            metadata, metadataId, messageIdsToLink);
 
             return domainResponseHelper.constructOkResponseFromString(
                     fhir.encodeResourceToJson(responseObject.getUnderlyingOutcome()));


### PR DESCRIPTION
# Retrieve Linked Metadata for Outbound Report ID

When calling the `PartnerMetadataOrchestrator` to get the linked metadata, we now pass in the received message ID instead of the raw message ID that was passed into the metadata API.  Previously, if the _sent_ message ID was passed into the metadata API, nothing would have been found.

## Issue

#1100.

## Checklist

- [x] I have added tests to cover my changes