### PR TITLE
Low Privilege User for Running the Application Take 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM amazoncorretto:17.0.12-alpine
 
+# Uppdate dependencies and clear the dependency cache.
 RUN apk update && apk -U upgrade && rm -rf /var/cache/apk/*
 
+# Create and use a lower permission (non-root) user.
 RUN adduser -S myLowPrivilegeUser
 USER myLowPrivilegeUser
 
@@ -13,6 +15,8 @@ WORKDIR /home/myLowPrivilegeUser/app/
 # If we put the jar file into the myLowPrivilegeUser's home directly, the container fails to run in Azure.
 COPY --chown=myLowPrivilegeUser ./app/build/libs/app-all.jar /usr/local/bin/app.jar
 
+# Run the service.
 CMD ["java", "-jar", "/usr/local/bin/app.jar"]
 
+# Inform Docker that this container listens on the specified port.
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 # Use Linux-Alpine image
 FROM amazoncorretto:17.0.12-alpine
 
-RUN apk -U upgrade
+RUN apk update && apk -U upgrade && rm -rf /var/cache/apk/*
+
+RUN adduser -S myLowPrivilegeUser
+USER myLowPrivilegeUser
 
 ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
 
 # Create directory and switch to it
-WORKDIR /app
+WORKDIR /home/myLowPrivilegeUser/app/
 
 # Add application JAR to created folder
-COPY ${JAR_LIB_FILE} app.jar
+COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} app.jar
 
 # Run the api
 CMD ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Use Linux-Alpine image
 FROM amazoncorretto:17.0.12-alpine
 
 RUN apk update && apk -U upgrade && rm -rf /var/cache/apk/*
@@ -6,16 +5,14 @@ RUN apk update && apk -U upgrade && rm -rf /var/cache/apk/*
 RUN adduser -S myLowPrivilegeUser
 USER myLowPrivilegeUser
 
-ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
-
-# Create directory and switch to it
+# Set the workdir to a location that the running application can write to
+# which is in the myLowPrivilegeUser home folder because we are running as that user instead of root.
 WORKDIR /home/myLowPrivilegeUser/app/
 
-# Add application JAR to created folder
-COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} /usr/local/bin/app.jar
+# Copy the jar file into /usr/local/bin/ because it seemingly needs to go to a location that any user can access.
+# If we put the jar file into the myLowPrivilegeUser's home directly, the container fails to run in Azure.
+COPY --chown=myLowPrivilegeUser ./app/build/libs/app-all.jar /usr/local/bin/app.jar
 
-# Run the api
 CMD ["java", "-jar", "/usr/local/bin/app.jar"]
 
-# Use port 8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ USER myLowPrivilegeUser
 ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
 
 # Create directory and switch to it
-WORKDIR /home/myLowPrivilegeUser/app
+#WORKDIR /home/myLowPrivilegeUser/app
+WORKDIR /usr/local/bin/
 
 # Add application JAR to created folder
 COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER myLowPrivilegeUser
 ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
 
 # Create directory and switch to it
-WORKDIR /home/myLowPrivilegeUser/app/
+WORKDIR /home/myLowPrivilegeUser/app
 
 # Add application JAR to created folder
 COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,13 @@ USER myLowPrivilegeUser
 ARG JAR_LIB_FILE=./app/build/libs/app-all.jar
 
 # Create directory and switch to it
-#WORKDIR /home/myLowPrivilegeUser/app
-WORKDIR /usr/local/bin/
+WORKDIR /home/myLowPrivilegeUser/app/
 
 # Add application JAR to created folder
-COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} app.jar
+COPY --chown=myLowPrivilegeUser ${JAR_LIB_FILE} /usr/local/bin/app.jar
 
 # Run the api
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-jar", "/usr/local/bin/app.jar"]
 
 # Use port 8080
 EXPOSE 8080


### PR DESCRIPTION
# Description

Updated our `Dockerfile` to use a lower privilege user for running the application.

Java cannot find the jar file if it resides in the lower-permission user's home directory in the Docker container while running on our Azure Web App.  Java sees the jar file just fine when running the Docker container locally.  This is what bit us in the previous PR #1261.

So, now we keep the work directory in the home folder, but we put the jar file in a location where any user can access (`/usr/local/bin/`).  This mimics the RS SFTP Ingestion service's `Dockerfile`.

This was tested in the Internal environment successfully.

## Issue

#1211.