### PR TITLE
Renovate azurerm 4 for real

### DIFF
--- a/operations/environments/dev/main.tf
+++ b/operations/environments/dev/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.1"
     }
   }
 

--- a/operations/environments/internal/main.tf
+++ b/operations/environments/internal/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.1"
     }
   }
 

--- a/operations/environments/pr/main.tf
+++ b/operations/environments/pr/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.1"
     }
   }
 

--- a/operations/environments/prd/main.tf
+++ b/operations/environments/prd/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.1"
     }
   }
 

--- a/operations/environments/stg/main.tf
+++ b/operations/environments/stg/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.1"
     }
   }
 

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -35,7 +35,7 @@
     ]
   }
 
-    depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
+  depends_on = [azurerm_user_assigned_identity.key_vault_identity]
 }
 
 resource "azurerm_user_assigned_identity" "key_vault_identity" {
@@ -61,6 +61,7 @@ resource "azurerm_user_assigned_identity" "key_vault_identity" {
       tags["zone"]
     ]
   }
+  depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
 }
 
 resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -116,6 +116,7 @@ resource "azurerm_linux_web_app" "api" {
 
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
+      docker_image_name   = ""
     }
 
     dynamic "ip_restriction" {
@@ -208,6 +209,7 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
+      docker_image_name   = ""
     }
 
     dynamic "ip_restriction" {

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -1,5 +1,5 @@
 # Create the container registry
-  resource "azurerm_container_registry" "registry" {
+resource "azurerm_container_registry" "registry" {
   name                = "cdcti${var.environment}containerregistry"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -1,5 +1,5 @@
 # Create the container registry
-resource "azurerm_container_registry" "registry" {
+  resource "azurerm_container_registry" "registry" {
   name                = "cdcti${var.environment}containerregistry"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
@@ -35,7 +35,7 @@ resource "azurerm_container_registry" "registry" {
     ]
   }
 
-  depends_on = [azurerm_user_assigned_identity.key_vault_identity]
+    depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
 }
 
 resource "azurerm_user_assigned_identity" "key_vault_identity" {
@@ -61,7 +61,6 @@ resource "azurerm_user_assigned_identity" "key_vault_identity" {
       tags["zone"]
     ]
   }
-  depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
 }
 
 resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -116,7 +116,7 @@ resource "azurerm_linux_web_app" "api" {
 
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
-      docker_image_name   = ""
+      docker_image_name   = "ignore_because_specified_later_in_deployment"
     }
 
     dynamic "ip_restriction" {
@@ -203,7 +203,7 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
-      docker_image_name   = ""
+      docker_image_name   = "ignore_because_specified_later_in_deployment"
     }
 
     dynamic "ip_restriction" {

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -167,9 +167,10 @@ resource "azurerm_linux_web_app" "api" {
     type = "SystemAssigned"
   }
 
-  #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [
+      site_config.application_stack.docker_image_name,
+      # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
       tags["environment"],
@@ -241,6 +242,12 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      site_config.application_stack.docker_image_name,
+    ]
   }
 }
 

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -114,6 +114,10 @@ resource "azurerm_linux_web_app" "api" {
 
     container_registry_use_managed_identity = true
 
+    application_stack {
+      docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
+    }
+
     dynamic "ip_restriction" {
       for_each = local.cdc_domain_environment ? [1] : []
 
@@ -140,7 +144,6 @@ resource "azurerm_linux_web_app" "api" {
   #   When adding new settings that are needed for the live app but shouldn't be used in the pre-live
   #   slot, add them to `sticky_settings` as well as `app_settings` for the main app resource
   app_settings = {
-    DOCKER_REGISTRY_SERVER_URL    = "https://${azurerm_container_registry.registry.login_server}"
     ENV                           = var.environment
     REPORT_STREAM_URL_PREFIX      = "https://${local.rs_domain_prefix}prime.cdc.gov"
     KEY_VAULT_NAME                = azurerm_key_vault.key_storage.name
@@ -203,6 +206,10 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
     scm_use_main_ip_restriction = local.cdc_domain_environment ? true : null
 
+    application_stack {
+      docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
+    }
+
     dynamic "ip_restriction" {
       for_each = local.cdc_domain_environment ? [1] : []
 
@@ -227,8 +234,6 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
   }
 
   app_settings = {
-    DOCKER_REGISTRY_SERVER_URL = "https://${azurerm_container_registry.registry.login_server}"
-
     ENV = var.environment
   }
 

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -169,7 +169,7 @@ resource "azurerm_linux_web_app" "api" {
 
   lifecycle {
     ignore_changes = [
-      site_config[0].application_stack.docker_image_name,
+      site_config[0].application_stack[0].docker_image_name,
       # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
@@ -239,7 +239,7 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
   lifecycle {
     ignore_changes = [
-      site_config[0].application_stack.docker_image_name,
+      site_config[0].application_stack[0].docker_image_name,
       # Ignore changes to tags because the CDC sets these automagically
       tags,
     ]

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -191,13 +191,6 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
   name           = "pre-live"
   app_service_id = azurerm_linux_web_app.api.id
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to tags because the CDC sets these automagically
-      tags,
-    ]
-  }
-
   https_only = true
 
   virtual_network_subnet_id = local.cdc_domain_environment ? azurerm_subnet.app.id : null
@@ -247,6 +240,8 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
   lifecycle {
     ignore_changes = [
       site_config.application_stack.docker_image_name,
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
     ]
   }
 }

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -1,5 +1,5 @@
 # Create the container registry
-resource "azurerm_container_registry" "registry" {
+  resource "azurerm_container_registry" "registry" {
   name                = "cdcti${var.environment}containerregistry"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
@@ -13,6 +13,7 @@ resource "azurerm_container_registry" "registry" {
   }
 
   encryption {
+    enabled            = true
     key_vault_key_id   = azurerm_key_vault_key.customer_managed_key.id
     identity_client_id = azurerm_user_assigned_identity.key_vault_identity.client_id
   }

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -1,5 +1,5 @@
 # Create the container registry
-  resource "azurerm_container_registry" "registry" {
+resource "azurerm_container_registry" "registry" {
   name                = "cdcti${var.environment}containerregistry"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
@@ -35,7 +35,7 @@
     ]
   }
 
-    depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
+  depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
 }
 
 resource "azurerm_user_assigned_identity" "key_vault_identity" {

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -169,7 +169,7 @@ resource "azurerm_linux_web_app" "api" {
 
   lifecycle {
     ignore_changes = [
-      site_config.application_stack.docker_image_name,
+      site_config[0].application_stack.docker_image_name,
       # below tags are managed by CDC
       tags["business_steward"],
       tags["center"],
@@ -239,7 +239,7 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
   lifecycle {
     ignore_changes = [
-      site_config.application_stack.docker_image_name,
+      site_config[0].application_stack.docker_image_name,
       # Ignore changes to tags because the CDC sets these automagically
       tags,
     ]

--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -13,7 +13,6 @@
   }
 
   encryption {
-    enabled            = true
     key_vault_key_id   = azurerm_key_vault_key.customer_managed_key.id
     identity_client_id = azurerm_user_assigned_identity.key_vault_identity.client_id
   }
@@ -35,6 +34,8 @@
       tags["zone"]
     ]
   }
+
+    depends_on = [azurerm_key_vault_access_policy.allow_container_registry_wrapping] // Wait for keyvault access policy to be in place before creating
 }
 
 resource "azurerm_user_assigned_identity" "key_vault_identity" {

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -50,6 +50,8 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
     "Update",
     "GetRotationPolicy",
     "SetRotationPolicy",
+    "UnwrapKey",
+    "WrapKey",
   ]
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -79,7 +79,7 @@ resource "azurerm_key_vault_access_policy" "allow_docs_storage_account_wrapping"
 resource "azurerm_key_vault_access_policy" "allow_container_registry_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_user_assigned_identity.key_vault_identity.id
+  object_id    = azurerm_user_assigned_identity.key_vault_identity.principal_id
 
   key_permissions = [
     "Get",

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -50,8 +50,6 @@ resource "azurerm_key_vault_access_policy" "allow_github_deployer" {
     "Update",
     "GetRotationPolicy",
     "SetRotationPolicy",
-    "UnwrapKey",
-    "WrapKey",
   ]
 }
 

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -76,6 +76,18 @@ resource "azurerm_key_vault_access_policy" "allow_docs_storage_account_wrapping"
   ]
 }
 
+resource "azurerm_key_vault_access_policy" "allow_container_registry_wrapping" {
+  key_vault_id = azurerm_key_vault.key_storage.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.key_vault_identity.id
+
+  key_permissions = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey",
+  ]
+}
+
 resource "azurerm_key_vault_access_policy" "allow_storage_storage_account_wrapping" {
   key_vault_id = azurerm_key_vault.key_storage.id
   tenant_id    = data.azurerm_client_config.current.tenant_id

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -4,7 +4,7 @@ resource "azurerm_public_ip" "vpn" {
   resource_group_name = data.azurerm_resource_group.group.name
 
   allocation_method = "Dynamic"
-
+  sku = "Basic"
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -4,7 +4,7 @@ resource "azurerm_public_ip" "vpn" {
   resource_group_name = data.azurerm_resource_group.group.name
 
   allocation_method = "Dynamic"
-  sku = "Basic"
+  sku               = "Basic"
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
# Description

Upgrading Terraform from version 3.116.0 to 4.0.1.  Including updates to any resources that may have had breaking changes across this major version update.  We are also adding a missing access policy for the container-registry so that it can use keys properly

## Issue

[Board issue](https://github.com/CDCgov/trusted-intermediary/issues/1290)

