### PR TITLE
`AcrPull` Permission for the `pre-live` Slot

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -69,6 +69,12 @@ resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {
   scope                = azurerm_container_registry.registry.id
 }
 
+resource "azurerm_role_assignment" "allow_app_slot_to_pull_from_registry" {
+  principal_id         = azurerm_linux_web_app_slot.pre_live.identity.0.principal_id
+  role_definition_name = "AcrPull"
+  scope                = azurerm_container_registry.registry.id
+}
+
 # Create the staging service plan
 resource "azurerm_service_plan" "plan" {
   name                   = "cdcti-${var.environment}-service-plan"


### PR DESCRIPTION
# Description

I've seen that some pre-live slot instances (1 of the 3) is unhealthy.  According to the platform logs, this single instance doesn't have permission to pull from the registry.  What?!  Why not all three?  So, I'm giving it permission.

## Issue

#1220.