### PR TITLE
Setting up keyvault settings and adding permissions to app

### DIFF
--- a/operations/environments/dev/main.tf
+++ b/operations/environments/dev/main.tf
@@ -19,7 +19,8 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false
+      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_keys_on_destroy    = false
     }
   }
 }

--- a/operations/environments/dev/main.tf
+++ b/operations/environments/dev/main.tf
@@ -19,7 +19,7 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_secrets_on_destroy = false
       purge_soft_deleted_keys_on_destroy    = false
     }
   }

--- a/operations/environments/internal/main.tf
+++ b/operations/environments/internal/main.tf
@@ -19,7 +19,8 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false
+      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_keys_on_destroy    = false
     }
   }
 }

--- a/operations/environments/internal/main.tf
+++ b/operations/environments/internal/main.tf
@@ -19,7 +19,7 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_secrets_on_destroy = false
       purge_soft_deleted_keys_on_destroy    = false
     }
   }

--- a/operations/environments/pr/main.tf
+++ b/operations/environments/pr/main.tf
@@ -18,7 +18,8 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false
+      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_keys_on_destroy    = false
     }
   }
 }

--- a/operations/environments/pr/main.tf
+++ b/operations/environments/pr/main.tf
@@ -18,7 +18,7 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_secrets_on_destroy = false
       purge_soft_deleted_keys_on_destroy    = false
     }
   }

--- a/operations/environments/prd/main.tf
+++ b/operations/environments/prd/main.tf
@@ -19,7 +19,8 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false
+      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_keys_on_destroy    = false
     }
   }
 }

--- a/operations/environments/prd/main.tf
+++ b/operations/environments/prd/main.tf
@@ -19,7 +19,7 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_secrets_on_destroy = false
       purge_soft_deleted_keys_on_destroy    = false
     }
   }

--- a/operations/environments/stg/main.tf
+++ b/operations/environments/stg/main.tf
@@ -19,7 +19,8 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false
+      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_keys_on_destroy    = false
     }
   }
 }

--- a/operations/environments/stg/main.tf
+++ b/operations/environments/stg/main.tf
@@ -19,7 +19,7 @@ terraform {
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_deleted_secrets_on_destroy = false,
+      purge_soft_deleted_secrets_on_destroy = false
       purge_soft_deleted_keys_on_destroy    = false
     }
   }

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -43,13 +43,6 @@ resource "azurerm_user_assigned_identity" "key_vault_identity" {
   name = "key-vault-identity-${var.environment}"
 }
 
-resource "azurerm_user_assigned_identity" "docs_identity" {
-  resource_group_name = data.azurerm_resource_group.group.name
-  location            = data.azurerm_resource_group.group.location
-
-  name = "docs-identity-${var.environment}"
-}
-
 resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {
   principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
   role_definition_name = "AcrPull"

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -36,7 +36,7 @@ resource "azurerm_service_plan" "plan" {
   resource_group_name    = data.azurerm_resource_group.group.name
   location               = data.azurerm_resource_group.group.location
   os_type                = "Linux"
-  sku_name               = local.higher_environment_level ? "P1v3" : "P1v3"
+  sku_name               = local.higher_environment_level ? "P1v3" : "P0v3"
   zone_balancing_enabled = local.higher_environment_level
 
   #   below tags are managed by CDC

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -13,7 +13,6 @@ resource "azurerm_container_registry" "registry" {
   }
 
   encryption {
-    enabled            = true
     key_vault_key_id   = azurerm_key_vault_key.customer_managed_key.id
     identity_client_id = azurerm_user_assigned_identity.key_vault_identity.client_id
   }

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -36,7 +36,7 @@ resource "azurerm_service_plan" "plan" {
   resource_group_name    = data.azurerm_resource_group.group.name
   location               = data.azurerm_resource_group.group.location
   os_type                = "Linux"
-  sku_name               = local.higher_environment_level ? "P1v3" : "P0v3"
+  sku_name               = local.higher_environment_level ? "P1v3" : "P1v3"
   zone_balancing_enabled = local.higher_environment_level
 
   #   below tags are managed by CDC

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -43,6 +43,13 @@ resource "azurerm_user_assigned_identity" "key_vault_identity" {
   name = "key-vault-identity-${var.environment}"
 }
 
+resource "azurerm_user_assigned_identity" "docs_identity" {
+  resource_group_name = data.azurerm_resource_group.group.name
+  location            = data.azurerm_resource_group.group.location
+
+  name = "docs-identity-${var.environment}"
+}
+
 resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {
   principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
   role_definition_name = "AcrPull"

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -44,4 +44,5 @@ resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account"
   storage_account_id           = azurerm_storage_account.docs.id
   storage_account_key          = azurerm_key_vault_key.customer_managed_key.name
   regenerate_key_automatically = false
+  regeneration_period          = "P360D"
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -33,10 +33,7 @@ resource "azurerm_storage_account" "docs" {
   }
 
   identity {
-    type = "UserAssigned"
-    identity_ids = [
-      azurerm_user_assigned_identity.docs_identity.id
-    ]
+    type = "SystemAssigned"
   }
 }
 

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -13,11 +13,6 @@ resource "azurerm_storage_account" "docs" {
     index_document = "index.html"
   }
 
-  #   customer_managed_key {
-  #     key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
-  #     user_assigned_identity_id = "SystemAssigned"
-  #   }
-
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
@@ -52,17 +47,3 @@ resource "azurerm_storage_account_customer_managed_key" "storage_account_custome
     azurerm_key_vault_access_policy.allow_storage_account_wrapping
   ] //wait for the permission that allows our deployer to write the secret
 }
-
-# resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account" {
-#   name                         = "key-vault-storage-account-${var.environment}"
-#   key_vault_id                 = azurerm_key_vault.key_storage.id
-#   storage_account_id           = azurerm_storage_account.docs.id
-#   storage_account_key          = "key1" # pragma: allowlist secret
-# #   regenerate_key_automatically = false
-# #   regeneration_period          = "P360D"
-#
-#   depends_on = [
-#     azurerm_key_vault_access_policy.allow_github_deployer,
-#     azurerm_key_vault_access_policy.allow_storage_account_wrapping
-#   ] //wait for the permission that allows our deployer to write the secret
-# }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -43,6 +43,6 @@ resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account"
   key_vault_id                 = azurerm_key_vault.key_storage.id
   storage_account_id           = azurerm_storage_account.docs.id
   storage_account_key          = "key1" # pragma: allowlist secret
-  regenerate_key_automatically = false
-  regeneration_period          = "P360D"
+#   regenerate_key_automatically = false
+#   regeneration_period          = "P360D"
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -42,7 +42,7 @@ resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account"
   name                         = "key-vault-storage-account-${var.environment}"
   key_vault_id                 = azurerm_key_vault.key_storage.id
   storage_account_id           = azurerm_storage_account.docs.id
-  storage_account_key          = azurerm_key_vault_key.customer_managed_key.name
+  storage_account_key          = "key1" # pragma: allowlist secret
   regenerate_key_automatically = false
   regeneration_period          = "P360D"
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -34,21 +34,10 @@ resource "azurerm_storage_account" "docs" {
 
   identity {
     type = "SystemAssigned"
-#     type = "UserAssigned"
-#     identity_ids = [
-#       azurerm_user_assigned_identity.docs_identity.id
-#     ]
   }
 }
 
-# resource "azurerm_user_assigned_identity" "docs_identity" {
-#   resource_group_name = data.azurerm_resource_group.group.name
-#   location            = data.azurerm_resource_group.group.location
-#
-#   name = "docs-identity-${var.environment}"
-# }
-
-resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {
+resource "azurerm_storage_account_customer_managed_key" "docs_storage_account_customer_key" {
   storage_account_id = azurerm_storage_account.docs.id
   key_vault_id       = azurerm_key_vault.key_storage.id
   key_name           = azurerm_key_vault_key.customer_managed_key.name

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -13,6 +13,11 @@ resource "azurerm_storage_account" "docs" {
     index_document = "index.html"
   }
 
+  customer_managed_key {
+    key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
+    user_assigned_identity_id = "SystemAssigned"
+  }
+
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
@@ -28,7 +33,7 @@ resource "azurerm_storage_account" "docs" {
       tags["system"],
       tags["technical_steward"],
       tags["zone"],
-      customer_managed_key,
+#       customer_managed_key,
     ]
   }
 
@@ -38,16 +43,16 @@ resource "azurerm_storage_account" "docs" {
 }
 
 
-resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account" {
-  name                         = "key-vault-storage-account-${var.environment}"
-  key_vault_id                 = azurerm_key_vault.key_storage.id
-  storage_account_id           = azurerm_storage_account.docs.id
-  storage_account_key          = "key1" # pragma: allowlist secret
-#   regenerate_key_automatically = false
-#   regeneration_period          = "P360D"
-
-  depends_on = [
-    azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_storage_account_wrapping
-  ] //wait for the permission that allows our deployer to write the secret
-}
+# resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account" {
+#   name                         = "key-vault-storage-account-${var.environment}"
+#   key_vault_id                 = azurerm_key_vault.key_storage.id
+#   storage_account_id           = azurerm_storage_account.docs.id
+#   storage_account_key          = "key1" # pragma: allowlist secret
+# #   regenerate_key_automatically = false
+# #   regeneration_period          = "P360D"
+#
+#   depends_on = [
+#     azurerm_key_vault_access_policy.allow_github_deployer,
+#     azurerm_key_vault_access_policy.allow_storage_account_wrapping
+#   ] //wait for the permission that allows our deployer to write the secret
+# }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -13,10 +13,10 @@ resource "azurerm_storage_account" "docs" {
     index_document = "index.html"
   }
 
-#   customer_managed_key {
-#     key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
-#     user_assigned_identity_id = "SystemAssigned"
-#   }
+  #   customer_managed_key {
+  #     key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
+  #     user_assigned_identity_id = "SystemAssigned"
+  #   }
 
   #   below tags are managed by CDC
   lifecycle {
@@ -44,8 +44,8 @@ resource "azurerm_storage_account" "docs" {
 
 resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {
   storage_account_id = azurerm_storage_account.docs.id
-  key_vault_id = azurerm_key_vault.key_storage.id
-  key_name = azurerm_key_vault_key.customer_managed_key.name
+  key_vault_id       = azurerm_key_vault.key_storage.id
+  key_name           = azurerm_key_vault_key.customer_managed_key.name
 
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -40,10 +40,6 @@ resource "azurerm_storage_account" "docs" {
   identity {
     type = "SystemAssigned"
   }
-
-  depends_on = [
-    azurerm_key_vault_access_policy.allow_github_deployer,
-  ] //wait for the permission that allows our deployer to write the secret
 }
 
 resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -13,10 +13,10 @@ resource "azurerm_storage_account" "docs" {
     index_document = "index.html"
   }
 
-  customer_managed_key {
-    key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
-    user_assigned_identity_id = "SystemAssigned"
-  }
+#   customer_managed_key {
+#     key_vault_key_id = azurerm_key_vault_key.customer_managed_key.id
+#     user_assigned_identity_id = "SystemAssigned"
+#   }
 
   #   below tags are managed by CDC
   lifecycle {
@@ -33,7 +33,7 @@ resource "azurerm_storage_account" "docs" {
       tags["system"],
       tags["technical_steward"],
       tags["zone"],
-#       customer_managed_key,
+      customer_managed_key,
     ]
   }
 
@@ -42,6 +42,16 @@ resource "azurerm_storage_account" "docs" {
   }
 }
 
+resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {
+  storage_account_id = azurerm_storage_account.docs.id
+  key_vault_id = azurerm_key_vault.key_storage.id
+  key_name = azurerm_key_vault_key.customer_managed_key.name
+
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_storage_account_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
+}
 
 # resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account" {
 #   name                         = "key-vault-storage-account-${var.environment}"

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -45,4 +45,9 @@ resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account"
   storage_account_key          = "key1" # pragma: allowlist secret
 #   regenerate_key_automatically = false
 #   regeneration_period          = "P360D"
+
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_storage_account_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -27,7 +27,21 @@ resource "azurerm_storage_account" "docs" {
       tags["support_group"],
       tags["system"],
       tags["technical_steward"],
-      tags["zone"]
+      tags["zone"],
+      customer_managed_key,
     ]
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
+resource "azurerm_key_vault_managed_storage_account" "key_vault_storage_account" {
+  name                         = "key-vault-storage-account-${var.environment}"
+  key_vault_id                 = azurerm_key_vault.key_storage.id
+  storage_account_id           = azurerm_storage_account.docs.id
+  storage_account_key          = azurerm_key_vault_key.customer_managed_key.name
+  regenerate_key_automatically = false
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -33,12 +33,20 @@ resource "azurerm_storage_account" "docs" {
   }
 
   identity {
-    type = "UserAssigned"
-    identity_ids = [
-      azurerm_user_assigned_identity.docs_identity.id
-    ]
+    type = "SystemAssigned"
+#     type = "UserAssigned"
+#     identity_ids = [
+#       azurerm_user_assigned_identity.docs_identity.id
+#     ]
   }
 }
+
+# resource "azurerm_user_assigned_identity" "docs_identity" {
+#   resource_group_name = data.azurerm_resource_group.group.name
+#   location            = data.azurerm_resource_group.group.location
+#
+#   name = "docs-identity-${var.environment}"
+# }
 
 resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {
   storage_account_id = azurerm_storage_account.docs.id

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -43,7 +43,6 @@ resource "azurerm_storage_account" "docs" {
 
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_storage_account_wrapping
   ] //wait for the permission that allows our deployer to write the secret
 }
 

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -40,6 +40,11 @@ resource "azurerm_storage_account" "docs" {
   identity {
     type = "SystemAssigned"
   }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_storage_account_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
 }
 
 resource "azurerm_storage_account_customer_managed_key" "storage_account_customer_key" {

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -44,6 +44,6 @@ resource "azurerm_storage_account_customer_managed_key" "docs_storage_account_cu
 
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_storage_account_wrapping
+    azurerm_key_vault_access_policy.allow_docs_storage_account_wrapping
   ] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -33,7 +33,10 @@ resource "azurerm_storage_account" "docs" {
   }
 
   identity {
-    type = "SystemAssigned"
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.docs_identity.id
+    ]
   }
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -43,7 +43,6 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
   key_permissions = [
     "Get",
     "Create",
-    "Set",
     "Delete",
     "Purge",
   ]

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -64,7 +64,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
+resource "azurerm_key_vault_access_policy" "allow_docs_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.docs.identity.0.principal_id
@@ -76,7 +76,7 @@ resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   ]
 }
 
-resource "azurerm_key_vault_access_policy" "allow_storage_account_real_wrapping" {
+resource "azurerm_key_vault_access_policy" "allow_storage_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.storage.identity.0.principal_id

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -63,17 +63,25 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-# resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
-#   key_vault_id = azurerm_key_vault.key_storage.id
-#   tenant_id    = data.azurerm_client_config.current.tenant_id
-#   object_id    = azurerm_storage_account.docs.identity.0.principal_id
-#
-#   key_permissions = [
-#     "Get",
-#     "WrapKey",
-#     "UnwrapKey",
-#   ]
-# }
+resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
+  key_vault_id = azurerm_key_vault.key_storage.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.docs.identity.0.principal_id
+
+  key_permissions = [
+    "Get",
+    "WrapKey",
+    "UnwrapKey",
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "GetRotationPolicy",
+    "SetRotationPolicy"
+  ]
+}
 
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -100,7 +100,6 @@ resource "azurerm_key_vault_secret" "trusted_intermediary_public_key" {
   depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
 }
 
-
 resource "azurerm_key_vault_secret" "trusted_intermediary_public_key_internal" {
   name  = "trusted-intermediary-public-key-${var.environment}"
   value = "dogcow"
@@ -142,7 +141,5 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
     "wrapKey"
   ]
 
-  depends_on = [
-    azurerm_key_vault_access_policy.allow_github_deployer,
-  ] //wait for the permission that allows our deployer to write the secret
+  depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -160,8 +160,7 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
     "sign",
     "unwrapKey",
     "verify",
-    "wrapKey",
-    "getrotationpolicy"
+    "wrapKey"
   ]
 
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -74,6 +74,8 @@ resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
     "UnwrapKey",
     "WrapKey",
   ]
+
+  depends_on = [azurerm_storage_account.docs]
 }
 
 resource "azurerm_key_vault_secret" "report_stream_public_key" {

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -38,6 +38,7 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
     "Get",
     "Delete",
     "Purge",
+    "Recover",
   ]
 
   key_permissions = [
@@ -48,7 +49,7 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
     "Recover",
     "Update",
     "GetRotationPolicy",
-    "SetRotationPolicy"
+    "SetRotationPolicy",
   ]
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -84,14 +84,18 @@ resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
 
   key_permissions = [
     "Get",
-    "WrapKey",
-    "UnwrapKey",
     "Create",
     "Delete",
-    "Get",
-    "Purge",
+    "List",
+    "Restore",
     "Recover",
-    "Update",
+    "UnwrapKey",
+    "WrapKey",
+    "Purge",
+    "Encrypt",
+    "Decrypt",
+    "Sign",
+    "Verify",
     "GetRotationPolicy",
     "SetRotationPolicy"
   ]

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -67,7 +67,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_user_assigned_identity.docs_identity.principal_id
+  object_id    = azurerm_storage_account.docs.identity.0.principal_id
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -39,6 +39,14 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
     "Delete",
     "Purge",
   ]
+
+  key_permissions = [
+    "Get",
+    "Create",
+    "Set",
+    "Delete",
+    "Purge",
+  ]
 }
 
 resource "azurerm_key_vault_access_policy" "allow_api_read" {
@@ -50,13 +58,19 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
     "List",
     "Get",
   ]
-
-  key_permissions = [
-    "WrapKey",
-    "UnwrapKey",
-    "Get"
-  ]
 }
+
+# resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
+#   key_vault_id = azurerm_key_vault.key_storage.id
+#   tenant_id    = data.azurerm_client_config.current.tenant_id
+#   object_id    = azurerm_storage_account.docs.identity.0.principal_id
+#
+#   key_permissions = [
+#     "Get",
+#     "WrapKey",
+#     "UnwrapKey",
+#   ]
+# }
 
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"
@@ -82,6 +96,7 @@ resource "azurerm_key_vault_secret" "trusted_intermediary_public_key" {
   depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
 }
 
+
 resource "azurerm_key_vault_secret" "trusted_intermediary_public_key_internal" {
   name  = "trusted-intermediary-public-key-${var.environment}"
   value = "dogcow"
@@ -103,5 +118,25 @@ resource "azurerm_key_vault_secret" "trusted_intermediary_private_key" {
   lifecycle {
     ignore_changes = [value]
   }
+  depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
+}
+
+
+resource "azurerm_key_vault_key" "customer_managed_key" {
+  name         = "customer-managed-key-${var.environment}"
+  key_vault_id = azurerm_key_vault.key_storage.id
+
+  key_type = "RSA"
+  key_size = 4096
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
   depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -63,7 +63,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
+data "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.docs.identity.0.principal_id

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -62,19 +62,6 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
     "Get",
   ]
 
-  key_permissions = [
-    "Get",
-    "WrapKey",
-    "UnwrapKey",
-    "Create",
-    "Delete",
-    "Get",
-    "Purge",
-    "Recover",
-    "Update",
-    "GetRotationPolicy",
-    "SetRotationPolicy"
-  ]
 }
 
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
@@ -84,20 +71,8 @@ resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
 
   key_permissions = [
     "Get",
-    "Create",
-    "Delete",
-    "List",
-    "Restore",
-    "Recover",
     "UnwrapKey",
     "WrapKey",
-    "Purge",
-    "Encrypt",
-    "Decrypt",
-    "Sign",
-    "Verify",
-    "GetRotationPolicy",
-    "SetRotationPolicy"
   ]
 }
 
@@ -169,6 +144,5 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
 
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_storage_account_wrapping
   ] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -64,22 +64,10 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-resource "terraform_data" "wait_for_identity" {
-  provisioner "local-exec" {
-    command = "echo 'Storage Account Identity Created'"
-  }
-
-  triggers_replace = [
-    azurerm_storage_account.docs.identity.0.principal_id
-  ]
-
-  input = azurerm_storage_account.docs.identity.0.principal_id
-}
-
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = terraform_data.wait_for_identity.output
+  object_id    = azurerm_user_assigned_identity.docs_identity.principal_id
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -61,7 +61,6 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
     "List",
     "Get",
   ]
-
 }
 
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -80,7 +80,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
+  object_id    = azurerm_storage_account.docs.identity.0.principal_id
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -67,7 +67,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_storage_account.docs.identity.0.principal_id
+  object_id    = azurerm_storage_account.docs.identity[0].principal_id
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -76,6 +76,18 @@ resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   ]
 }
 
+resource "azurerm_key_vault_access_policy" "allow_storage_account_real_wrapping" {
+  key_vault_id = azurerm_key_vault.key_storage.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.storage.identity.0.principal_id
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+  ]
+}
+
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"
   value = "dogcow"

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -64,20 +64,22 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-resource "null_resource" "wait_for_identity" {
+resource "terraform_data" "wait_for_identity" {
   provisioner "local-exec" {
     command = "echo 'Storage Account Identity Created'"
   }
 
-  triggers = {
-    identity_id = azurerm_storage_account.docs.identity.0.principal_id
-  }
+  triggers_replace = [
+    azurerm_storage_account.docs.identity.0.principal_id
+  ]
+
+  input = azurerm_storage_account.docs.identity.0.principal_id
 }
 
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = null_resource.wait_for_identity.triggers.identity_id
+  object_id    = terraform_data.wait_for_identity.output
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -167,8 +167,6 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
     "wrapKey"
   ]
 
-
-
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,
     azurerm_key_vault_access_policy.allow_storage_account_wrapping

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -61,6 +61,20 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
     "List",
     "Get",
   ]
+
+  key_permissions = [
+    "Get",
+    "WrapKey",
+    "UnwrapKey",
+    "Create",
+    "Delete",
+    "Get",
+    "Purge",
+    "Recover",
+    "Update",
+    "GetRotationPolicy",
+    "SetRotationPolicy"
+  ]
 }
 
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
@@ -147,7 +161,10 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
     "unwrapKey",
     "verify",
     "wrapKey",
+    "getrotationpolicy"
   ]
+
+
 
   depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -41,10 +41,14 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
   ]
 
   key_permissions = [
-    "Get",
     "Create",
     "Delete",
+    "Get",
     "Purge",
+    "Recover",
+    "Update",
+    "GetRotationPolicy",
+    "SetRotationPolicy"
   ]
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -63,7 +63,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   ]
 }
 
-data "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
+resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.docs.identity.0.principal_id

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -7,7 +7,7 @@ resource "azurerm_key_vault" "key_storage" {
   sku_name  = "standard"
   tenant_id = data.azurerm_client_config.current.tenant_id
 
-  purge_protection_enabled = false
+  purge_protection_enabled = true
 
   #   below tags are managed by CDC
   lifecycle {
@@ -49,6 +49,12 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
   secret_permissions = [
     "List",
     "Get",
+  ]
+
+  key_permissions = [
+    "WrapKey",
+    "UnwrapKey",
+    "Get"
   ]
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -80,7 +80,7 @@ resource "azurerm_key_vault_access_policy" "allow_api_read" {
 resource "azurerm_key_vault_access_policy" "allow_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_storage_account.docs.identity.0.principal_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "Get",
@@ -165,5 +165,8 @@ resource "azurerm_key_vault_key" "customer_managed_key" {
 
 
 
-  depends_on = [azurerm_key_vault_access_policy.allow_github_deployer] //wait for the permission that allows our deployer to write the secret
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_storage_account_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -39,7 +39,7 @@ resource "azurerm_storage_account_customer_managed_key" "storage_storage_account
 
   depends_on = [
     azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_storage_account_real_wrapping
+    azurerm_key_vault_access_policy.allow_storage_storage_account_wrapping
   ] //wait for the permission that allows our deployer to write the secret
 }
 

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -26,6 +26,21 @@ resource "azurerm_storage_account" "storage" {
       tags["zone"]
     ]
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account_customer_managed_key" "storage_real_account_customer_key" {
+  storage_account_id = azurerm_storage_account.storage.id
+  key_vault_id       = azurerm_key_vault.key_storage.id
+  key_name           = azurerm_key_vault_key.customer_managed_key.name
+
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_storage_account_real_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
 }
 
 resource "azurerm_storage_container" "metadata" {

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -32,7 +32,7 @@ resource "azurerm_storage_account" "storage" {
   }
 }
 
-resource "azurerm_storage_account_customer_managed_key" "storage_real_account_customer_key" {
+resource "azurerm_storage_account_customer_managed_key" "storage_storage_account_customer_key" {
   storage_account_id = azurerm_storage_account.storage.id
   key_vault_id       = azurerm_key_vault.key_storage.id
   key_name           = azurerm_key_vault_key.customer_managed_key.name


### PR DESCRIPTION
# Description

We are changing settings for our azure storage accounts so that they utilize Azure Customer managed keys.  


Run something like `az storage account update --identity-type SystemAssigned --name cdctipr1276 --resource-group csels-rsti-pr1276-moderate-rg` in all the environments shortly before merging.

## Issue

Add a link to the issue here.  Consider using
[Fortify card](https://github.com/CDCgov/trusted-intermediary/issues/1214)


