### PR TITLE
Handle warning regarding double locking

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -39,7 +39,7 @@ public class TransformationRuleEngine implements RuleEngine {
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
-                if (rules.isEmpty()) {
+                if (!rulesLoaded) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -9,14 +9,13 @@ import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 
 /** Implements the RuleEngine interface. It represents a rule engine for transformations. */
 public class TransformationRuleEngine implements RuleEngine {
     private String ruleDefinitionsFileName;
-    final List<TransformationRule> rules = Collections.synchronizedList(new ArrayList<>());
+    final List<TransformationRule> rules = new ArrayList<>();
     volatile boolean rulesLoaded = false;
     private static final TransformationRuleEngine INSTANCE = new TransformationRuleEngine();
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -39,14 +39,12 @@ public class TransformationRuleEngine implements RuleEngine {
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
-                rulesLoaded = true;
                 if (rules.isEmpty()) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()
                                     .getResourceAsStream(ruleDefinitionsFileName);
                     if (resourceStream == null) {
-                        rulesLoaded = false;
                         throw new RuleLoaderException(
                                 "File not found: " + ruleDefinitionsFileName,
                                 new FileNotFoundException());
@@ -54,6 +52,7 @@ public class TransformationRuleEngine implements RuleEngine {
                     List<TransformationRule> parsedRules =
                             ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
                     rules.addAll(parsedRules);
+                    rulesLoaded = true;
                 }
             }
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -33,18 +33,21 @@ public class TransformationRuleEngine implements RuleEngine {
     @Override
     public void unloadRules() {
         rules.clear();
+        rulesLoaded = false;
     }
 
     @Override
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
+                rulesLoaded = true;
                 if (rules.isEmpty()) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()
                                     .getResourceAsStream(ruleDefinitionsFileName);
                     if (resourceStream == null) {
+                        rulesLoaded = false;
                         throw new RuleLoaderException(
                                 "File not found: " + ruleDefinitionsFileName,
                                 new FileNotFoundException());
@@ -52,7 +55,6 @@ public class TransformationRuleEngine implements RuleEngine {
                     List<TransformationRule> parsedRules =
                             ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
                     rules.addAll(parsedRules);
-                    rulesLoaded = true;
                 }
             }
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -9,13 +9,14 @@ import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 
 /** Implements the RuleEngine interface. It represents a rule engine for transformations. */
 public class TransformationRuleEngine implements RuleEngine {
     private String ruleDefinitionsFileName;
-    volatile List<TransformationRule> rules = new ArrayList<>();
+    final List<TransformationRule> rules = Collections.synchronizedList(new ArrayList<>());
 
     private static final TransformationRuleEngine INSTANCE = new TransformationRuleEngine();
 
@@ -36,23 +37,18 @@ public class TransformationRuleEngine implements RuleEngine {
 
     @Override
     public void ensureRulesLoaded() throws RuleLoaderException {
-        // Double-checked locking - needed to protect from excessive sync locks
-        if (rules.isEmpty()) {
-            synchronized (this) {
-                if (rules.isEmpty()) {
-                    InputStream resourceStream =
-                            getClass()
-                                    .getClassLoader()
-                                    .getResourceAsStream(ruleDefinitionsFileName);
-                    if (resourceStream == null) {
-                        throw new RuleLoaderException(
-                                "File not found: " + ruleDefinitionsFileName,
-                                new FileNotFoundException());
-                    }
-                    List<TransformationRule> parsedRules =
-                            ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
-                    this.rules.addAll(parsedRules);
+        synchronized (this) {
+            if (rules.isEmpty()) {
+                InputStream resourceStream =
+                        getClass().getClassLoader().getResourceAsStream(ruleDefinitionsFileName);
+                if (resourceStream == null) {
+                    throw new RuleLoaderException(
+                            "File not found: " + ruleDefinitionsFileName,
+                            new FileNotFoundException());
                 }
+                List<TransformationRule> parsedRules =
+                        ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
+                this.rules.addAll(parsedRules);
             }
         }
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 /** Implements the RuleEngine interface. It represents a rule engine for transformations. */
 public class TransformationRuleEngine implements RuleEngine {
     private String ruleDefinitionsFileName;
-    final List<TransformationRule> rules = new ArrayList<>();
+    volatile List<TransformationRule> rules = new ArrayList<>();
 
     private static final TransformationRuleEngine INSTANCE = new TransformationRuleEngine();
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleEngine.java
@@ -37,7 +37,7 @@ public class TransformationRuleEngine implements RuleEngine {
 
     @Override
     public void ensureRulesLoaded() throws RuleLoaderException {
-        synchronized (this) {
+        synchronized (rules) {
             if (rules.isEmpty()) {
                 InputStream resourceStream =
                         getClass().getClassLoader().getResourceAsStream(ruleDefinitionsFileName);
@@ -48,7 +48,7 @@ public class TransformationRuleEngine implements RuleEngine {
                 }
                 List<TransformationRule> parsedRules =
                         ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
-                this.rules.addAll(parsedRules);
+                rules.addAll(parsedRules);
             }
         }
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -33,18 +33,21 @@ public class ValidationRuleEngine implements RuleEngine {
     @Override
     public void unloadRules() {
         rules.clear();
+        rulesLoaded = false;
     }
 
     @Override
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
+                rulesLoaded = true;
                 if (rules.isEmpty()) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()
                                     .getResourceAsStream(ruleDefinitionsFileName);
                     if (resourceStream == null) {
+                        rulesLoaded = false;
                         throw new RuleLoaderException(
                                 "File not found: " + ruleDefinitionsFileName,
                                 new FileNotFoundException());
@@ -52,7 +55,6 @@ public class ValidationRuleEngine implements RuleEngine {
                     List<ValidationRule> parsedRules =
                             ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
                     rules.addAll(parsedRules);
-                    rulesLoaded = true;
                 }
             }
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -37,7 +37,7 @@ public class ValidationRuleEngine implements RuleEngine {
 
     @Override
     public void ensureRulesLoaded() throws RuleLoaderException {
-        synchronized (this) {
+        synchronized (rules) {
             if (rules.isEmpty()) {
                 InputStream resourceStream =
                         getClass().getClassLoader().getResourceAsStream(ruleDefinitionsFileName);
@@ -48,7 +48,7 @@ public class ValidationRuleEngine implements RuleEngine {
                 }
                 List<ValidationRule> parsedRules =
                         ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
-                this.rules.addAll(parsedRules);
+                rules.addAll(parsedRules);
             }
         }
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -39,7 +39,7 @@ public class ValidationRuleEngine implements RuleEngine {
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
-                if (rules.isEmpty()) {
+                if (!rulesLoaded) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 /** Implements the RuleEngine interface. It represents a rule engine for validations. */
 public class ValidationRuleEngine implements RuleEngine {
     private String ruleDefinitionsFileName;
-    final List<ValidationRule> rules = new ArrayList<>();
+    volatile List<ValidationRule> rules = new ArrayList<>();
 
     private static final ValidationRuleEngine INSTANCE = new ValidationRuleEngine();
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -39,14 +39,12 @@ public class ValidationRuleEngine implements RuleEngine {
     public void ensureRulesLoaded() throws RuleLoaderException {
         if (!rulesLoaded) {
             synchronized (rules) {
-                rulesLoaded = true;
                 if (rules.isEmpty()) {
                     InputStream resourceStream =
                             getClass()
                                     .getClassLoader()
                                     .getResourceAsStream(ruleDefinitionsFileName);
                     if (resourceStream == null) {
-                        rulesLoaded = false;
                         throw new RuleLoaderException(
                                 "File not found: " + ruleDefinitionsFileName,
                                 new FileNotFoundException());
@@ -54,6 +52,7 @@ public class ValidationRuleEngine implements RuleEngine {
                     List<ValidationRule> parsedRules =
                             ruleLoader.loadRules(resourceStream, new TypeReference<>() {});
                     rules.addAll(parsedRules);
+                    rulesLoaded = true;
                 }
             }
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/validation/ValidationRuleEngine.java
@@ -9,14 +9,13 @@ import gov.hhs.cdc.trustedintermediary.wrappers.formatter.TypeReference;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 
 /** Implements the RuleEngine interface. It represents a rule engine for validations. */
 public class ValidationRuleEngine implements RuleEngine {
     private String ruleDefinitionsFileName;
-    final List<ValidationRule> rules = Collections.synchronizedList(new ArrayList<>());
+    final List<ValidationRule> rules = new ArrayList<>();
     volatile boolean rulesLoaded = false;
     private static final ValidationRuleEngine INSTANCE = new ValidationRuleEngine();
 


### PR DESCRIPTION
# Handle warning regarding double locking
Instead of double-locking, we're now using a synchronized list inside a sync block.

## Issue

#1210

## Checklist

- [ ] I have added tests to cover my changes
- [ ] I have added logging where useful (with appropriate log level)
- [ ] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
