### PR TITLE
Updated RS Hurl Script to Replace MSH Header When Not Toggled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ localfileorder.json
 
 logback.log
 
-# Ignore folder created when substituting receiver fields in MSH Header
-substituted_receivers
+# Ignore folder created when substituting header in MSH Header
+substituted_header

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__
 localfileorder.json
 
 logback.log
+
+# Ignore folder created when substituting receiver fields in MSH Header
+substituted_receivers

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ __pycache__
 localfileorder.json
 
 logback.log
-
-# Ignore folder created when substituting header in MSH Header
-substituted_header

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -120,25 +120,20 @@ if [ -z "$secret" ]; then
 fi
 
 
-if [ "$allow_outbound" = true ]; then
-  file_name=$(basename $fpath)
-  echo "$fpath"
-  mkdir -p "$CDCTI_HOME/substituted_receivers/$fpath" && touch -f "$CDCTI_HOME/substituted_receivers/$fpath/$file_name"
-  echo "$file_name"
-  receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
-  echo "$receiverFieldsToSubstitute"
-  substitutedReceiverFields=$(sed "s/$receiverFieldsToSubstitute/!!!!!!!**********substituted|ToPreventFileOutput**********!!!!!!!/" "$CDCTI_HOME/$fpath" > "$CDCTI_HOME/substituted_receivers/$fpath/$file_name")
-  echo "$substitutedReceiverFields"
-  fpath=$CDCTI_HOME/substituted_receivers/$fpath
-
-  echo "$fpath"
-  exit 1
-fi
-
 if [ "$allow_outbound" = false ]; then
-  echo "$allow_outbound"
-  exit 1
+  file_path=$(dirname "$fpath")
+  substitutedFilePathPrefix="$CDCTI_HOME/substituted_receivers"
+#  Make temporary directory to store scrambled file
+  mkdir -p "$substitutedFilePathPrefix/$file_path" && touch -f "$substitutedFilePathPrefix/$fpath"
+#  Grab MSH Header receiver fields
+  receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
+#  Substitute receivers fields with scramble and write into temporary directory
+  sed "s/$receiverFieldsToSubstitute/!!!!!!!**********substituted|ToPreventFileOutput**********!!!!!!!/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
+#  Update fpath to allow hurl to run scrambled file
+  fpath=$substitutedFilePathPrefix/$fpath
+  echo "The MSH Header receiver fields have been scrambled to prevent sending to a real receiver. To toggle this, run with -p."
 fi
+
 hurl \
     --variable fpath=$fpath \
     --file-root $root \
@@ -148,7 +143,6 @@ hurl \
     --variable client-sender=$client_sender \
     --variable jwt=$(jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256 -k $client_id.$client_sender -i $client_id.$client_sender -s $client_id.$client_sender -a $host --no-iat -S @$secret) \
     $submission_id \
-    $allow_outbound \
     $verbose \
     $hurl_file \
     $@

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -15,6 +15,7 @@ client_sender=simulated-hospital
 verbose=""
 submission_id=""
 allow_outbound=false
+msh_header_replacement=""
 
 show_help() {
     echo "Usage: $(basename $0) <HURL_FILE> [OPTIONS]"
@@ -119,19 +120,28 @@ if [ -z "$secret" ]; then
     exit 1
 fi
 
-
 if [ "$allow_outbound" = false ]; then
+# Grab MSH Header
+  msh_header=$(head -n1 "$CDCTI_HOME/$fpath")
+# Check message type
+  if [[ "$msh_header" = *"|ORU^"* ]]; then
+    msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-hospital-id^DNS|20230101010000-0000||ORU^R01^ORU_R01|111111|T|2.5.1||||||||||"
+  elif [[ "$msh_header" = *"|ORM^"* ]]; then
+    msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||ORM^O01^ORM_O01|111111|T|2.5.1||||||||||"
+  elif [[ "$msh_header" = *"|OML^"* ]]; then
+      msh_header_replacement=""
+  else
+      echo "File is not OMU or ORM"
+      exit 1
+  fi
   file_path=$(dirname "$fpath")
-  substitutedFilePathPrefix="$CDCTI_HOME/substituted_receivers"
-#  Make temporary directory to store scrambled file
+  substitutedFilePathPrefix="$CDCTI_HOME/substituted_header"
+# Make temporary directory to store scrambled file
   mkdir -p "$substitutedFilePathPrefix/$file_path" && touch -f "$substitutedFilePathPrefix/$fpath"
-#  Grab MSH Header receiver fields
-  receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
-#  Substitute receivers fields with scramble and write into temporary directory
-  sed "s/$receiverFieldsToSubstitute/!!!!!!!**********substituted|ToPreventFileOutput**********!!!!!!!/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
-#  Update fpath to allow hurl to run scrambled file
+# Replace MSH Header and write into temporary directory
+  sed "1s/.*/$msh_header_replacement/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
   fpath=$substitutedFilePathPrefix/$fpath
-  echo "The MSH Header receiver fields have been scrambled to prevent sending to a real receiver. To toggle this, run with -p."
+  echo "The MSH Header was replaced to contain Flexion receivers. To toggle this, run with -p."
 fi
 
 hurl \

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -124,14 +124,14 @@ if [ "$allow_outbound" = false ]; then
 # Grab MSH Header
   msh_header=$(head -n1 "$CDCTI_HOME/$fpath")
 # Check message type
-  if [[ "$msh_header" = *"|ORU^"* ]]; then
+  if [[ "$msh_header" = *"^R01"* ]]; then
     msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-hospital-id^DNS|20230101010000-0000||ORU^R01^ORU_R01|111111|T|2.5.1||||||||||"
-  elif [[ "$msh_header" = *"|ORM^"* ]]; then
+  elif [[ "$msh_header" = *"^O01"* ]]; then
     msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||ORM^O01^ORM_O01|111111|T|2.5.1||||||||||"
-  elif [[ "$msh_header" = *"|OML^"* ]]; then
+  elif [[ "$msh_header" = *"^O21"* ]]; then
       msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||OML^O21^OML_O21|111111|T|2.5.1||||||||||"
   else
-      echo "File does not contain OMU, ORM, or OML"
+      echo "File does not contain any valid subfields."
       exit 1
   fi
   file_path=$(dirname "$fpath")

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -141,7 +141,7 @@ if [ "$allow_outbound" = false ]; then
 # Replace MSH Header and write into temporary directory
   sed "1s/.*/$msh_header_replacement/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
   fpath=$substitutedFilePathPrefix/$fpath
-  echo "The MSH Header was replaced to contain Flexion receivers. To toggle this, run with -p."
+  echo "The MSH Header was replaced to contain a Flexion receiver and sender. To toggle this, run with -p."
 fi
 
 hurl \

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -121,14 +121,17 @@ fi
 
 
 if [ "$allow_outbound" = true ]; then
-  file_name=$(echo "$fpath" | awk -F'/')
+  file_name=$(basename $fpath)
+  echo "$fpath"
+  mkdir -p "$CDCTI_HOME/substituted_receivers/$fpath" && touch -f "$CDCTI_HOME/substituted_receivers/$fpath/$file_name"
   echo "$file_name"
-  mkdir "$CDCTI_HOME/substituted_receivers" && touch "$CDCTI_HOME/substituted_receivers/$fpath"
-  echo "$allow_outbound"
   receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
   echo "$receiverFieldsToSubstitute"
-  substitutedReceiverFields=$(sed -n "s/$receiverFieldsToSubstitute/substituted|ToPreventFileOutput/p" "$CDCTI_HOME/$fpath" > "$CDCTI_HOME/substituted_receivers/$fpath")
+  substitutedReceiverFields=$(sed "s/$receiverFieldsToSubstitute/!!!!!!!**********substituted|ToPreventFileOutput**********!!!!!!!/" "$CDCTI_HOME/$fpath" > "$CDCTI_HOME/substituted_receivers/$fpath/$file_name")
   echo "$substitutedReceiverFields"
+  fpath=$CDCTI_HOME/substituted_receivers/$fpath
+
+  echo "$fpath"
   exit 1
 fi
 

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -156,3 +156,8 @@ hurl \
     $verbose \
     $hurl_file \
     $@
+
+# Remove temporary directory
+if [ "$allow_outbound" = false ]; then
+  rm -r "$substitutedFilePathPrefix"
+fi

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -31,7 +31,7 @@ show_help() {
     echo "    -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)"
     echo "    -v                    Verbose mode"
     echo "    -h                    Display this help and exit"
-    echo "    -p                    Produce a real message, receiver will not be Flexion specific"
+    echo "    -p                    By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced"
 }
 
 # Check if required HURL_FILE is provided
@@ -141,7 +141,7 @@ if [ "$allow_outbound" = false ]; then
 # Replace MSH Header and write into temporary directory
   sed "1s/.*/$msh_header_replacement/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
   fpath=$substitutedFilePathPrefix/$fpath
-  echo "The MSH Header was replaced to contain a Flexion receiver and sender. To toggle this, run with -p."
+  echo "By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. To toggle this, run with -p."
 fi
 
 hurl \

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -129,9 +129,9 @@ if [ "$allow_outbound" = false ]; then
   elif [[ "$msh_header" = *"|ORM^"* ]]; then
     msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||ORM^O01^ORM_O01|111111|T|2.5.1||||||||||"
   elif [[ "$msh_header" = *"|OML^"* ]]; then
-      msh_header_replacement=""
+      msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||OML^O21^OML_O21|111111|T|2.5.1||||||||||"
   else
-      echo "File is not OMU or ORM"
+      echo "File does not contain OMU, ORM, or OML"
       exit 1
   fi
   file_path=$(dirname "$fpath")

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -121,10 +121,13 @@ fi
 
 
 if [ "$allow_outbound" = true ]; then
+  file_name=$(echo "$fpath" | awk -F'/')
+  echo "$file_name"
+  mkdir "$CDCTI_HOME/substituted_receivers" && touch "$CDCTI_HOME/substituted_receivers/$fpath"
   echo "$allow_outbound"
   receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
   echo "$receiverFieldsToSubstitute"
-  substitutedReceiverFields=$(sed -n "s/$receiverFieldsToSubstitute/substituted|ToPreventFileOutput/" "$CDCTI_HOME/$fpath")
+  substitutedReceiverFields=$(sed -n "s/$receiverFieldsToSubstitute/substituted|ToPreventFileOutput/p" "$CDCTI_HOME/$fpath" > "$CDCTI_HOME/substituted_receivers/$fpath")
   echo "$substitutedReceiverFields"
   exit 1
 fi

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -14,6 +14,7 @@ client_id=flexion
 client_sender=simulated-hospital
 verbose=""
 submission_id=""
+allow_outbound=false
 
 show_help() {
     echo "Usage: $(basename $0) <HURL_FILE> [OPTIONS]"
@@ -29,6 +30,7 @@ show_help() {
     echo "    -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)"
     echo "    -v                    Verbose mode"
     echo "    -h                    Display this help and exit"
+    echo "    -p                    Produce a real message, receiver will not be Flexion specific"
 }
 
 # Check if required HURL_FILE is provided
@@ -47,7 +49,7 @@ fi
 hurl_file="$1" # Assign the first argument to hurl_file
 shift          # Remove the first argument from the list of arguments
 
-while getopts ':f:r:t:e:c:s:x:i:vh' opt; do
+while getopts ':f:r:t:e:c:s:x:i:vh:p' opt; do
     case "$opt" in
     f)
         fpath="$OPTARG"
@@ -79,6 +81,9 @@ while getopts ':f:r:t:e:c:s:x:i:vh' opt; do
     h)
         show_help
         exit 0
+        ;;
+    p)
+        allow_outbound=true
         ;;
     :)
         echo -e "Option requires an argument"
@@ -114,6 +119,20 @@ if [ -z "$secret" ]; then
     exit 1
 fi
 
+
+if [ "$allow_outbound" = true ]; then
+  echo "$allow_outbound"
+  receiverFieldsToSubstitute=$(head -n1 "$CDCTI_HOME/$fpath" | cut -d "|" -f 5,6)
+  echo "$receiverFieldsToSubstitute"
+  substitutedReceiverFields=$(sed -n "s/$receiverFieldsToSubstitute/substituted|ToPreventFileOutput/" "$CDCTI_HOME/$fpath")
+  echo "$substitutedReceiverFields"
+  exit 1
+fi
+
+if [ "$allow_outbound" = false ]; then
+  echo "$allow_outbound"
+  exit 1
+fi
 hurl \
     --variable fpath=$fpath \
     --file-root $root \
@@ -123,6 +142,7 @@ hurl \
     --variable client-sender=$client_sender \
     --variable jwt=$(jwt encode --exp='+5min' --jti $(uuidgen) --alg RS256 -k $client_id.$client_sender -i $client_id.$client_sender -s $client_id.$client_sender -a $host --no-iat -S @$secret) \
     $submission_id \
+    $allow_outbound \
     $verbose \
     $hurl_file \
     $@

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -131,7 +131,7 @@ if [ "$allow_outbound" = false ]; then
   elif [[ "$msh_header" = *"^O21"* ]]; then
       msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||OML^O21^OML_O21|111111|T|2.5.1||||||||||"
   else
-      echo "File does not contain any valid subfields."
+      echo "File does not contain valid message type (MSH-9) values."
       exit 1
   fi
   file_path=$(dirname "$fpath")

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -16,6 +16,7 @@ Options:
     -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)
     -v                    Verbose mode
     -h                    Display this help and exit
+    -p                    Produce a real message, receiver will not be Flexion specific
 ```
 
 ## Examples

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -16,7 +16,7 @@ Options:
     -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)
     -v                    Verbose mode
     -h                    Display this help and exit
-    -p                    Produce a real message, MSH Header will not be replaced to contain a Flexion receiver or sender
+    -p                    Produce a real message, MSH Header will not be replaced to contain a Flexion receiver and sender
 ```
 
 ## Examples

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -16,7 +16,7 @@ Options:
     -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)
     -v                    Verbose mode
     -h                    Display this help and exit
-    -p                    Produce a real message, receiver will not be Flexion specific
+    -p                    Produce a real message, MSH Header will not be replaced to contain a Flexion receiver or sender
 ```
 
 ## Examples

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -16,7 +16,7 @@ Options:
     -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)
     -v                    Verbose mode
     -h                    Display this help and exit
-    -p                    Produce a real message, MSH Header will not be replaced to contain a Flexion receiver and sender
+    -p                    By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced
 ```
 
 ## Examples

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -35,12 +35,12 @@ Sending an order to staging
 ./hrl waters.hurl -f Test/Orders/003_AL_ORM_O01_NBS_Fully_Populated_0_initial_message.hl7 -e staging -x /path/to/staging/private/key
 ```
 
-Checking the history in local environment for a submision id
+Checking the history in local environment for a submission id
 ```
 ./hrl history.hurl -i 100
 ```
 
-Checking the history in staging for a submision id
+Checking the history in staging for a submission id
 ```
 ./hrl history.hurl -i 100 -e staging -x /path/to/staging/private/key
 ```


### PR DESCRIPTION
# Replace MSH Header When Not Toggled

Added so by default when hurl script for ReportStream is ran, MSH header is replaced to prevent out bound to a real receiver. Added a flag to allow out bound in command line. 

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1322

## Checklist

- [x] I have added logging where useful (with appropriate log level)
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
