### PR TITLE
Fix `Constructor Invokes Overridable Function` Fortify finding

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponse.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponse.java
@@ -1,25 +1,9 @@
 package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 /** Response for the v1/etor/orders endpoint. */
-public final class OrderResponse {
-
-    private final String fhirResourceId;
-    private final String patientId;
-
-    OrderResponse(String fhirResourceId, String patientId) {
-        this.fhirResourceId = fhirResourceId;
-        this.patientId = patientId;
-    }
+public record OrderResponse(String fhirResourceId, String patientId) {
 
     public OrderResponse(Order<?> orders) {
         this(orders.getFhirResourceId(), orders.getPatientId());
-    }
-
-    public String getFhirResourceId() {
-        return fhirResourceId;
-    }
-
-    public String getPatientId() {
-        return patientId;
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponse.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponse.java
@@ -1,34 +1,25 @@
 package gov.hhs.cdc.trustedintermediary.etor.orders;
 
 /** Response for the v1/etor/orders endpoint. */
-public class OrderResponse {
+public final class OrderResponse {
 
-    private String fhirResourceId;
-    private String patientId;
+    private final String fhirResourceId;
+    private final String patientId;
 
     OrderResponse(String fhirResourceId, String patientId) {
-        setFhirResourceId(fhirResourceId);
-        setPatientId(patientId);
+        this.fhirResourceId = fhirResourceId;
+        this.patientId = patientId;
     }
 
     public OrderResponse(Order<?> orders) {
-        setFhirResourceId(orders.getFhirResourceId());
-        setPatientId(orders.getPatientId());
+        this(orders.getFhirResourceId(), orders.getPatientId());
     }
 
     public String getFhirResourceId() {
         return fhirResourceId;
     }
 
-    public void setFhirResourceId(String fhirResourceId) {
-        this.fhirResourceId = fhirResourceId;
-    }
-
     public String getPatientId() {
         return patientId;
-    }
-
-    public void setPatientId(String patientId) {
-        this.patientId = patientId;
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/ResultResponse.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/ResultResponse.java
@@ -1,21 +1,8 @@
 package gov.hhs.cdc.trustedintermediary.etor.results;
 
-public class ResultResponse {
-    private String fhirResourceId;
-
-    public ResultResponse(String fhirResourceId) {
-        this.fhirResourceId = fhirResourceId;
-    }
+public record ResultResponse(String fhirResourceId) {
 
     public ResultResponse(Result<?> result) {
-        this.fhirResourceId = result.getFhirResourceId();
-    }
-
-    public String getFhirResourceId() {
-        return fhirResourceId;
-    }
-
-    public void setFhirResourceId(final String fhirResourceId) {
-        this.fhirResourceId = fhirResourceId;
+        this(result.getFhirResourceId());
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/OrderResponseTest.groovy
@@ -25,8 +25,8 @@ class OrderResponseTest extends Specification {
         def actual = new OrderResponse(orders)
 
         then:
-        actual.getFhirResourceId() == expectedResourceId
-        actual.getPatientId() == expectedPatientId
+        actual.fhirResourceId() == expectedResourceId
+        actual.patientId() == expectedPatientId
     }
 
     def "test argument constructor"() {
@@ -38,7 +38,7 @@ class OrderResponseTest extends Specification {
         def actual = new OrderResponse(expectedResourceId, expectedPatientId)
 
         then:
-        actual.getFhirResourceId() == expectedResourceId
-        actual.getPatientId() == expectedPatientId
+        actual.fhirResourceId() == expectedResourceId
+        actual.patientId() == expectedPatientId
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/ResultResponseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/ResultResponseTest.groovy
@@ -24,7 +24,7 @@ class ResultResponseTest extends Specification {
         def actual = new ResultResponse(result)
 
         then:
-        actual.getFhirResourceId() == expectedResourceId
+        actual.fhirResourceId() == expectedResourceId
     }
 
     def "test argument constructor"() {
@@ -35,6 +35,6 @@ class ResultResponseTest extends Specification {
         def actual = new ResultResponse(expectedResourceId)
 
         then:
-        actual.getFhirResourceId() == expectedResourceId
+        actual.fhirResourceId() == expectedResourceId
     }
 }


### PR DESCRIPTION
# Fix `Constructor Invokes Overridable Function` Fortify finding

Refactored `OrderResponse` to make it immutable, and along with `ResultResponse` which was already immutable, turned them into records

## Issue

#1216 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly
