### PR TITLE
turn off admin_enabled and use managed identity for container registry

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -4,7 +4,7 @@ resource "azurerm_container_registry" "registry" {
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
   sku                 = "Standard"
-  admin_enabled       = true
+
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
@@ -22,6 +22,12 @@ resource "azurerm_container_registry" "registry" {
       tags["zone"]
     ]
   }
+}
+
+resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {
+  principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
+  role_definition_name = "AcrPull"
+  scope                = azurerm_container_registry.registry.id
 }
 
 # Create the staging service plan
@@ -68,6 +74,8 @@ resource "azurerm_linux_web_app" "api" {
     health_check_eviction_time_in_min = 5
 
     scm_use_main_ip_restriction = local.cdc_domain_environment ? true : null
+
+    container_registry_use_managed_identity = true
 
     dynamic "ip_restriction" {
       for_each = local.cdc_domain_environment ? [1] : []


### PR DESCRIPTION
Reverts CDCgov/trusted-intermediary#1272 - **DO NOT merge this PR until we get updated permissions from CDC that will allow this to run in their environments**
## Description
Fortify wants us to not have `admin_enabled` set to `true` on the container registry. This PR changes that setting and turns on `container_registry_use_managed_identity` instead. To test this, we deployed to both a Flexion environment (this PR env) and a CDC one (dev) and confirmed the app deployed successfully and was running

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1209