### PR TITLE
Add hurl scripts for delivery and token RS endpoints

### DIFF
--- a/scripts/hurl/rs/delivery.hurl
+++ b/scripts/hurl/rs/delivery.hurl
@@ -1,0 +1,15 @@
+POST {{url}}/api/token
+Content-Type: application/x-www-form-urlencoded
+[FormParams]
+scope: {{client-id}}.*.report
+client_assertion: {{jwt}}
+client_assertion_type: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+grant_type: client_credentials
+
+HTTP 200
+
+[Captures]
+token: jsonpath "$['access_token']"
+
+GET {{url}}/api/waters/report/{{submissionid}}/delivery
+Authorization: Bearer {{token}}

--- a/scripts/hurl/rs/token.hurl
+++ b/scripts/hurl/rs/token.hurl
@@ -1,0 +1,7 @@
+POST {{url}}/api/token
+Content-Type: application/x-www-form-urlencoded
+[FormParams]
+scope: {{client-id}}.*.report
+client_assertion: {{jwt}}
+client_assertion_type: urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+grant_type: client_credentials


### PR DESCRIPTION
# Add hurl scripts for delivery and token RS endpoints

Added hurl scripts for the `/api/token` and `/api/waters/report/{{submissionid}}/delivery` endpoints