### PR TITLE
Ignore `customer_managed_key` for the `storage` Storage Account

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -41,6 +41,24 @@ resource "azurerm_user_assigned_identity" "key_vault_identity" {
   location            = data.azurerm_resource_group.group.location
 
   name = "key-vault-identity-${var.environment}"
+
+  lifecycle {
+    ignore_changes = [
+      # below tags are managed by CDC
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
 }
 
 resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {

--- a/operations/template/docs.tf
+++ b/operations/template/docs.tf
@@ -13,9 +13,10 @@ resource "azurerm_storage_account" "docs" {
     index_document = "index.html"
   }
 
-  #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
+      customer_managed_key,
+      # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
       tags["environment"],
@@ -28,7 +29,6 @@ resource "azurerm_storage_account" "docs" {
       tags["system"],
       tags["technical_steward"],
       tags["zone"],
-      customer_managed_key,
     ]
   }
 

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -9,7 +9,6 @@ resource "azurerm_storage_account" "storage" {
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
 
-
   lifecycle {
     ignore_changes = [
       customer_managed_key,

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -9,9 +9,11 @@ resource "azurerm_storage_account" "storage" {
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
 
-  #   below tags are managed by CDC
+
   lifecycle {
     ignore_changes = [
+      customer_managed_key,
+      # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
       tags["environment"],


### PR DESCRIPTION
# Description

We forgot to ignore changes for `customer_managed_key` in the `storage` storage account in our last [PR](https://github.com/CDCgov/trusted-intermediary/pull/1276).  We're now adding it.  We do this because this setting conflicts with the separate `azurerm_storage_account_customer_managed_key` resource.  You can read the [documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#customer_managed_key) on this too.

## Issue

#1214.
