### PR TITLE
Create Azure storage account and container to store HL7 files for automated testing

### DIFF
--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -88,17 +88,17 @@ resource "azurerm_key_vault_access_policy" "allow_storage_storage_account_wrappi
   ]
 }
 
-resource "azurerm_key_vault_access_policy" "allow_automated_storage_storage_account_wrapping" {
-  key_vault_id = azurerm_key_vault.key_storage.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_storage_account.automated_storage.identity.0.principal_id
+# resource "azurerm_key_vault_access_policy" "allow_automated_storage_storage_account_wrapping" {
+#   key_vault_id = azurerm_key_vault.key_storage.id
+#   tenant_id    = data.azurerm_client_config.current.tenant_id
+#   object_id    = azurerm_storage_account.automated_storage.identity.0.principal_id
 
-  key_permissions = [
-    "Get",
-    "UnwrapKey",
-    "WrapKey",
-  ]
-}
+#   key_permissions = [
+#     "Get",
+#     "UnwrapKey",
+#     "WrapKey",
+#   ]
+# }
 
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -88,6 +88,18 @@ resource "azurerm_key_vault_access_policy" "allow_storage_storage_account_wrappi
   ]
 }
 
+resource "azurerm_key_vault_access_policy" "allow_automated_storage_storage_account_wrapping" {
+  key_vault_id = azurerm_key_vault.key_storage.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.automated_storage.identity.0.principal_id
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+  ]
+}
+
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"
   value = "dogcow"

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -88,17 +88,17 @@ resource "azurerm_key_vault_access_policy" "allow_storage_storage_account_wrappi
   ]
 }
 
-# resource "azurerm_key_vault_access_policy" "allow_automated_storage_storage_account_wrapping" {
-#   key_vault_id = azurerm_key_vault.key_storage.id
-#   tenant_id    = data.azurerm_client_config.current.tenant_id
-#   object_id    = azurerm_storage_account.automated_storage.identity.0.principal_id
+resource "azurerm_key_vault_access_policy" "allow_automated_storage_storage_account_wrapping" {
+  key_vault_id = azurerm_key_vault.key_storage.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.automated_storage.identity.0.principal_id
 
-#   key_permissions = [
-#     "Get",
-#     "UnwrapKey",
-#     "WrapKey",
-#   ]
-# }
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+  ]
+}
 
 resource "azurerm_key_vault_secret" "report_stream_public_key" {
   name  = "organization-report-stream-public-key-${var.environment}"

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -92,16 +92,16 @@ resource "azurerm_storage_account" "automated_storage" {
   }
 }
 
-resource "azurerm_storage_account_customer_managed_key" "automated_storage_storage_account_customer_key" {
-  storage_account_id = azurerm_storage_account.automated_storage.id
-  key_vault_id       = azurerm_key_vault.key_storage.id
-  key_name           = azurerm_key_vault_key.customer_managed_key.name
+# resource "azurerm_storage_account_customer_managed_key" "automated_storage_storage_account_customer_key" {
+#   storage_account_id = azurerm_storage_account.automated_storage.id
+#   key_vault_id       = azurerm_key_vault.key_storage.id
+#   key_name           = azurerm_key_vault_key.customer_managed_key.name
 
-  depends_on = [
-    azurerm_key_vault_access_policy.allow_github_deployer,
-    azurerm_key_vault_access_policy.allow_automated_storage_storage_account_wrapping
-  ] //wait for the permission that allows our deployer to write the secret
-}
+#   depends_on = [
+#     azurerm_key_vault_access_policy.allow_github_deployer,
+#     azurerm_key_vault_access_policy.allow_automated_storage_storage_account_wrapping
+#   ] //wait for the permission that allows our deployer to write the secret
+# }
 
 resource "azurerm_storage_container" "automated_container" {
   name                  = "automated"

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -39,3 +39,40 @@ resource "azurerm_role_assignment" "allow_api_read_write" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
 }
+
+resource "azurerm_storage_account" "sftp_storage" {
+  name                              = "cdctisftp${var.environment}"
+  resource_group_name               = data.azurerm_resource_group.group.name
+  location                          = data.azurerm_resource_group.group.location
+  account_tier                      = "Standard"
+  account_replication_type          = "GRS"
+  account_kind                      = "StorageV2"
+  allow_nested_items_to_be_public   = false
+  sftp_enabled                      = true
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+
+  #   below tags are managed by CDC
+  lifecycle {
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
+}
+
+resource "azurerm_storage_container" "sftp_container" {
+  name                  = "samples"
+  storage_account_name  = azurerm_storage_account.sftp_storage.name
+  container_access_type = "private"
+}

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -70,14 +70,14 @@ resource "azurerm_storage_account" "automated_storage" {
   }
 }
 
-resource "azurerm_storage_container" "initial_container" {
-  name                  = "initial"
+resource "azurerm_storage_container" "automated_container" {
+  name                  = "automated"
   storage_account_name  = azurerm_storage_account.automated_storage.name
   container_access_type = "private"
 }
 
-resource "azurerm_storage_container" "final_container" {
-  name                  = "final"
-  storage_account_name  = azurerm_storage_account.automated_storage.name
-  container_access_type = "private"
+resource "azurerm_role_assignment" "allow_automated_test_read_write" {
+  scope                = azurerm_storage_container.automated_container.resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = <PRINCIPAL_ID>
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -40,15 +40,14 @@ resource "azurerm_role_assignment" "allow_api_read_write" {
   principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
 }
 
-resource "azurerm_storage_account" "sftp_storage" {
-  name                              = "cdctisftp${var.environment}"
+resource "azurerm_storage_account" "automated_storage" {
+  name                              = "cdctiautomated${var.environment}"
   resource_group_name               = data.azurerm_resource_group.group.name
   location                          = data.azurerm_resource_group.group.location
   account_tier                      = "Standard"
   account_replication_type          = "GRS"
   account_kind                      = "StorageV2"
   allow_nested_items_to_be_public   = false
-  sftp_enabled                      = true
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
 
@@ -71,8 +70,14 @@ resource "azurerm_storage_account" "sftp_storage" {
   }
 }
 
-resource "azurerm_storage_container" "sftp_container" {
-  name                  = "samples"
-  storage_account_name  = azurerm_storage_account.sftp_storage.name
+resource "azurerm_storage_container" "initial_container" {
+  name                  = "initial"
+  storage_account_name  = azurerm_storage_account.automated_storage.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "final_container" {
+  name                  = "final"
+  storage_account_name  = azurerm_storage_account.automated_storage.name
   container_access_type = "private"
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -79,5 +79,5 @@ resource "azurerm_storage_container" "automated_container" {
 resource "azurerm_role_assignment" "allow_automated_test_read_write" {
   scope                = azurerm_storage_container.automated_container.resource_manager_id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = <PRINCIPAL_ID>
+  principal_id         = var.deployer_id
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -92,16 +92,16 @@ resource "azurerm_storage_account" "automated_storage" {
   }
 }
 
-# resource "azurerm_storage_account_customer_managed_key" "automated_storage_storage_account_customer_key" {
-#   storage_account_id = azurerm_storage_account.automated_storage.id
-#   key_vault_id       = azurerm_key_vault.key_storage.id
-#   key_name           = azurerm_key_vault_key.customer_managed_key.name
+resource "azurerm_storage_account_customer_managed_key" "automated_storage_storage_account_customer_key" {
+  storage_account_id = azurerm_storage_account.automated_storage.id
+  key_vault_id       = azurerm_key_vault.key_storage.id
+  key_name           = azurerm_key_vault_key.customer_managed_key.name
 
-#   depends_on = [
-#     azurerm_key_vault_access_policy.allow_github_deployer,
-#     azurerm_key_vault_access_policy.allow_automated_storage_storage_account_wrapping
-#   ] //wait for the permission that allows our deployer to write the secret
-# }
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_automated_storage_storage_account_wrapping
+  ]
+}
 
 resource "azurerm_storage_container" "automated_container" {
   name                  = "automated"

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -70,6 +70,8 @@ resource "azurerm_storage_account" "automated_storage" {
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
+      customer_managed_key,
+      # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
       tags["environment"],
@@ -84,6 +86,21 @@ resource "azurerm_storage_account" "automated_storage" {
       tags["zone"]
     ]
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account_customer_managed_key" "automated_storage_storage_account_customer_key" {
+  storage_account_id = azurerm_storage_account.automated_storage.id
+  key_vault_id       = azurerm_key_vault.key_storage.id
+  key_name           = azurerm_key_vault_key.customer_managed_key.name
+
+  depends_on = [
+    azurerm_key_vault_access_policy.allow_github_deployer,
+    azurerm_key_vault_access_policy.allow_automated_storage_storage_account_wrapping
+  ] //wait for the permission that allows our deployer to write the secret
 }
 
 resource "azurerm_storage_container" "automated_container" {


### PR DESCRIPTION
# Create Azure storage account and container to store HL7 files for automated testing

This PR creates an Azure storage account to use for the RS automated integration tests. It creates one container where we'll store the final HL7 files uploaded by RS at the end of the message flow

## Issue

#1255 