### PR TITLE
Bugfix for RemovePatientNameTypeCode transformation

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
@@ -12,6 +12,8 @@ public class RemovePatientNameTypeCode implements CustomFhirTransformation {
     @Override
     public void transform(final FhirResource<?> resource, final Map<String, String> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
-        HapiHelper.removePID5_7Extension(bundle);
+        // Need to set the value for extension to empty instead of removing the extension,
+        // otherwise RS will set its own value in its place
+        HapiHelper.setPID5_7ExtensionValue(bundle, null);
     }
 }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -275,7 +275,9 @@ public class HapiHelper {
     public static void removePID5_7Extension(Bundle bundle) {
         Extension extension = getPID5Extension(bundle);
         if (extension != null && extension.hasExtension(HapiHelper.EXTENSION_XPN7_URL)) {
-            extension.removeExtension(HapiHelper.EXTENSION_XPN7_URL);
+            // Need to set the value for extension to empty instead of removing the extension,
+            // otherwise RS will set its own value in its place
+            extension.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL).setValue(new StringType());
         }
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -272,12 +272,12 @@ public class HapiHelper {
         return name.getExtensionByUrl(HapiHelper.EXTENSION_XPN_HUMAN_NAME_URL);
     }
 
-    public static void removePID5_7Extension(Bundle bundle) {
+    public static void setPID5_7ExtensionValue(Bundle bundle, String value) {
         Extension extension = getPID5Extension(bundle);
         if (extension != null && extension.hasExtension(HapiHelper.EXTENSION_XPN7_URL)) {
-            // Need to set the value for extension to empty instead of removing the extension,
-            // otherwise RS will set its own value in its place
-            extension.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL).setValue(new StringType());
+            extension
+                    .getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)
+                    .setValue(new StringType(value));
         }
     }
 

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -457,7 +457,7 @@ class HapiHelperTest extends Specification {
 
         when:
         def bundle = new Bundle()
-        HapiHelper.removePID5_7Extension(bundle)
+        HapiHelper.setPID5_7ExtensionValue(bundle, null)
 
         then:
         HapiHelper.getPID5Extension(bundle) == null
@@ -465,7 +465,7 @@ class HapiHelperTest extends Specification {
         when:
         HapiFhirHelper.createPIDPatient(bundle)
         HapiFhirHelper.setPID5Extension(bundle)
-        HapiHelper.removePID5_7Extension(bundle)
+        HapiHelper.setPID5_7ExtensionValue(bundle, null)
 
         then:
         HapiFhirHelper.getPID5_7Value(bundle) == null
@@ -478,7 +478,7 @@ class HapiHelperTest extends Specification {
         HapiFhirHelper.getPID5_7Value(bundle) == pid5_7
 
         when:
-        HapiHelper.removePID5_7Extension(bundle)
+        HapiHelper.setPID5_7ExtensionValue(bundle, null)
 
         then:
         HapiHelper.getPID5Extension(bundle) != null


### PR DESCRIPTION
# Bugfix for RemovePatientNameTypeCode transformation

The `RemovePatientNameTypeCode` transformation, which is supposed to remove PID-5.7, instead was replacing it with `L`. We found the transformation is working correctly, but the `L` is being added in RS when converting FHIR => HL7. We found there is `%resource.extension(%'rsext-xpn-human-name').extension("XPN.7").exists().not()` condition in the mapping that will add character based on the `.use` field, when the extension doesn't exist. To fix it, instead of removing the extension we're just setting it to empty.