### PR TITLE
Use a Managed Identity to Pull Images for Deployment Slots

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -203,6 +203,8 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
 
     scm_use_main_ip_restriction = local.cdc_domain_environment ? true : null
 
+    container_registry_use_managed_identity = true
+
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"
       docker_image_name   = "ignore_because_specified_later_in_deployment"


### PR DESCRIPTION
# Description

We are still seeing failures after the [previous PR](https://github.com/CDCgov/trusted-intermediary/pull/1301) was merged.  I discovered that our deployment slot isn't set to use a managed identity to pull like the main application is, so I changed it to also use the managed identity.

## Issue

#1220.