### PR TITLE
Transformation Engine To Use Map<String,Object> As Args

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/CustomFhirTransformation.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/CustomFhirTransformation.java
@@ -8,5 +8,5 @@ import java.util.Map;
  * implemented by classes in the custom/ folder.
  */
 public interface CustomFhirTransformation {
-    void transform(FhirResource<?> resource, Map<String, String> args);
+    void transform(FhirResource<?> resource, Map<String, Object> args);
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRule.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRule.java
@@ -48,7 +48,7 @@ public class TransformationRule extends Rule<TransformationRuleMethod> {
     private void applyTransformation(
             TransformationRuleMethod transformation, FhirResource<?> resource) {
         String name = transformation.name();
-        Map<String, String> args = transformation.args();
+        Map<String, Object> args = transformation.args();
         logger.logInfo("Applying transformation: " + name);
 
         CustomFhirTransformation transformationInstance = getTransformationInstance(name);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleMethod.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/TransformationRuleMethod.java
@@ -8,4 +8,4 @@ import java.util.Map;
  * @param name The name of the transformation.
  * @param args The arguments to pass to the transformation method.
  */
-public record TransformationRuleMethod(String name, Map<String, String> args) {}
+public record TransformationRuleMethod(String name, Map<String, Object> args) {}

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/AddContactSectionToPatientResource.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/AddContactSectionToPatientResource.java
@@ -19,7 +19,7 @@ public class AddContactSectionToPatientResource implements CustomFhirTransformat
             ApplicationContext.getImplementation(MetricMetadata.class);
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
 
         HapiHelper.resourcesInBundle(bundle, Patient.class)

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/AddEtorProcessingTag.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/AddEtorProcessingTag.java
@@ -16,7 +16,7 @@ public class AddEtorProcessingTag implements CustomFhirTransformation {
             ApplicationContext.getImplementation(MetricMetadata.class);
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
 
         var system = "http://localcodes.org/ETOR";

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/ConvertToOmlOrder.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/ConvertToOmlOrder.java
@@ -16,7 +16,7 @@ public class ConvertToOmlOrder implements CustomFhirTransformation {
             ApplicationContext.getImplementation(MetricMetadata.class);
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         HapiHelper.setMSH9Coding(bundle, HapiHelper.OML_CODING);
         metadata.put(bundle.getId(), EtorMetadataStep.ORDER_CONVERTED_TO_OML);

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 public class CopyOrcOrderProviderToObrOrderProvider implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         DiagnosticReport diagnosticReport = HapiHelper.getDiagnosticReport(bundle);
         if (diagnosticReport == null) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodes.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodes.java
@@ -31,7 +31,7 @@ public class MapLocalObservationCodes implements CustomFhirTransformation {
     }
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         var bundle = (Bundle) resource.getUnderlyingResource();
         var observations = HapiHelper.resourcesInBundle(bundle, Observation.class);
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveMessageTypeStructure.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveMessageTypeStructure.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.Bundle;
 public class RemoveMessageTypeStructure implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         String msh9_3 = HapiHelper.getMSH9_3Value(bundle);
         if (msh9_3 == null) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
@@ -24,13 +24,8 @@ public class RemoveObservationRequests implements CustomFhirTransformation {
     @Override
     public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
-        String universalServiceIdentifier =
-                args.get("universalServiceIdentifier") instanceof String
-                        ? (String) args.get("universalServiceIdentifier")
-                        : null;
-        if (universalServiceIdentifier == null) {
-            return;
-        }
+        // Let it fail if it is not a String
+        String universalServiceIdentifier = (String) args.get("universalServiceIdentifier");
 
         Set<Resource> resourcesToRemove = new HashSet<>();
         List<Reference> observationReferences = new ArrayList<>();

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
@@ -22,10 +22,13 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 public class RemoveObservationRequests implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
+        String universalServiceIdentifier =
+                args.get("universalServiceIdentifier") instanceof String
+                        ? (String) args.get("universalServiceIdentifier")
+                        : "";
 
-        String universalServiceIdentifier = args.get("universalServiceIdentifier");
         Set<Resource> resourcesToRemove = new HashSet<>();
         List<Reference> observationReferences = new ArrayList<>();
         DiagnosticReport singleDiagnosticReport = null;

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
@@ -27,7 +27,7 @@ public class RemoveObservationRequests implements CustomFhirTransformation {
         String universalServiceIdentifier =
                 args.get("universalServiceIdentifier") instanceof String
                         ? (String) args.get("universalServiceIdentifier")
-                        : "";
+                        : null;
 
         Set<Resource> resourcesToRemove = new HashSet<>();
         List<Reference> observationReferences = new ArrayList<>();

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequests.java
@@ -28,6 +28,9 @@ public class RemoveObservationRequests implements CustomFhirTransformation {
                 args.get("universalServiceIdentifier") instanceof String
                         ? (String) args.get("universalServiceIdentifier")
                         : null;
+        if (universalServiceIdentifier == null) {
+            return;
+        }
 
         Set<Resource> resourcesToRemove = new HashSet<>();
         List<Reference> observationReferences = new ArrayList<>();

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
@@ -13,7 +13,7 @@ import org.hl7.fhir.r4.model.Bundle;
 public class RemovePatientIdentifiers implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         HapiHelper.setPID3_4Value(bundle, ""); // remove PID.3-4
         HapiHelper.setPID3_5Value(bundle, ""); // remove PID.3-5

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
@@ -10,7 +10,7 @@ import org.hl7.fhir.r4.model.Bundle;
 public class RemovePatientNameTypeCode implements CustomFhirTransformation {
 
     @Override
-    public void transform(final FhirResource<?> resource, final Map<String, String> args) {
+    public void transform(final FhirResource<?> resource, final Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         // Need to set the value for extension to empty instead of removing the extension,
         // otherwise RS will set its own value in its place

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/SwapPlacerOrderAndGroupNumbers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/SwapPlacerOrderAndGroupNumbers.java
@@ -17,7 +17,7 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 public class SwapPlacerOrderAndGroupNumbers implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         var serviceRequests = HapiHelper.resourcesInBundle(bundle, ServiceRequest.class);
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
@@ -17,10 +17,15 @@ public class UpdateReceivingApplicationNamespace implements CustomFhirTransforma
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         String name = (args.get("name") instanceof String ? (String) args.get("name") : null);
         var receivingApplication = HapiHelper.getMSH5MessageDestinationComponent(bundle);
-        if (receivingApplication != null && name != null) {
-            receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL);
-            receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL);
-            receivingApplication.setName(name);
+        if (name == null) {
+            return;
         }
+        if (receivingApplication == null) {
+            return;
+        }
+
+        receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL);
+        receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL);
+        receivingApplication.setName(name);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
@@ -13,11 +13,12 @@ import org.hl7.fhir.r4.model.Bundle;
 public class UpdateReceivingApplicationNamespace implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         var receivingApplication = HapiHelper.getMSH5MessageDestinationComponent(bundle);
         receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL);
         receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL);
-        receivingApplication.setName(args.get("name"));
+        receivingApplication.setName(
+                (args.get("name") instanceof String ? (String) args.get("name") : null));
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
@@ -15,11 +15,10 @@ public class UpdateReceivingApplicationNamespace implements CustomFhirTransforma
     @Override
     public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
-        String name = (args.get("name") instanceof String ? (String) args.get("name") : null);
+        // Let it fail if it is not a string
+        String name = (String) args.get("name");
         var receivingApplication = HapiHelper.getMSH5MessageDestinationComponent(bundle);
-        if (name == null) {
-            return;
-        }
+
         if (receivingApplication == null) {
             return;
         }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespace.java
@@ -15,10 +15,12 @@ public class UpdateReceivingApplicationNamespace implements CustomFhirTransforma
     @Override
     public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
+        String name = (args.get("name") instanceof String ? (String) args.get("name") : null);
         var receivingApplication = HapiHelper.getMSH5MessageDestinationComponent(bundle);
-        receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL);
-        receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL);
-        receivingApplication.setName(
-                (args.get("name") instanceof String ? (String) args.get("name") : null));
+        if (receivingApplication != null && name != null) {
+            receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL);
+            receivingApplication.removeExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL);
+            receivingApplication.setName(name);
+        }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingFacilityWithOrderingFacilityIdentifier.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingFacilityWithOrderingFacilityIdentifier.java
@@ -16,7 +16,7 @@ public class UpdateReceivingFacilityWithOrderingFacilityIdentifier
         implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         DiagnosticReport diagnosticReport = HapiHelper.getDiagnosticReport(bundle);
         if (diagnosticReport == null) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
@@ -23,10 +23,8 @@ public class UpdateSendingFacilityNamespace implements CustomFhirTransformation 
             return;
         }
 
-        String name = args.get("name") instanceof String ? (String) args.get("name") : null;
-        if (name == null) {
-            return;
-        }
+        // Let it fail if it is not a string
+        String name = (String) args.get("name");
 
         namespaceIdentifier.setValue(name);
         Objects.requireNonNull(HapiHelper.getMSH4Organization(bundle))

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
@@ -15,13 +15,14 @@ import org.hl7.fhir.r4.model.Identifier;
 public class UpdateSendingFacilityNamespace implements CustomFhirTransformation {
 
     @Override
-    public void transform(FhirResource<?> resource, Map<String, String> args) {
+    public void transform(FhirResource<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         Identifier namespaceIdentifier = HapiHelper.getMSH4_1Identifier(bundle);
         if (namespaceIdentifier == null) {
             return;
         }
-        namespaceIdentifier.setValue(args.get("name"));
+        namespaceIdentifier.setValue(
+                (args.get("name") instanceof String ? (String) args.get("name") : null));
         HapiHelper.getMSH4Organization(bundle)
                 .setIdentifier(Collections.singletonList(namespaceIdentifier));
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespace.java
@@ -5,6 +5,7 @@ import gov.hhs.cdc.trustedintermediary.etor.ruleengine.transformation.CustomFhir
 import gov.hhs.cdc.trustedintermediary.external.hapi.HapiHelper;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Identifier;
 
@@ -21,9 +22,14 @@ public class UpdateSendingFacilityNamespace implements CustomFhirTransformation 
         if (namespaceIdentifier == null) {
             return;
         }
-        namespaceIdentifier.setValue(
-                (args.get("name") instanceof String ? (String) args.get("name") : null));
-        HapiHelper.getMSH4Organization(bundle)
+
+        String name = args.get("name") instanceof String ? (String) args.get("name") : null;
+        if (name == null) {
+            return;
+        }
+
+        namespaceIdentifier.setValue(name);
+        Objects.requireNonNull(HapiHelper.getMSH4Organization(bundle))
                 .setIdentifier(Collections.singletonList(namespaceIdentifier));
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateUniversalServiceIdentifier.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateUniversalServiceIdentifier.java
@@ -27,12 +27,13 @@ public class UpdateUniversalServiceIdentifier implements CustomFhirTransformatio
         Bundle bundle = (Bundle) resource.getUnderlyingResource();
         var serviceRequests = HapiHelper.resourcesInBundle(bundle, ServiceRequest.class);
 
+        // Let it fail if args.get("<property>") is not a string
         serviceRequests.forEach(
                 it -> {
                     var allCodings = it.getCode().getCoding();
                     var codingSystemContainer =
                             getCodingSystemContainer(
-                                    allCodings, castToString(args.get(CHECK_VALUE_NAME)));
+                                    allCodings, (String) args.get(CHECK_VALUE_NAME));
 
                     if (codingSystemContainer == null) {
                         // we're only interested in coding that matches the checkValue argument
@@ -41,21 +42,15 @@ public class UpdateUniversalServiceIdentifier implements CustomFhirTransformatio
 
                     // check for the coding system label and create or override it
                     updateCodingSystemLabel(
-                            codingSystemContainer, castToString(args.get(CODING_SYSTEM_NAME)));
+                            codingSystemContainer, (String) args.get(CODING_SYSTEM_NAME));
 
                     // the alt id is stored on a separate coding object, so we need to filter
                     // for it
-                    String alternateId = castToString(args.get(ALTERNATE_ID_NAME));
+                    String alternateId = (String) args.get(ALTERNATE_ID_NAME);
                     if (alternateId != null) {
                         updateAlternateCodingId(allCodings, alternateId);
                     }
                 });
-    }
-
-    // Returns null if it is not a String
-    private String castToString(Object obj) {
-        // Let it fail if it is not a string
-        return (String) obj;
     }
 
     /**

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateUniversalServiceIdentifier.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateUniversalServiceIdentifier.java
@@ -54,7 +54,8 @@ public class UpdateUniversalServiceIdentifier implements CustomFhirTransformatio
 
     // Returns null if it is not a String
     private String castToString(Object obj) {
-        return obj instanceof String ? (String) obj : null;
+        // Let it fail if it is not a string
+        return (String) obj;
     }
 
     /**

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/HappyPathCustomTransformationMockClass.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/HappyPathCustomTransformationMockClass.groovy
@@ -9,7 +9,7 @@ import org.hl7.fhir.r4.model.Coding
 class HappyPathCustomTransformationMockClass implements CustomFhirTransformation {
 
     @Override
-    public void transform(final FhirResource<?> resource, final Map<String, String> args) {
+    public void transform(final FhirResource<?> resource, final Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingResource()
 
         def system = "http://terminology.hl7.org/CodeSystem/v2-0003"

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -124,19 +124,8 @@ class MapLocalObservationCodesTest extends Specification {
 
     def "When no coding system, no mapping should occur"() {
         given:
-        final String LOCAL_CODE = "A_LOCAL_CODE"
-        final String LOCAL_DISPLAY = "The local code description"
-        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
-
-        def observation = new Observation()
-        def coding = new Coding()
-        coding.code = LOCAL_CODE
-        coding.display = LOCAL_DISPLAY
-        coding.addExtension(HapiHelper.EXTENSION_CWE_CODING, new StringType("alt-coding"))
-        coding.addExtension(HapiHelper.EXTENSION_CODING_SYSTEM, new StringType(HapiHelper.LOCAL_CODE))
-        observation.code.addCoding(coding)
-
-        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        def bundle = createBundleWithNoSystem()
+        def originalCodingList = HapiHelper.resourceInBundle(bundle, Observation.class).getCode().getCoding()
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), null)
@@ -146,7 +135,7 @@ class MapLocalObservationCodesTest extends Specification {
         def transformedCodingList = transformedObservation.getCode().getCoding()
         transformedCodingList.size() == 1
 
-        observation.code.coding == transformedCodingList
+        originalCodingList == transformedCodingList
     }
 
     def "When no coding extension, no mapping should occur"() {
@@ -315,6 +304,18 @@ class MapLocalObservationCodesTest extends Specification {
         def observation = new Observation()
         observation.code.addCoding(createCoding(code1, display1, false, "coding"))
         observation.code.addCoding(createCoding(code2, display2, true, "alt-coding"))
+        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        return bundle
+    }
+
+    def createBundleWithNoSystem() {
+        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
+        def observation = new Observation()
+        def coding = new Coding()
+        coding.code = "A_LOCAL_CODE"
+        coding.display = "The local code description"
+        coding.addExtension(HapiHelper.EXTENSION_CWE_CODING, new StringType("alt-coding"))
+        observation.code.addCoding(coding)
         bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
         return bundle
     }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -83,13 +83,8 @@ class MapLocalObservationCodesTest extends Specification {
 
     def "When message has a mappable local observation code in OBX-3.4/5/6 and other content in OBX3-1/2/3, no mapping should occur"() {
         given:
-        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
-
-        def observation = new Observation()
-        observation.code.addCoding(getCoding(obx31code, obx32display, false, "coding" ))
-        observation.code.addCoding(getCoding("99717-32", "Adrenoleukodystrophy deficiency newborn screening interpretation", true, "alt-coding" ))
-
-        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        def bundle = createBundleWithMultipleCodings(obx31code, obx32display, "99717-32", "Adrenoleukodystrophy deficiency")
+        def originalCodingList = HapiHelper.resourceInBundle(bundle, Observation.class).getCode().getCoding()
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), null)
@@ -99,7 +94,7 @@ class MapLocalObservationCodesTest extends Specification {
         def transformedCodingList = transformedObservation.getCode().getCoding()
         transformedCodingList.size() == 2
 
-        observation.code.coding == transformedCodingList
+        originalCodingList == transformedCodingList
 
         where:
         obx31code    | obx32display
@@ -317,6 +312,15 @@ class MapLocalObservationCodesTest extends Specification {
         def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
         def observation = new Observation()
         observation.code.addCoding(createCoding(code, display, isLocal, "alt-coding"))
+        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        return bundle
+    }
+
+    def createBundleWithMultipleCodings(String code1, String display1, String code2, String display2) {
+        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
+        def observation = new Observation()
+        observation.code.addCoding(createCoding(code1, display1, false, "coding"))
+        observation.code.addCoding(createCoding(code2, display2, true, "alt-coding"))
         bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
         return bundle
     }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -321,7 +321,6 @@ class MapLocalObservationCodesTest extends Specification {
         coding.code = code
         coding.display = display
 
-        // Add extensions properly using Extension objects
         coding.addExtension(new Extension(HapiHelper.EXTENSION_CWE_CODING, new StringType(cweCoding)))
         coding.addExtension(new Extension(HapiHelper.EXTENSION_CODING_SYSTEM, new StringType(isLocal ? HapiHelper.LOCAL_CODE : HapiHelper.LOINC_CODE)))
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -248,17 +248,6 @@ class MapLocalObservationCodesTest extends Specification {
         return observationList.find {observation -> observation.code?.coding?.find { coding -> coding.code == code}}
     }
 
-    Coding getCoding(String code, String display, boolean localCoding, String cweCoding) {
-        def coding = new Coding()
-        coding.system = localCoding ? HapiHelper.LOCAL_CODE_URL : HapiHelper.LOINC_URL
-        coding.code = code
-        coding.display = display
-
-        coding.addExtension(HapiHelper.EXTENSION_CWE_CODING, new StringType(cweCoding))
-        coding.addExtension(HapiHelper.EXTENSION_CODING_SYSTEM, new StringType(localCoding ? HapiHelper.LOCAL_CODE : HapiHelper.LOINC_CODE))
-        return coding
-    }
-
     void evaluateCoding(
             Coding coding,
             String expectedCode,

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -156,15 +156,8 @@ class MapLocalObservationCodesTest extends Specification {
 
     def "When no observation identifier, the observation does not change"() {
         given:
-        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
-
-        // Add an observation with an observation value and a status, but no observation identifier
-        def observation = new Observation()
-        observation.status = Observation.ObservationStatus.FINAL
-        def valueCoding = new Coding()
-        valueCoding.code = "123456"
-        observation.valueCodeableConcept.coding.add(valueCoding)
-        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        def bundle = createBundleWithNoIdentifier()
+        def originalObservation = HapiHelper.resourceInBundle(bundle, Observation.class)
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), null)
@@ -172,7 +165,7 @@ class MapLocalObservationCodesTest extends Specification {
         then:
         def transformedObservation = HapiHelper.resourceInBundle(bundle, Observation.class)
 
-        observation == transformedObservation
+        originalObservation == transformedObservation
     }
 
     def "When message has multiple observations, local and non-local codes are handled appropriately"() {
@@ -320,6 +313,15 @@ class MapLocalObservationCodesTest extends Specification {
         coding.display = display
 
         observation.code.addCoding(coding)
+        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        return bundle
+    }
+
+    def createBundleWithNoIdentifier() {
+        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
+        def observation = new Observation()
+        observation.status = Observation.ObservationStatus.FINAL
+        observation.valueCodeableConcept.coding.add(new Coding(code: "123456"))
         bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
         return bundle
     }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -140,18 +140,8 @@ class MapLocalObservationCodesTest extends Specification {
 
     def "When no coding extension, no mapping should occur"() {
         given:
-        final String LOCAL_CODE = "A_LOCAL_CODE"
-        final String LOCAL_DISPLAY = "The local code description"
-        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
-
-        def observation = new Observation()
-        def coding = new Coding()
-        coding.system = HapiHelper.LOCAL_CODE_URL
-        coding.code = LOCAL_CODE
-        coding.display = LOCAL_DISPLAY
-        observation.code.addCoding(coding)
-
-        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        def bundle = createBundleWithNoExtension("A_LOCAL_CODE", "The local code description")
+        def originalCodingList = HapiHelper.resourceInBundle(bundle, Observation.class).getCode().getCoding()
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), null)
@@ -161,7 +151,7 @@ class MapLocalObservationCodesTest extends Specification {
         def transformedCodingList = transformedObservation.getCode().getCoding()
         transformedCodingList.size() == 1
 
-        observation.code.coding == transformedCodingList
+        originalCodingList == transformedCodingList
     }
 
     def "When no observation identifier, the observation does not change"() {
@@ -315,6 +305,20 @@ class MapLocalObservationCodesTest extends Specification {
         coding.code = "A_LOCAL_CODE"
         coding.display = "The local code description"
         coding.addExtension(HapiHelper.EXTENSION_CWE_CODING, new StringType("alt-coding"))
+        observation.code.addCoding(coding)
+        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        return bundle
+    }
+
+    def createBundleWithNoExtension(String code, String display) {
+        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
+        def observation = new Observation()
+
+        def coding = new Coding()
+        coding.system = HapiHelper.LOCAL_CODE_URL // System is present, but no extensions
+        coding.code = code
+        coding.display = display
+
         observation.code.addCoding(coding)
         bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
         return bundle

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/MapLocalObservationCodesTest.groovy
@@ -105,14 +105,8 @@ class MapLocalObservationCodesTest extends Specification {
 
     def "When message has a LOINC code, no mapping should occur"() {
         given:
-        final String CODE = "A_LOINC_CODE"
-        final String DISPLAY = "Some display"
-
-        def bundle = HapiFhirHelper.createMessageBundle(messageTypeCode: 'ORU_R01')
-
-        def observation = new Observation()
-        observation.code.addCoding(getCoding(CODE, DISPLAY, false, codingSystem ))
-        bundle.addEntry(new Bundle.BundleEntryComponent().setResource(observation))
+        def bundle = createBundleWithObservation("A_LOINC_CODE", "Some display", false)
+        def originalCodingList = HapiHelper.resourceInBundle(bundle, Observation.class).getCode().getCoding()
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), null)
@@ -122,7 +116,7 @@ class MapLocalObservationCodesTest extends Specification {
         def transformedCodingList = transformedObservation.getCode().getCoding()
         transformedCodingList.size() == 1
 
-        observation.code.coding == transformedCodingList
+        originalCodingList == transformedCodingList
 
         where:
         codingSystem << ["coding", "alt-coding"]

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
@@ -22,7 +22,7 @@ class RemoveObservationRequestsTest extends Specification {
         transformClass = new RemoveObservationRequests()
     }
 
-    def "test when universalServiceIdentifier is not a String but a List<String>"() {
+    def "test when universalServiceIdentifier is not a String"() {
         given:
         // Load a FHIR resource example
         def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
@@ -37,7 +37,7 @@ class RemoveObservationRequestsTest extends Specification {
         transformClass.transform(fhirResource, args)
 
         then:
-        thrown(NullPointerException)
+        noExceptionThrown()
     }
 
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
@@ -12,7 +12,7 @@ import spock.lang.Specification
 class RemoveObservationRequestsTest extends Specification {
     def transformClass
     def obr4_1 = "54089-8"
-    def args = Map.of("universalServiceIdentifier", obr4_1)
+    def args = Map.of("universalServiceIdentifier",  (Object) obr4_1)
 
     def setup() {
         TestApplicationContext.reset()
@@ -21,6 +21,25 @@ class RemoveObservationRequestsTest extends Specification {
 
         transformClass = new RemoveObservationRequests()
     }
+
+    def "test when universalServiceIdentifier is not a String but a List<String>"() {
+        given:
+        // Load a FHIR resource example
+        def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")
+        def bundle = fhirResource.getUnderlyingResource() as Bundle
+
+        // Prepare args with a List<String> instead of a String to trigger null response from ternary operator
+        def listOfIdentifiers = ["54089-8", "99717-5"]
+        def args = Map.of("universalServiceIdentifier", (Object) listOfIdentifiers)
+
+        when:
+        // Call transform with the complex args map
+        transformClass.transform(fhirResource, args)
+
+        then:
+        thrown(NullPointerException)
+    }
+
 
     def "remove all OBRs except for the one with OBR-4.1 = '54089-8'"() {
         given:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemoveObservationRequestsTest.groovy
@@ -37,7 +37,7 @@ class RemoveObservationRequestsTest extends Specification {
         transformClass.transform(fhirResource, args)
 
         then:
-        noExceptionThrown()
+        thrown(ClassCastException)
     }
 
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
@@ -52,7 +52,7 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
         HapiHelper.createMSHMessageHeader(bundle)
 
         when:
-        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", ""))
+        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", (Object) ""))
 
         then:
         noExceptionThrown()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
@@ -57,7 +57,7 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
         noExceptionThrown()
     }
 
-    def "don't throw exception if args.get('name') is not a string"() {
+    def "throw exception if args.get('name') is not a string"() {
         given:
         def listOfNames = (Object) ["EPIC", "CIPE"]
         def bundle = new Bundle()
@@ -71,6 +71,6 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
         transformClass.transform(new HapiFhirResource(bundle), Map.of("name", listOfNames))
 
         then:
-        noExceptionThrown()
+        thrown(ClassCastException)
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
@@ -22,7 +22,7 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
 
     def "update receiving application namespace to given name and remove Universal Id and Universal Id Type "() {
         given:
-        def name = "EPIC"
+        def name = (Object) "EPIC"
         def bundle = new Bundle()
         HapiHelper.createMSHMessageHeader(bundle)
         def receivingApplication = HapiFhirHelper.createMessageDestinationComponent()
@@ -53,6 +53,23 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), Map.of("name", ""))
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "don't throw exception if args.get('name') is not a string"() {
+        given:
+        def listOfNames = (Object) ["EPIC", "CIPE"]
+        def bundle = new Bundle()
+        HapiHelper.createMSHMessageHeader(bundle)
+        def receivingApplication = HapiFhirHelper.createMessageDestinationComponent()
+        receivingApplication.addExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_URL, new StringType("universal-id"))
+        receivingApplication.addExtension(HapiHelper.EXTENSION_UNIVERSAL_ID_TYPE_URL, new StringType("universal-id-type"))
+        HapiFhirHelper.setMSH5MessageDestinationComponent(bundle, receivingApplication)
+
+        when:
+        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", listOfNames))
 
         then:
         noExceptionThrown()

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateReceivingApplicationNamespaceTest.groovy
@@ -49,7 +49,6 @@ class UpdateReceivingApplicationNamespaceTest extends Specification {
     def "don't throw exception if receiving application not in bundle"() {
         given:
         def bundle = new Bundle()
-        HapiHelper.createMSHMessageHeader(bundle)
 
         when:
         transformClass.transform(new HapiFhirResource(bundle), Map.of("name", (Object) ""))

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
@@ -50,7 +50,7 @@ class UpdateSendingFacilityNamespaceTest extends Specification {
         noExceptionThrown()
     }
 
-    def "don't throw exception if arg.get('name') is not a string"() {
+    def "throw exception if arg.get('name') is not a string"() {
         given:
         def name = "CDPH"
         def fhirResource = ExamplesHelper.getExampleFhirResource("../MN/004_MN_ORU_R01_NBS_1_hl7_translation.fhir")
@@ -65,6 +65,6 @@ class UpdateSendingFacilityNamespaceTest extends Specification {
         transformClass.transform(new HapiFhirResource(bundle), Map.of("name", (Object) listOfNames))
 
         then:
-        noExceptionThrown()
+        thrown(ClassCastException)
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
@@ -49,4 +49,22 @@ class UpdateSendingFacilityNamespaceTest extends Specification {
         then:
         noExceptionThrown()
     }
+
+    def "don't throw exception if arg.get('name') is not a string"() {
+        given:
+        def name = "CDPH"
+        def fhirResource = ExamplesHelper.getExampleFhirResource("../MN/004_MN_ORU_R01_NBS_1_hl7_translation.fhir")
+        def bundle = fhirResource.getUnderlyingResource() as Bundle
+        def listOfNames = ["trusted", "intermediary"]
+
+        expect:
+        HapiHelper.getMSH4Organization(bundle).getIdentifier().size() > 1
+        HapiHelper.getMSH4_1Identifier(bundle).getValue() != name
+
+        when:
+        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", (Object) listOfNames))
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/UpdateSendingFacilityNamespaceTest.groovy
@@ -22,7 +22,7 @@ class UpdateSendingFacilityNamespaceTest extends Specification {
 
     def "update sending facility namespace to given name and remove other identifiers"() {
         given:
-        def name = "CDPH"
+        def name =  (Object) "CDPH"
         def fhirResource = ExamplesHelper.getExampleFhirResource("../MN/004_MN_ORU_R01_NBS_1_hl7_translation.fhir")
         def bundle = fhirResource.getUnderlyingResource() as Bundle
 
@@ -44,7 +44,7 @@ class UpdateSendingFacilityNamespaceTest extends Specification {
         HapiHelper.createMSHMessageHeader(bundle)
 
         when:
-        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", ""))
+        transformClass.transform(new HapiFhirResource(bundle), Map.of("name", (Object) ""))
 
         then:
         noExceptionThrown()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Complex Map As Args For Transformation Engine

This PR adds the logic for the trasnformation engine to use a Map<String,Object> intead of a Map<String,String> allowing for more flexibility when passing parameters when using the transformation_definitions.json file.

## Issue
#1366 



## Checklist

- [x] All tests pass

**Note**: You may remove items that are not applicable
