### PR TITLE
Fix Database Deploy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -218,7 +218,7 @@
         "filename": "operations/template/db.tf",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 20,
         "is_secret": false
       }
     ],
@@ -243,5 +243,5 @@
       }
     ]
   },
-  "generated_at": "2024-03-27T15:53:08Z"
+  "generated_at": "2024-05-28T21:15:26Z"
 }

--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -11,8 +11,10 @@ resource "azurerm_postgresql_flexible_server" "database" {
   storage_mb            = "32768"
   auto_grow_enabled     = true
   backup_retention_days = "14"
-  delegated_subnet_id   = local.cdc_domain_environment ? azurerm_subnet.database.id : null
-  private_dns_zone_id   = local.cdc_domain_environment ? azurerm_private_dns_zone.dns_zone.id : null
+
+  public_network_access_enabled = !local.cdc_domain_environment
+  delegated_subnet_id           = local.cdc_domain_environment ? azurerm_subnet.database.id : null
+  private_dns_zone_id           = local.cdc_domain_environment ? azurerm_private_dns_zone.dns_zone.id : null
 
   authentication {
     password_auth_enabled         = "false"


### PR DESCRIPTION
# Fix Database Deploy

I noticed that the deploy to staging is failing in `main`.  This should fix it.

A new field was added to the Terraform `azurerm_postgresql_flexible_server` resource called `public_network_access_enabled`.  It defaults to `true` which is incompatible with our other fields set when deploying to a CDC domain.  I now set it to the correct value depending on whether we are deploying into a CDC domain or not.

This wasn't caught in our CI process when it was introduced over the weekend in the latest AzureRM Terraform provider update because we keep the database "public" when deploying in a PR environment.  This is on purpose to make the deploys faster and easier for us to interact with the environments.

## Issue

_None_.