### PR TITLE
Fix message encoding when sending HTTP request back to RS

### DIFF
--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/apache/ApacheClient.java
@@ -3,6 +3,7 @@ package gov.hhs.cdc.trustedintermediary.external.apache;
 import gov.hhs.cdc.trustedintermediary.wrappers.HttpClient;
 import gov.hhs.cdc.trustedintermediary.wrappers.HttpClientException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.core5.http.Header;
@@ -32,7 +33,7 @@ public class ApacheClient implements HttpClient {
         try {
             return Request.post(url)
                     .setHeaders(headers)
-                    .body(new StringEntity(body))
+                    .body(new StringEntity(body, StandardCharsets.UTF_8))
                     .execute()
                     .returnContent()
                     .asString();


### PR DESCRIPTION
# Fix message encoding when sending HTTP request back to RS

The HTTP request message was being encoded using `ISO-8859-1` by default, which doesn't encode correctly characters like `µ`. Fixed by explicitly encoding with `UTF-8`

## Issue

#1133
