### PR TITLE
Add content type option to `hrl` script

### DIFF
--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -9,8 +9,9 @@ fi
 # default values
 env=local
 root=$CDCTI_HOME/examples/Test/
+content_type=application/hl7-v2
 client_id=flexion
-client_sender=simulated-lab
+client_sender=simulated-hospital
 verbose=""
 submission_id=""
 
@@ -20,6 +21,7 @@ show_help() {
     echo "Options:"
     echo "    -f <REL_PATH>         The path to the hl7/fhir file to submit, relative the root path (Required for waters API)"
     echo "    -r <ROOT_PATH>        The root path to the hl7/fhir files (Default: $root)"
+    echo "    -t <CONTENT_TYPE>     The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: $content_type)"
     echo "    -e [local | staging]  The environment to run the test in (Default: $env)"
     echo "    -c <CLIENT_ID>        The client id to use (Default: $client_id)"
     echo "    -s <CLIENT_SENDER>    The client sender to use (Default: $client_sender)"
@@ -45,13 +47,16 @@ fi
 hurl_file="$1" # Assign the first argument to hurl_file
 shift          # Remove the first argument from the list of arguments
 
-while getopts ':f:r:e:c:s:x:i:vh' opt; do
+while getopts ':f:r:t:e:c:s:x:i:vh' opt; do
     case "$opt" in
     f)
         fpath="$OPTARG"
         ;;
     r)
         root="$OPTARG"
+        ;;
+    t)
+        content_type="$OPTARG"
         ;;
     e)
         env="$OPTARG"
@@ -113,6 +118,7 @@ hurl \
     --variable fpath=$fpath \
     --file-root $root \
     --variable url=$url \
+    --variable content-type=$content_type \
     --variable client-id=$client_id \
     --variable client-sender=$client_sender \
     --variable jwt=$(jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256 -k $client_id.$client_sender -i $client_id.$client_sender -s $client_id.$client_sender -a $host --no-iat -S @$secret) \

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -8,6 +8,7 @@ Usage: ./hrl <HURL_FILE> [OPTIONS]
 Options:
     -f <REL_PATH>         The path to the hl7/fhir file to submit, relative the root path (Required for waters API)
     -r <ROOT_PATH>        The root path to the hl7/fhir files (Default: $CDCTI_HOME/examples/Test/)
+    -t <CONTENT_TYPE>     The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: application/hl7-v2)
     -e [local | staging]  The environment to run the test in (Default: local)
     -c <CLIENT_ID>        The client id to use (Default: flexion)
     -s <CLIENT_SENDER>    The client sender to use (Default: simulated-lab)

--- a/scripts/hurl/rs/waters.hurl
+++ b/scripts/hurl/rs/waters.hurl
@@ -12,13 +12,7 @@ HTTP 200
 token: jsonpath "$['access_token']"
 
 POST {{url}}/api/waters
-Content-Type: application/hl7-v2
+Content-Type: {{content-type}}
 Client: {{client-id}}.{{client-sender}}
 Authorization: Bearer {{token}}
 file,{{fpath}};
-
-# POST {{url}}/api/waters
-# Content-Type: application/fhir+ndjson
-# Client: {{client-id}}.{{client-sender}}
-# Authorization: Bearer {{token}}
-# file,{{fpath}};


### PR DESCRIPTION
Updated `hrl` script to add content type option to call `waters` endpoint
