### PR TITLE
Ignore Terraform tags managed by CDC

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -7,6 +7,24 @@ resource "azurerm_monitor_action_group" "notify_slack_email" {
     name          = "cdcti-flexion-slack-email-receiver"
     email_address = var.alert_slack_email
   }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "database_token_expired_alert" {
@@ -39,5 +57,23 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "database_token_expired_a
   trigger {
     operator  = "GreaterThan"
     threshold = 1
+  }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
   }
 }

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -5,6 +5,23 @@ resource "azurerm_container_registry" "registry" {
   location            = data.azurerm_resource_group.group.location
   sku                 = "Standard"
   admin_enabled       = true
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 # Create the staging service plan
@@ -15,6 +32,24 @@ resource "azurerm_service_plan" "plan" {
   os_type                = "Linux"
   sku_name               = local.higher_environment_level ? "P1v3" : "P0v3"
   zone_balancing_enabled = local.higher_environment_level
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 # Create the staging App Service
@@ -74,6 +109,24 @@ resource "azurerm_linux_web_app" "api" {
   identity {
     type = "SystemAssigned"
   }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_monitor_autoscale_setting" "api_autoscale" {
@@ -81,7 +134,6 @@ resource "azurerm_monitor_autoscale_setting" "api_autoscale" {
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
   target_resource_id  = azurerm_service_plan.plan.id
-
 
   profile {
     name = "defaultProfile"
@@ -133,5 +185,23 @@ resource "azurerm_monitor_autoscale_setting" "api_autoscale" {
         cooldown  = "PT5M"
       }
     }
+  }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
   }
 }

--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -27,7 +27,20 @@ resource "azurerm_postgresql_flexible_server" "database" {
   lifecycle {
     ignore_changes = [
       zone,
-      high_availability.0.standby_availability_zone
+      high_availability.0.standby_availability_zone,
+      #   below tags are managed by CDC
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
     ]
   }
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -11,4 +11,22 @@ resource "azurerm_storage_account" "docs" {
   static_website {
     index_document = "index.html"
   }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -8,6 +8,24 @@ resource "azurerm_key_vault" "key_storage" {
   tenant_id = data.azurerm_client_config.current.tenant_id
 
   purge_protection_enabled = false
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "allow_github_deployer" {

--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -3,12 +3,48 @@ resource "azurerm_log_analytics_workspace" "logs_workspace" {
 
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_log_analytics_query_pack" "application_logs_pack" {
   name                = "TI Application Logs"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_log_analytics_query_pack_query" "application_logs" {

--- a/operations/template/net.tf
+++ b/operations/template/net.tf
@@ -105,6 +105,24 @@ resource "azurerm_subnet" "resolver_outbound" {
 resource "azurerm_private_dns_zone" "dns_zone" {
   name                = "privateintermediary.postgres.database.azure.com"
   resource_group_name = data.azurerm_resource_group.group.name
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "db_network_link" {
@@ -113,18 +131,71 @@ resource "azurerm_private_dns_zone_virtual_network_link" "db_network_link" {
   virtual_network_id    = data.azurerm_virtual_network.app.id
   resource_group_name   = data.azurerm_resource_group.group.name
   depends_on            = [azurerm_subnet.database]
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_network_security_group" "db_security_group" {
   name                = "database-security-group"
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_route_table" "database" {
   name                = "database-route-table"
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_route" "entra_internet" {
@@ -234,6 +305,23 @@ resource "azurerm_network_security_group" "app_security_group" {
   name                = "app-security-group"
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_network_security_rule" "App_Splunk_UF_omhsinf" {

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -7,6 +7,24 @@ resource "azurerm_storage_account" "storage" {
   account_kind                    = "StorageV2"
   allow_nested_items_to_be_public = false
   min_tls_version                 = "TLS1_2"
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_storage_container" "metadata" {

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -4,6 +4,24 @@ resource "azurerm_public_ip" "vpn" {
   resource_group_name = data.azurerm_resource_group.group.name
 
   allocation_method = "Dynamic"
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_virtual_network_gateway" "vpn" {
@@ -39,6 +57,24 @@ resource "azurerm_virtual_network_gateway" "vpn" {
   }
 
   depends_on = [azurerm_subnet.app, azurerm_subnet.database, azurerm_subnet.resolver_inbound, azurerm_subnet.resolver_outbound, azurerm_subnet_network_security_group_association.app_security_group, azurerm_subnet_network_security_group_association.database_security_group, azurerm_subnet_route_table_association.database_database] # the VPN "locks" the subnets, so the VPN should wait until the subnet edits are done
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_private_dns_resolver" "private_zone_resolver" {
@@ -46,6 +82,24 @@ resource "azurerm_private_dns_resolver" "private_zone_resolver" {
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
   virtual_network_id  = data.azurerm_virtual_network.app.id
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 
@@ -58,6 +112,24 @@ resource "azurerm_private_dns_resolver_inbound_endpoint" "resolver_inbound_endpo
     private_ip_allocation_method = "Dynamic"
     subnet_id                    = azurerm_subnet.resolver_inbound.id
   }
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_private_dns_resolver_outbound_endpoint" "resolver_outbound_endpoint" {
@@ -65,4 +137,22 @@ resource "azurerm_private_dns_resolver_outbound_endpoint" "resolver_outbound_end
   private_dns_resolver_id = azurerm_private_dns_resolver.private_zone_resolver.id
   location                = azurerm_private_dns_resolver.private_zone_resolver.location
   subnet_id               = azurerm_subnet.resolver_outbound.id
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }


### PR DESCRIPTION
# Add a PR title

The CDC automatically adds a set of tags to Terraform resources. This PR adds a set of ignore tags so we do not delete them each time we apply Terraform and CDC re-adds them.

## Issue

N/A

