### PR TITLE
Fix NPE for Logging when getting the Azure Database Credentials

### DIFF
--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/azure/AzureDatabaseCredentialsProvider.java
@@ -2,9 +2,9 @@ package gov.hhs.cdc.trustedintermediary.external.azure;
 
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import gov.hhs.cdc.trustedintermediary.context.ApplicationContext;
 import gov.hhs.cdc.trustedintermediary.wrappers.Logger;
 import gov.hhs.cdc.trustedintermediary.wrappers.database.DatabaseCredentialsProvider;
-import javax.inject.Inject;
 
 /**
  * AzureDatabaseCredentialsProvider is a class responsible for providing credentials for a database
@@ -21,12 +21,12 @@ public class AzureDatabaseCredentialsProvider implements DatabaseCredentialsProv
 
     private AzureDatabaseCredentialsProvider() {}
 
-    @Inject Logger logger;
-
     @Override
     public String getPassword() {
 
-        logger.logInfo("Fetching credentials from Azure");
+        // this method is at least called during bootstrapping, so we can't use @Inject
+        ApplicationContext.getImplementation(Logger.class)
+                .logInfo("Fetching credentials from Azure");
 
         return new DefaultAzureCredentialBuilder()
                 .build()


### PR DESCRIPTION
# Fix NPE for Logging when getting the Azure Database Credentials

A `NullPointerException` was encountered in any deployed environment because our logger was `null` while getting the Azure database credentials.  I fixed it by getting the logger a different way.

## Issue

_None_.

## Checklist

- [x] I have added logging where useful (with appropriate log level)
