### PR TITLE
Fix id handling in load tests

### DIFF
--- a/examples/Test/e2e/orders/002_ORM_O01_short.fhir
+++ b/examples/Test/e2e/orders/002_ORM_O01_short.fhir
@@ -1,0 +1,1017 @@
+{
+    "resourceType": "Bundle",
+    "id": "1713991685806650392.f865cc8e-d438-4d5f-9147-05930f25a997",
+    "meta": {
+        "lastUpdated": "2024-04-24T20:48:05.813+00:00"
+    },
+    "identifier": {
+        "system": "https://reportstream.cdc.gov/prime-router",
+        "value": "31808297"
+    },
+    "type": "message",
+    "timestamp": "2023-05-06T10:29:16.000+00:00",
+    "entry": [
+        {
+            "fullUrl": "MessageHeader/87c2d0db-6f31-3666-b9e2-7152e039c11f",
+            "resource": {
+                "resourceType": "MessageHeader",
+                "id": "87c2d0db-6f31-3666-b9e2-7152e039c11f",
+                "meta": {
+                    "tag": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0103",
+                            "code": "P"
+                        }
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/msh-message-header",
+                        "extension": [
+                            {
+                                "url": "MSH.7",
+                                "valueString": "20230506052916-0500"
+                            },
+                            {
+                                "url": "MSH.15",
+                                "valueString": "AL"
+                            },
+                            {
+                                "url": "MSH.16",
+                                "valueString": "AL"
+                            },
+                            {
+                                "url": "MSH.21",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "2.16.840.1.113883.9.82"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "LAB_PRU_COMPONENT"
+                                }
+                            },
+                            {
+                                "url": "MSH.21",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "2.16.840.1.113883.9.22"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "LAB_TO_COMPONENT"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "eventCoding": {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0003",
+                    "code": "O01",
+                    "display": "ORM^O01^ORM_O01"
+                },
+                "destination": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                "valueString": "natus.health.state.mn.us"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                "valueString": "DNS"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "MSH.5"
+                            }
+                        ],
+                        "name": "NATUS",
+                        "receiver": {
+                            "reference": "Organization/1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3"
+                        }
+                    }
+                ],
+                "sender": {
+                    "reference": "Organization/1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494"
+                },
+                "source": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                            "valueString": "Epic"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                            "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                            "valueString": "ISO"
+                        },
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                            "valueString": "MSH.3"
+                        }
+                    ],
+                    "endpoint": "urn:oid:1.2.840.114350.1.13.145.2.7.2.695071"
+                }
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991685881552998.10ccacc7-1879-4a11-b1cc-c1f87830d494",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "Centracare"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.2,HD.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0301",
+                                    "code": "DNS"
+                                }
+                            ]
+                        },
+                        "value": "centracare.com"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991685926824266.a1dc31ff-2719-470f-9a9d-2bfd3d6353e3",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                        "valueString": "MSH.6"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "MN Public Health Lab"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.2,HD.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0301",
+                                    "code": "ISO"
+                                }
+                            ]
+                        },
+                        "system": "urn:ietf:rfc:3986",
+                        "value": "2.16.840.1.114222.4.1.10080"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/pid-patient",
+                        "extension": [
+                            {
+                                "url": "PID.8"
+                            },
+                            {
+                                "url": "PID.24",
+                                "valueString": "N"
+                            },
+                            {
+                                "url": "PID.30",
+                                "valueString": "N"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+                        "valueHumanName": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                                    "extension": [
+                                        {
+                                            "url": "XPN.2",
+                                            "valueString": "SADIE"
+                                        },
+                                        {
+                                            "url": "XPN.3",
+                                            "valueString": "S"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "family": "SMITH",
+                            "given": [
+                                "SADIE",
+                                "S"
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cx-identifier",
+                                "extension": [
+                                    {
+                                        "url": "CX.5",
+                                        "valueString": "MR"
+                                    }
+                                ]
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "PID.3"
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "MR"
+                                }
+                            ]
+                        },
+                        "value": "11102779",
+                        "assigner": {
+                            "reference": "Organization/1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xpn-human-name",
+                                "extension": [
+                                    {
+                                        "url": "XPN.2",
+                                        "valueString": "BB SARAH"
+                                    },
+                                    {
+                                        "url": "XPN.7",
+                                        "valueString": "L"
+                                    }
+                                ]
+                            }
+                        ],
+                        "use": "official",
+                        "text": "TestValue",
+                        "family": "SMITH",
+                        "given": [
+                            "BB SARAH"
+                        ]
+                    }
+                ],
+                "telecom": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+                                "valueString": "763"
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+                                "valueString": "5555555"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xtn-contact-point",
+                                "extension": [
+                                    {
+                                        "url": "XTN.3",
+                                        "valueString": "PH"
+                                    },
+                                    {
+                                        "url": "XTN.7",
+                                        "valueString": "5555555"
+                                    },
+                                    {
+                                        "url": "XTN.9",
+                                        "valueString": "(763)555-5555"
+                                    }
+                                ]
+                            }
+                        ],
+                        "system": "phone",
+                        "use": "home"
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "2023-05-04",
+                "_birthDate": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230504131023-0500"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                            "valueDateTime": "2023-05-04T13:10:23-05:00"
+                        }
+                    ]
+                },
+                "deceasedBoolean": false,
+                "address": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xad-address",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sad-address-line",
+                                        "extension": [
+                                            {
+                                                "url": "SAD.1",
+                                                "valueString": "555 STATE HIGHWAY 13"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "url": "XAD.7",
+                                        "valueCode": "H"
+                                    }
+                                ]
+                            }
+                        ],
+                        "use": "home",
+                        "line": [
+                            "555 STATE HIGHWAY 13"
+                        ],
+                        "city": "DEER CREEK",
+                        "district": "OTTER TAIL",
+                        "state": "MN",
+                        "postalCode": "56527-9657",
+                        "country": "USA"
+                    }
+                ],
+                "multipleBirthInteger": 1
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686376793169.d63d39d1-bd81-4180-a007-1a963547ff8d",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "CRPMRN"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "ServiceRequest/1713991686444544794.4cd34f9e-a7da-489c-8c3a-bd8c3edfaf67",
+            "resource": {
+                "resourceType": "ServiceRequest",
+                "id": "1713991686444544794.4cd34f9e-a7da-489c-8c3a-bd8c3edfaf67",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+                        "valueCode": "NW"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/business-event",
+                        "valueString": "20230506052913-0500"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/orc-common-order",
+                        "extension": [
+                            {
+                                "url": "orc-21-ordering-facility-name",
+                                "valueReference": {
+                                    "reference": "Organization/1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee"
+                                }
+                            },
+                            {
+                                "url": "orc-21-ordering-facility-name",
+                                "valueReference": {
+                                    "reference": "Organization/1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7"
+                                }
+                            },
+                            {
+                                "url": "orc-12-ordering-provider",
+                                "valueReference": {
+                                    "reference": "Practitioner/1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obr-observation-request",
+                        "extension": [
+                            {
+                                "url": "OBR.2",
+                                "valueIdentifier": {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                            "extension": [
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                                    "valueString": "EPIC"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                                    "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                                                },
+                                                {
+                                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                                    "valueCode": "ISO"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "value": "421832901"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "ORC.2"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "EPIC"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id",
+                                        "valueString": "1.2.840.114350.1.13.145.2.7.2.695071"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type",
+                                        "valueCode": "ISO"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "PLAC"
+                                }
+                            ]
+                        },
+                        "value": "{{placer_order_id}}"
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "authoredOn": "2023-05-06T05:29:13-05:00",
+                "_authoredOn": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506052913-0500"
+                        }
+                    ]
+                },
+                "requester": {
+                    "reference": "PractitionerRole/1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69"
+                }
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "NPI"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Practitioner/1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                "valueString": "NPI"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+                        "extension": [
+                            {
+                                "url": "XCN.3",
+                                "valueString": "JANE"
+                            },
+                            {
+                                "url": "XCN.10",
+                                "valueString": "L"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                        "valueString": "ORC.12"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/codeable-concept-id",
+                                            "valueBoolean": true
+                                        }
+                                    ],
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1265136360",
+                        "assigner": {
+                            "reference": "Organization/1713991686430978000.29e1ded0-6428-44af-8e58-0eeb2bea06af"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "JONES",
+                        "given": [
+                            "JANE"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "1043269798"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "CMS"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1043269798"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "PractitionerRole/1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69",
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "1713991686430248172.048e0c37-4095-440f-994b-5cd80bf34c69",
+                "practitioner": {
+                    "reference": "Practitioner/1713991686433173618.77eeecb0-0bad-4feb-8c05-d06d06735c90"
+                },
+                "organization": {
+                    "reference": "Organization/1713991686435100196.d7b35c8a-94d2-492f-9010-728a69b55a92"
+                }
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686439304395.dadd5b53-5f0e-4ca5-8e58-d6109d26f5ee",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "1043269798"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "CMS"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1043269798"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686440767640.8871e10e-767a-46a3-81d3-150c106697f7",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/organization-name-type",
+                        "valueCoding": {
+                            "extension": [
+                                {
+                                    "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/cwe-coding",
+                                    "valueCodeableConcept": {
+                                        "extension": [
+                                            {
+                                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                                "valueString": "XON.2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization",
+                        "extension": [
+                            {
+                                "url": "XON.10",
+                                "valueString": "739"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                                "extension": [
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                        "valueString": "MN Public Health Lab"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                                    },
+                                    {
+                                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                                    }
+                                ]
+                            }
+                        ],
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/code-index-name",
+                                            "valueString": "identifier"
+                                        }
+                                    ],
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "Submitter ID"
+                                }
+                            ]
+                        },
+                        "value": "739"
+                    }
+                ],
+                "name": "ST. CLOUD HOSPITAL"
+            }
+        },
+        {
+            "fullUrl": "Organization/1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d",
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Field",
+                                "valueString": "HD.1"
+                            }
+                        ],
+                        "value": "NPI"
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Practitioner/1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e",
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1713991686442730297.157adf6e-ef27-4065-a895-18dfd561d19e",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/assigning-authority",
+                        "extension": [
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/namespace-id",
+                                "valueString": "NPI"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-unknown-type"
+                            },
+                            {
+                                "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/universal-id-type"
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/xcn-practitioner",
+                        "extension": [
+                            {
+                                "url": "XCN.3",
+                                "valueString": "JANE"
+                            },
+                            {
+                                "url": "XCN.10",
+                                "valueString": "L"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/codeable-concept-id",
+                                            "valueBoolean": true
+                                        }
+                                    ],
+                                    "code": "NPI"
+                                }
+                            ]
+                        },
+                        "value": "1265136360",
+                        "assigner": {
+                            "reference": "Organization/1713991686441504208.f7b9b8ec-da49-4154-9290-0a8df47fbc4d"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "JONES",
+                        "given": [
+                            "JANE"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "Observation/1713991686770356478.1910e6f0-c091-4478-a7f6-ede1f3711b9f",
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1713991686770356478.1910e6f0-c091-4478-a7f6-ede1f3711b9f",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/sub-id",
+                        "valueString": "1"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/observation-sub-type",
+                        "valueCode": "AOE"
+                    },
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/obx-observation",
+                        "extension": [
+                            {
+                                "url": "OBX.2",
+                                "valueId": "NM"
+                            },
+                            {
+                                "url": "OBX.6"
+                            },
+                            {
+                                "url": "OBX.11",
+                                "valueString": "O"
+                            }
+                        ]
+                    }
+                ],
+                "status": "unknown",
+                "subject": {
+                    "reference": "Patient/1713991686420540992.4160b099-3871-449c-9e90-dadeb21100e7"
+                },
+                "effectiveDateTime": "2023-05-06T05:00:00-05:00",
+                "_effectiveDateTime": {
+                    "extension": [
+                        {
+                            "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2-date-time",
+                            "valueString": "20230506050000-0500"
+                        }
+                    ]
+                },
+                "valueQuantity": {
+                    "value": 1769.859285,
+                    "unit": "gram",
+                    "system": "UCUM",
+                    "code": "g"
+                }
+            }
+        },
+        {
+            "fullUrl": "Specimen/1713991686845404556.ccf23f10-1abe-4090-aa7c-c91dd0988c22",
+            "resource": {
+                "resourceType": "Specimen",
+                "id": "1713991686845404556.ccf23f10-1abe-4090-aa7c-c91dd0988c22",
+                "extension": [
+                    {
+                        "url": "https://reportstream.cdc.gov/fhir/StructureDefinition/hl7v2Segment",
+                        "valueString": "SPM"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/examples/Test/e2e/results/001_ORU_R01_short.fhir
+++ b/examples/Test/e2e/results/001_ORU_R01_short.fhir
@@ -966,7 +966,7 @@
                 }
               ]
             },
-            "value": "423787478"
+            "value": "{{placer_order_id}}"
           },
           {
             "extension": [

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -81,7 +81,7 @@ class SampleUser(FastHttpUser):
     def post_v1_etor_results(self):
         self.submission_id = str(uuid.uuid4())
         poi = self.placer_order_id or str(uuid.uuid4())
-        self.placer_order_id = None
+        self.placer_order_id = None if self.placer_order_id else poi
         response = self.client.post(
             RESULTS_ENDPOINT,
             headers={

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -5,7 +5,7 @@ import urllib.parse
 import urllib.request
 import uuid
 
-from locust import FastHttpUser, events, task
+from locust import FastHttpUser, between, events, task
 from locust.runners import MasterRunner
 
 HEALTH_ENDPOINT = "/health"
@@ -27,6 +27,7 @@ class SampleUser(FastHttpUser):
 
     token_refresh_interval = 280
     access_token = None
+    wait_time = between(1, 5)
 
     def on_start(self):
         self.authenticate()

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -31,7 +31,8 @@ class SampleUser(FastHttpUser):
     def on_start(self):
         self.authenticate()
 
-        self.submission_id = str(uuid.uuid4())
+        self.submission_id = None
+        self.placer_order_id = None
         self.orders_api_called = False
         self.results_api_called = False
         self.sender = "flexion.simulated-hospital"
@@ -58,33 +59,39 @@ class SampleUser(FastHttpUser):
 
     @task(5)
     def post_v1_etor_orders(self):
+        self.submission_id = str(uuid.uuid4())
+        poi = self.placer_order_id or str(uuid.uuid4())
+        self.placer_order_id = None if self.placer_order_id else poi
         response = self.client.post(
             ORDERS_ENDPOINT,
             headers={
                 "Authorization": self.access_token,
                 "RecordId": self.submission_id,
             },
-            data=order_request_body,
+            data=order_request_body.replace("{{placer_order_id}}", poi),
         )
         if response.status_code == 200:
             self.orders_api_called = True
 
     @task(5)
     def post_v1_etor_results(self):
+        self.submission_id = str(uuid.uuid4())
+        poi = self.placer_order_id or str(uuid.uuid4())
+        self.placer_order_id = None
         response = self.client.post(
             RESULTS_ENDPOINT,
             headers={
                 "Authorization": self.access_token,
                 "RecordId": self.submission_id,
             },
-            data=result_request_body,
+            data=result_request_body.replace("{{placer_order_id}}", poi),
         )
         if response.status_code == 200:
             self.results_api_called = True
 
     @task(1)
     def get_v1_etor_metadata(self):
-        if self.orders_api_called:
+        if self.orders_api_called or self.results_api_called:
             self.client.get(
                 f"{METADATA_ENDPOINT}/{self.submission_id}",
                 headers={"Authorization": self.access_token},
@@ -93,7 +100,7 @@ class SampleUser(FastHttpUser):
 
     @task(1)
     def get_v1_metadata_consolidated(self):
-        if self.orders_api_called:
+        if self.orders_api_called or self.results_api_called:
             self.client.get(
                 f"{CONSOLIDATED_ENDPOINT}/{self.sender}",
                 headers={"Authorization": self.access_token},
@@ -111,8 +118,8 @@ def test_start(environment):
         return
 
     auth_request_body = get_auth_request_body()
-    order_request_body = get_orders_request_body()
-    result_request_body = get_results_request_body()
+    order_request_body = get_order_fhir_message()
+    result_request_body = get_result_fhir_message()
 
 
 @events.quitting.add_listener
@@ -139,13 +146,13 @@ def get_auth_request_body():
     return params.encode("utf-8")
 
 
-def get_orders_request_body():
+def get_order_fhir_message():
     # read the sample request body for the orders endpoint
     with open("examples/Test/e2e/orders/001_OML_O21_short.fhir", "r") as f:
         return f.read()
 
 
-def get_results_request_body():
+def get_result_fhir_message():
     # read the sample request body for the results endpoint
     with open("examples/Test/e2e/results/001_ORU_R01_short.fhir", "r") as f:
         return f.read()

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -34,8 +34,7 @@ class SampleUser(FastHttpUser):
 
         self.submission_id = None
         self.placer_order_id = None
-        self.orders_api_called = False
-        self.results_api_called = False
+        self.message_api_called = False
         self.sender = "flexion.simulated-hospital"
 
         # Start the token refreshing thread
@@ -61,41 +60,32 @@ class SampleUser(FastHttpUser):
     def get_health(self):
         self.client.get(HEALTH_ENDPOINT)
 
-    @task(5)
-    def post_v1_etor_orders(self):
+    def post_message_request(self, endpoint, message):
         self.submission_id = str(uuid.uuid4())
         poi = self.placer_order_id or str(uuid.uuid4())
         self.placer_order_id = None if self.placer_order_id else poi
         response = self.client.post(
-            ORDERS_ENDPOINT,
+            endpoint,
             headers={
                 "Authorization": self.access_token,
                 "RecordId": self.submission_id,
             },
-            data=order_request_body.replace("{{placer_order_id}}", poi),
+            data=message.replace("{{placer_order_id}}", poi),
         )
         if response.status_code == 200:
-            self.orders_api_called = True
+            self.message_api_called = True
+
+    @task(5)
+    def post_v1_etor_orders(self):
+        self.post_message_request(ORDERS_ENDPOINT, order_request_body)
 
     @task(5)
     def post_v1_etor_results(self):
-        self.submission_id = str(uuid.uuid4())
-        poi = self.placer_order_id or str(uuid.uuid4())
-        self.placer_order_id = None if self.placer_order_id else poi
-        response = self.client.post(
-            RESULTS_ENDPOINT,
-            headers={
-                "Authorization": self.access_token,
-                "RecordId": self.submission_id,
-            },
-            data=result_request_body.replace("{{placer_order_id}}", poi),
-        )
-        if response.status_code == 200:
-            self.results_api_called = True
+        self.post_message_request(RESULTS_ENDPOINT, result_request_body)
 
     @task(1)
     def get_v1_etor_metadata(self):
-        if self.orders_api_called or self.results_api_called:
+        if self.message_api_called:
             self.client.get(
                 f"{METADATA_ENDPOINT}/{self.submission_id}",
                 headers={"Authorization": self.access_token},
@@ -104,7 +94,7 @@ class SampleUser(FastHttpUser):
 
     @task(1)
     def get_v1_metadata_consolidated(self):
-        if self.orders_api_called or self.results_api_called:
+        if self.message_api_called:
             self.client.get(
                 f"{CONSOLIDATED_ENDPOINT}/{self.sender}",
                 headers={"Authorization": self.access_token},

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -148,7 +148,7 @@ def get_auth_request_body():
 
 def get_order_fhir_message():
     # read the sample request body for the orders endpoint
-    with open("examples/Test/e2e/orders/001_OML_O21_short.fhir", "r") as f:
+    with open("examples/Test/e2e/orders/002_ORM_O01_short.fhir", "r") as f:
         return f.read()
 
 

--- a/operations/locustfile.py
+++ b/operations/locustfile.py
@@ -50,8 +50,11 @@ class SampleUser(FastHttpUser):
     def authenticate(self):
         logging.debug("Authenticating...")
         response = self.client.post(AUTH_ENDPOINT, data=auth_request_body)
-        data = response.json()
-        self.access_token = data["access_token"]
+        if response.status_code == 200:
+            data = response.json()
+            self.access_token = data["access_token"]
+        else:
+            logging.error(f"Authentication failed: {response.error}")
 
     @task
     def get_health(self):


### PR DESCRIPTION
# Fix id handling in load tests

- Created a new `RecordId` for each request
- Replacing Placer Order Number in orders and results to be linked uniquely by pair
- Added ORM sample FHIR message that pairs with the ORU sample to be linked
- Some refactoring

## Issue

#1121