### PR TITLE
Add terraform format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,13 @@ repos:
           - java
           - groovy
         pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: terraform-format
+        name: terraform-format
+        entry: bash -c 'terraform fmt -recursive -write'
+        language: system
+        types_or:
+          - terraform
+        pass_filenames: false


### PR DESCRIPTION
## Description
This PR adds terraform format to pre-commit hooks because it's really irritating when PR checks fail just because of terraform formatting

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1291

