### PR TITLE
Update UCSD transformation filters with expected values

### DIFF
--- a/etor/src/main/resources/transformation_definitions.json
+++ b/etor/src/main/resources/transformation_definitions.json
@@ -45,7 +45,7 @@
       "description": "Updates UCSD ORU Receiving Facility (MSH-6) to value in ORC-21.10 and remove content from MSH-6.2 and MSH-6.3",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(DiagnosticReport)[0].basedOn.resolve().requester.resolve().organization.resolve().extension.where(url = 'https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization').extension.where(url = 'XON.10').value",
+        "Bundle.entry.resource.ofType(DiagnosticReport)[0].basedOn.resolve().requester.resolve().organization.resolve().extension.where(url = 'https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization').extension.where(url = 'XON.10').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [

--- a/etor/src/main/resources/transformation_definitions.json
+++ b/etor/src/main/resources/transformation_definitions.json
@@ -1,13 +1,14 @@
 {
-  "definitions": [ {
+  "definitions": [
+    {
       "name": "addEtorProcessingTag",
       "description": "Adds ETOR processing tag to all messages",
       "message": "",
-      "conditions": [ ],
+      "conditions": [],
       "rules": [
         {
           "name": "AddEtorProcessingTag",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -21,7 +22,7 @@
       "rules": [
         {
           "name": "ConvertToOmlOrder",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -35,7 +36,22 @@
       "rules": [
         {
           "name": "AddContactSectionToPatientResource",
-          "args": { }
+          "args": {}
+        }
+      ]
+    },
+    {
+      "name": "ucsdOruUpdateReceivingFacilityWithOrderingFacilityIdentifier",
+      "description": "Updates UCSD ORU Receiving Facility (MSH-6) to value in ORC-21.10 and remove content from MSH-6.2 and MSH-6.3",
+      "message": "",
+      "conditions": [
+        "Bundle.entry.resource.ofType(DiagnosticReport)[0].basedOn.resolve().requester.resolve().organization.resolve().extension.where(url = 'https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization').extension.where(url = 'XON.10').value",
+        "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
+      ],
+      "rules": [
+        {
+          "name": "UpdateReceivingFacilityWithOrderingFacilityIdentifier",
+          "args": {}
         }
       ]
     },
@@ -44,7 +60,7 @@
       "description": "Updates UCSD ORU Sending Facility's Namespace Id (MSH-4) to 'CDPH'. It also removes Universal Id (MSH-4.2) and Universal Id Type (MSH-4.3).",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
@@ -61,7 +77,7 @@
       "description": "Updates UCSD ORU Receiving Application's Namespace Id (MSH-5.1) to 'EPIC'. It also removes Universal Id (MSH-5.2) and Universal Id Type (MSH-5.3)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
@@ -74,32 +90,17 @@
       ]
     },
     {
-      "name": "ucsdOruUpdateReceivingFacilityWithOrderingFacilityIdentifier",
-      "description": "Updates UCSD ORU Receiving Facility (MSH-6) to value in ORC-21.10 and remove content from MSH-6.2 and MSH-6.3",
-      "message": "",
-      "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
-        "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
-      ],
-      "rules": [
-        {
-          "name": "UpdateReceivingFacilityWithOrderingFacilityIdentifier",
-          "args": { }
-        }
-      ]
-    },
-    {
       "name": "ucsdOruRemoveMessageTypeStructure",
       "description": "Removes UCSD ORU Message Structure (MSH-9.3) from the Message Type (MSH-9)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
         {
           "name": "RemoveMessageTypeStructure",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -108,13 +109,13 @@
       "description": "Swaps UCSD ORU's Placer Order Number (ORC-2) and Placer Group Number (ORC-4)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
         {
           "name": "SwapPlacerOrderAndGroupNumbers",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -123,13 +124,13 @@
       "description": "Removes UCSD ORU Assigning Authority (PID-3.4) and Identifier Type Code (PID-3.5) from Patient Identifier List (PID-3)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
         {
           "name": "RemovePatientIdentifiers",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -138,13 +139,13 @@
       "description": "Removes UCSD ORU Name Type Code (PID-5.7) from Patient Name (PID-5)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'"
       ],
       "rules": [
         {
           "name": "RemovePatientNameTypeCode",
-          "args": { }
+          "args": {}
         }
       ]
     },
@@ -153,7 +154,7 @@
       "description": "Removes all OBRs from an UCSD ORU message except for the OBR with value '54089-8' in OBR-4.1. All OBXs are attached to the sole remaining OBR",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'",
         "Bundle.entry.resource.ofType(ServiceRequest).code.coding.where(code = '54089-8').exists()"
       ],
@@ -171,7 +172,7 @@
       "description": "Overrides the values of Name of Coding System (OBR-4.3) and Alternate Identifier (OBR-4.4) in Universal Type Code (OBR-4)",
       "message": "",
       "conditions": [
-        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.2,HD.3').value = 'UCSD'",
+        "Bundle.entry.resource.ofType(MessageHeader).destination.receiver.resolve().identifier.where(extension.value = 'HD.1').value in ('R797' | 'R508')",
         "Bundle.entry.resource.ofType(MessageHeader).event.code = 'R01'",
         "Bundle.entry.resource.ofType(ServiceRequest).code.coding.where(code = '54089-8').exists()"
       ],

--- a/etor/src/main/resources/transformation_definitions.json
+++ b/etor/src/main/resources/transformation_definitions.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "ucsdOruUpdateReceivingFacilityWithOrderingFacilityIdentifier",
-      "description": "Updates UCSD ORU Receiving Facility (MSH-6) to value in ORC-21.10 and remove content from MSH-6.2 and MSH-6.3",
+      "description": "Updates UCSD ORU Receiving Facility (MSH-6) to value in ORC-21.10 and remove Universal Id (MSH-6.2) and Universal Id Type (MSH-6.3).",
       "message": "",
       "conditions": [
         "Bundle.entry.resource.ofType(DiagnosticReport)[0].basedOn.resolve().requester.resolve().organization.resolve().extension.where(url = 'https://reportstream.cdc.gov/fhir/StructureDefinition/xon-organization').extension.where(url = 'XON.10').value in ('R797' | 'R508')",


### PR DESCRIPTION
# Update UCSD transformation filters with expected values

Updated transformations condition to filter UCSD messages using 
- `ORC-21.10` for the transformation that updated `MSH-6.1` with the value from `ORC-21.10`
- `MSH-6.1` for the rest of the transformations once that value has been updated
- Use the expected routing values: `R797` and `R508`