### PR TITLE
Fixes for baseline transformations

### DIFF
--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifierTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifierTest.groovy
@@ -33,10 +33,12 @@ class RemovePatientIdentifierTest extends Specification {
 
         when:
         transformClass.transform(fhirResource, null)
+        def actualPid3_4 = HapiFhirHelper.getPID3_4Value(bundle)
+        def actualPid3_5 = HapiFhirHelper.getPID3_5Value(bundle)
 
         then:
-        HapiFhirHelper.getPID3_4Value(bundle) == null
-        HapiFhirHelper.getPID3_5Value(bundle) == null
+        actualPid3_4 == null || actualPid3_4.isEmpty()
+        actualPid3_5 == null || actualPid3_5.isEmpty()
     }
 
     def "don't throw exception if patient resource not present"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/SwapPlacerOrderAndGroupNumbersTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/SwapPlacerOrderAndGroupNumbersTest.groovy
@@ -34,8 +34,8 @@ class SwapPlacerOrderAndGroupNumbersTest extends Specification {
         expect:
         orc2_1 == "423787478"
         orc2_2 == "EPIC"
-        orc4_1 == "57128-1"
-        orc4_2 == "Newborn Screening Report summary panel"
+        orc4_1 == null
+        orc4_2 == null
 
         when:
         transformClass.transform(fhirResource, null)

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -257,52 +257,43 @@ public class HapiHelper {
     }
 
     // ORC-4 - Placer Group Number
-    public static Coding getORC4Coding(ServiceRequest serviceRequest) {
-        List<Coding> codings = serviceRequest.getCode().getCoding();
-        if (codings.isEmpty()) {
-            return null;
-        }
-        return codings.get(0);
-    }
-
-    public static void setORC4Coding(ServiceRequest serviceRequest, Coding coding) {
-        serviceRequest.getCode().setCoding(List.of(coding));
+    public static Identifier getORC4Identifier(ServiceRequest serviceRequest) {
+        List<Identifier> identifiers = serviceRequest.getIdentifier();
+        return getHl7FieldIdentifier(identifiers, EXTENSION_ORC4_DATA_TYPE);
     }
 
     // ORC-4.1 - Entity Identifier
     public static String getORC4_1Value(ServiceRequest serviceRequest) {
-        Coding coding = getORC4Coding(serviceRequest);
-        if (coding == null) {
+        Identifier identifier = getORC4Identifier(serviceRequest);
+        if (identifier == null) {
             return null;
         }
-        return coding.getCode();
+        return getEI1Value(identifier);
     }
 
     public static void setORC4_1Value(ServiceRequest serviceRequest, String value) {
-        Coding coding = getORC4Coding(serviceRequest);
-        if (coding == null) {
-            coding = new Coding();
-            setORC4Coding(serviceRequest, coding);
+        Identifier identifier = getORC4Identifier(serviceRequest);
+        if (identifier == null) {
+            return;
         }
-        coding.setCode(value);
+        setEI1Value(identifier, value);
     }
 
     // ORC-4.2 - Namespace ID
     public static String getORC4_2Value(ServiceRequest serviceRequest) {
-        Coding coding = getORC4Coding(serviceRequest);
-        if (coding == null) {
+        Identifier identifier = getORC4Identifier(serviceRequest);
+        if (identifier == null) {
             return null;
         }
-        return coding.getDisplay();
+        return getEI2Value(identifier);
     }
 
     public static void setORC4_2Value(ServiceRequest serviceRequest, String value) {
-        Coding coding = getORC4Coding(serviceRequest);
-        if (coding == null) {
-            coding = new Coding();
-            setORC4Coding(serviceRequest, coding);
+        Identifier identifier = getORC4Identifier(serviceRequest);
+        if (identifier == null) {
+            return;
         }
-        coding.setDisplay(value);
+        setEI2Value(identifier, value);
     }
 
     // HD - Hierarchic Designator

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -191,14 +191,6 @@ public class HapiHelper {
     }
 
     // PID-3.5 - Identifier Type Code
-    public static String getPID3_5Value(Bundle bundle) {
-        Identifier identifier = getPID3Identifier(bundle);
-        if (identifier == null) {
-            return null;
-        }
-        return getCX5Value(identifier);
-    }
-
     public static void setPID3_5Value(Bundle bundle, String value) {
         Identifier identifier = getPID3Identifier(bundle);
         if (identifier == null) {
@@ -358,7 +350,7 @@ public class HapiHelper {
 
     public static String getCX5Value(Identifier identifier) {
         if (!identifier.hasExtension(EXTENSION_CX_IDENTIFIER_URL)
-                || identifier
+                || !identifier
                         .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
                         .hasExtension(EXTENSION_CX5_URL)) {
             return null;

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -1,6 +1,7 @@
 package gov.hhs.cdc.trustedintermediary.external.hapi;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
@@ -217,49 +218,49 @@ public class HapiHelper {
     }
 
     // ORC-2 - Placer Order Number
-    public static Identifier getORC2Identifier(ServiceRequest serviceRequest) {
+    public static List<Identifier> getORC2Identifiers(ServiceRequest serviceRequest) {
         List<Identifier> identifiers = serviceRequest.getIdentifier();
-        return getHl7FieldIdentifier(identifiers, EXTENSION_ORC2_DATA_TYPE);
+        return getHl7FieldIdentifiers(identifiers, EXTENSION_ORC2_DATA_TYPE);
     }
 
     // ORC-2.1 - Entity Identifier
     public static String getORC2_1Value(ServiceRequest serviceRequest) {
-        Identifier identifier = getORC2Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC2Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return null;
         }
-        return getEI1Value(identifier);
+        return getEI1Value(identifiers.get(0));
     }
 
     public static void setORC2_1Value(ServiceRequest serviceRequest, String value) {
-        Identifier identifier = getORC2Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC2Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return;
         }
-        setEI1Value(identifier, value);
+        identifiers.forEach(identifier -> setEI1Value(identifier, value));
     }
 
     // ORC-2.2 - Namespace ID
     public static String getORC2_2Value(ServiceRequest serviceRequest) {
-        Identifier identifier = getORC2Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC2Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return null;
         }
-        return getEI2Value(identifier);
+        return getEI2Value(identifiers.get(0));
     }
 
     public static void setORC2_2Value(ServiceRequest serviceRequest, String value) {
-        Identifier identifier = getORC2Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC2Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return;
         }
-        setEI2Value(identifier, value);
+        identifiers.forEach(identifier -> setEI2Value(identifier, value));
     }
 
     // ORC-4 - Placer Group Number
-    public static Identifier getORC4Identifier(ServiceRequest serviceRequest) {
+    public static List<Identifier> getORC4Identifiers(ServiceRequest serviceRequest) {
         List<Identifier> identifiers = serviceRequest.getIdentifier();
-        return getHl7FieldIdentifier(identifiers, EXTENSION_ORC4_DATA_TYPE);
+        return getHl7FieldIdentifiers(identifiers, EXTENSION_ORC4_DATA_TYPE);
     }
 
     public static Identifier createORC4Identifier() {
@@ -270,43 +271,50 @@ public class HapiHelper {
 
     // ORC-4.1 - Entity Identifier
     public static String getORC4_1Value(ServiceRequest serviceRequest) {
-        Identifier identifier = getORC4Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC4Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return null;
         }
-        return getEI1Value(identifier);
+        return getEI1Value(identifiers.get(0));
     }
 
     public static void setORC4_1Value(ServiceRequest serviceRequest, String value) {
-        Identifier identifier = getORC4Identifier(serviceRequest);
-        if (identifier == null) {
-            identifier = createORC4Identifier();
+        List<Identifier> identifiers = getORC4Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
+            Identifier identifier = createORC4Identifier();
+            identifiers.add(identifier);
             serviceRequest.addIdentifier(identifier);
         }
-        setEI1Value(identifier, value);
+        identifiers.forEach(identifier -> setEI1Value(identifier, value));
     }
 
     // ORC-4.2 - Namespace ID
     public static String getORC4_2Value(ServiceRequest serviceRequest) {
-        Identifier identifier = getORC4Identifier(serviceRequest);
-        if (identifier == null) {
+        List<Identifier> identifiers = getORC4Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
             return null;
         }
-        return getEI2Value(identifier);
+        return getEI2Value(identifiers.get(0));
     }
 
     public static void setORC4_2Value(ServiceRequest serviceRequest, String value) {
-        Identifier identifier = getORC4Identifier(serviceRequest);
-        if (identifier == null) {
-            identifier = createORC4Identifier();
+        List<Identifier> identifiers = getORC4Identifiers(serviceRequest);
+        if (identifiers.isEmpty()) {
+            Identifier identifier = createORC4Identifier();
+            identifiers.add(identifier);
             serviceRequest.addIdentifier(identifier);
         }
-        setEI2Value(identifier, value);
+        identifiers.forEach(identifier -> setEI2Value(identifier, value));
     }
 
     // HD - Hierarchic Designator
     public static Identifier getHD1Identifier(List<Identifier> identifiers) {
-        return getHl7FieldIdentifier(identifiers, EXTENSION_HD1_DATA_TYPE);
+        List<Identifier> hd1Identifiers =
+                getHl7FieldIdentifiers(identifiers, EXTENSION_HD1_DATA_TYPE);
+        if (hd1Identifiers.isEmpty()) {
+            return null;
+        }
+        return hd1Identifiers.get(0);
     }
 
     // EI - Entity Identifier
@@ -379,18 +387,17 @@ public class HapiHelper {
                 .setValue(new StringType(value));
     }
 
-    public static Identifier getHl7FieldIdentifier(
+    public static List<Identifier> getHl7FieldIdentifiers(
             List<Identifier> identifiers, StringType dataType) {
-        for (Identifier identifier : identifiers) {
-            if (identifier.hasExtension(EXTENSION_HL7_FIELD_URL)
-                    && identifier
-                            .getExtensionByUrl(EXTENSION_HL7_FIELD_URL)
-                            .getValue()
-                            .equalsDeep(dataType)) {
-                return identifier;
-            }
-        }
-        return null;
+        return identifiers.stream()
+                .filter(
+                        identifier ->
+                                identifier.hasExtension(EXTENSION_HL7_FIELD_URL)
+                                        && identifier
+                                                .getExtensionByUrl(EXTENSION_HL7_FIELD_URL)
+                                                .getValue()
+                                                .equalsDeep(dataType))
+                .collect(Collectors.toList());
     }
 
     public static void setHl7FieldExtensionValue(Identifier identifier, StringType dataType) {

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -32,7 +32,10 @@ public class HapiHelper {
             "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id";
     public static final String EXTENSION_XPN_HUMAN_NAME_URL =
             "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name";
+    public static final String EXTENSION_CX_IDENTIFIER_URL =
+            "https://reportstream.cdc.gov/fhir/StructureDefinition/cx-identifier";
     public static final String EXTENSION_XPN7_URL = "XPN.7";
+    public static final String EXTENSION_CX5_URL = "CX.5";
     public static final StringType EXTENSION_HD1_DATA_TYPE = new StringType("HD.1");
     public static final StringType EXTENSION_ORC2_DATA_TYPE = new StringType("ORC.2");
     public static final StringType EXTENSION_ORC4_DATA_TYPE = new StringType("ORC.4");
@@ -188,20 +191,20 @@ public class HapiHelper {
     }
 
     // PID-3.5 - Identifier Type Code
-    public static Coding getPID3_5Coding(Bundle bundle) {
+    public static String getPID3_5Value(Bundle bundle) {
         Identifier identifier = getPID3Identifier(bundle);
         if (identifier == null) {
             return null;
         }
-        return identifier.getType().getCodingFirstRep();
+        return getCX5Value(identifier);
     }
 
     public static void setPID3_5Value(Bundle bundle, String value) {
-        Coding coding = getPID3_5Coding(bundle);
-        if (coding == null) {
+        Identifier identifier = getPID3Identifier(bundle);
+        if (identifier == null) {
             return;
         }
-        coding.setCode(value);
+        setCX5Value(identifier, value);
     }
 
     // PID-5 - Patient Name
@@ -350,6 +353,38 @@ public class HapiHelper {
         identifier
                 .getExtensionByUrl(EXTENSION_ASSIGNING_AUTHORITY_URL)
                 .getExtensionByUrl(EXTENSION_NAMESPACE_ID_URL)
+                .setValue(new StringType(value));
+    }
+
+    public static String getCX5Value(Identifier identifier) {
+        if (!identifier.hasExtension(EXTENSION_CX_IDENTIFIER_URL)
+                || identifier
+                        .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
+                        .hasExtension(EXTENSION_CX5_URL)) {
+            return null;
+        }
+        return identifier
+                .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
+                .getExtensionByUrl(EXTENSION_CX5_URL)
+                .getValue()
+                .primitiveValue();
+    }
+
+    public static void setCX5Value(Identifier identifier, String value) {
+        if (!identifier.hasExtension(EXTENSION_CX_IDENTIFIER_URL)) {
+            identifier.addExtension().setUrl(EXTENSION_CX_IDENTIFIER_URL);
+        }
+        if (!identifier
+                .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
+                .hasExtension(EXTENSION_CX5_URL)) {
+            identifier
+                    .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
+                    .addExtension()
+                    .setUrl(EXTENSION_CX5_URL);
+        }
+        identifier
+                .getExtensionByUrl(EXTENSION_CX_IDENTIFIER_URL)
+                .getExtensionByUrl(EXTENSION_CX5_URL)
                 .setValue(new StringType(value));
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -262,6 +262,12 @@ public class HapiHelper {
         return getHl7FieldIdentifier(identifiers, EXTENSION_ORC4_DATA_TYPE);
     }
 
+    public static Identifier createORC4Identifier() {
+        Identifier identifier = new Identifier();
+        setHl7FieldExtensionValue(identifier, EXTENSION_ORC4_DATA_TYPE);
+        return identifier;
+    }
+
     // ORC-4.1 - Entity Identifier
     public static String getORC4_1Value(ServiceRequest serviceRequest) {
         Identifier identifier = getORC4Identifier(serviceRequest);
@@ -274,7 +280,8 @@ public class HapiHelper {
     public static void setORC4_1Value(ServiceRequest serviceRequest, String value) {
         Identifier identifier = getORC4Identifier(serviceRequest);
         if (identifier == null) {
-            return;
+            identifier = createORC4Identifier();
+            serviceRequest.addIdentifier(identifier);
         }
         setEI1Value(identifier, value);
     }
@@ -291,7 +298,8 @@ public class HapiHelper {
     public static void setORC4_2Value(ServiceRequest serviceRequest, String value) {
         Identifier identifier = getORC4Identifier(serviceRequest);
         if (identifier == null) {
-            return;
+            identifier = createORC4Identifier();
+            serviceRequest.addIdentifier(identifier);
         }
         setEI2Value(identifier, value);
     }
@@ -371,7 +379,8 @@ public class HapiHelper {
                 .setValue(new StringType(value));
     }
 
-    static Identifier getHl7FieldIdentifier(List<Identifier> identifiers, StringType dataType) {
+    public static Identifier getHl7FieldIdentifier(
+            List<Identifier> identifiers, StringType dataType) {
         for (Identifier identifier : identifiers) {
             if (identifier.hasExtension(EXTENSION_HL7_FIELD_URL)
                     && identifier
@@ -382,5 +391,12 @@ public class HapiHelper {
             }
         }
         return null;
+    }
+
+    public static void setHl7FieldExtensionValue(Identifier identifier, StringType dataType) {
+        if (!identifier.hasExtension(EXTENSION_HL7_FIELD_URL)) {
+            identifier.addExtension().setUrl(EXTENSION_HL7_FIELD_URL);
+        }
+        identifier.getExtensionByUrl(EXTENSION_HL7_FIELD_URL).setValue(dataType);
     }
 }

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -360,16 +360,15 @@ class HapiHelperTest extends Specification {
     }
 
     // PID-3.5 - Assigning Identifier Type Code
-    def "patient assigning authority methods work as expected"() {
+    def "patient assigning identifier methods work as expected"() {
         given:
-        def bundle = new Bundle()
         def pid3_5 = "pid3_5"
 
         when:
-        HapiFhirHelper.setPID3_5Coding(bundle, new Coding())
+        def bundle = new Bundle()
 
         then:
-        HapiHelper.getPID3_5Coding(bundle) == null
+        HapiFhirHelper.getPID3_5Value(bundle) == null
 
         when:
         HapiHelper.setPID3_5Value(bundle, pid3_5)
@@ -380,7 +379,6 @@ class HapiHelperTest extends Specification {
         when:
         HapiFhirHelper.createPIDPatient(bundle)
         HapiFhirHelper.setPID3Identifier(bundle, new Identifier())
-        HapiFhirHelper.setPID3_5Coding(bundle, new Coding())
         HapiHelper.setPID3_5Value(bundle, pid3_5)
 
         then:

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -366,11 +366,6 @@ class HapiHelperTest extends Specification {
 
         when:
         def bundle = new Bundle()
-
-        then:
-        HapiFhirHelper.getPID3_5Value(bundle) == null
-
-        when:
         HapiHelper.setPID3_5Value(bundle, pid3_5)
 
         then:

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -452,7 +452,7 @@ class HapiHelperTest extends Specification {
         HapiFhirHelper.setORC2Identifier(serviceRequest, new Identifier())
 
         then:
-        HapiHelper.getORC2Identifier(serviceRequest) != null
+        HapiHelper.getORC2Identifiers(serviceRequest) != null
         HapiHelper.getORC2_1Value(serviceRequest) == null
         HapiHelper.getORC2_2Value(serviceRequest) == null
 

--- a/shared/src/testFixtures/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiFhirHelper.groovy
+++ b/shared/src/testFixtures/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiFhirHelper.groovy
@@ -133,20 +133,12 @@ class HapiFhirHelper {
     }
 
     // PID-3.5 - Identifier Type Code
-    static void setPID3_5Coding(Bundle bundle, Coding coding) {
+    static String getPID3_5Value(Bundle bundle) {
         Identifier identifier = HapiHelper.getPID3Identifier(bundle)
         if (identifier == null) {
-            return
-        }
-        identifier.setType(new CodeableConcept().addCoding(coding))
-    }
-
-    static String getPID3_5Value(Bundle bundle) {
-        Coding coding = HapiHelper.getPID3_5Coding(bundle)
-        if (coding == null) {
             return null
         }
-        return coding.getCode()
+        return HapiHelper.getCX5Value(identifier)
     }
 
     // PID-5 - Patient Name


### PR DESCRIPTION
# Fixes for baseline transformations

- `RemovePatientIdentifiers`: fixed to remove PID-3.5 as expected
- `SwapPlacerOrderAndGroupNumbers`: fixed to get and set `ORC-4` mapped to the right resources in FHIR

## Issue

#1024 