### PR TITLE
Hurl script updates

### DIFF
--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -21,17 +21,17 @@ show_help() {
     echo "Usage: $(basename $0) <HURL_FILE> [OPTIONS]"
     echo
     echo "Options:"
-    echo "    -f <REL_PATH>         The path to the hl7/fhir file to submit, relative the root path (Required for waters API)"
-    echo "    -r <ROOT_PATH>        The root path to the hl7/fhir files (Default: $root)"
-    echo "    -t <CONTENT_TYPE>     The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: $content_type)"
-    echo "    -e [local | staging]  The environment to run the test in (Default: $env)"
-    echo "    -c <CLIENT_ID>        The client id to use (Default: $client_id)"
-    echo "    -s <CLIENT_SENDER>    The client sender to use (Default: $client_sender)"
-    echo "    -x <KEY_PATH>         The path to the client private key for the environment"
-    echo "    -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)"
-    echo "    -v                    Verbose mode"
-    echo "    -h                    Display this help and exit"
-    echo "    -p                    By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced"
+    echo "    -f <REL_PATH>                       The path to the hl7/fhir file to submit, relative the root path (Required for waters API)"
+    echo "    -r <ROOT_PATH>                      The root path to the hl7/fhir files (Default: $root)"
+    echo "    -t <CONTENT_TYPE>                   The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: $content_type)"
+    echo "    -e [local | staging | production ]  The environment to run the test in (Default: $env)"
+    echo "    -c <CLIENT_ID>                      The client id to use (Default: $client_id)"
+    echo "    -s <CLIENT_SENDER>                  The client sender to use (Default: $client_sender)"
+    echo "    -x <KEY_PATH>                       The path to the client private key for the environment"
+    echo "    -i <SUBMISSION_ID>                  The submissionId to call the history API with (Required for history API)"
+    echo "    -v                                  Verbose mode"
+    echo "    -h                                  Display this help and exit"
+    echo "    -p                                  By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced"
 }
 
 # Check if required HURL_FILE is provided
@@ -109,6 +109,9 @@ if [ "$env" = "local" ]; then
 elif [ "$env" = "staging" ]; then
     host=staging.prime.cdc.gov
     url=https://$host:443
+elif [ "$env" = "production" ]; then
+    host=prime.cdc.gov
+    url=https://$host:443
 else
     echo "Error: Invalid environment $env"
     show_help
@@ -121,27 +124,27 @@ if [ -z "$secret" ]; then
 fi
 
 if [ "$allow_outbound" = false ]; then
-# Grab MSH Header
-  msh_header=$(head -n1 "$CDCTI_HOME/$fpath")
-# Check message type
-  if [[ "$msh_header" = *"^R01"* ]]; then
-    msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-hospital-id^DNS|20230101010000-0000||ORU^R01^ORU_R01|111111|T|2.5.1||||||||||"
-  elif [[ "$msh_header" = *"^O01"* ]]; then
-    msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||ORM^O01^ORM_O01|111111|T|2.5.1||||||||||"
-  elif [[ "$msh_header" = *"^O21"* ]]; then
-      msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||OML^O21^OML_O21|111111|T|2.5.1||||||||||"
-  else
-      echo "File does not contain valid message type (MSH-9) values."
-      exit 1
-  fi
-  file_path=$(dirname "$fpath")
-  substitutedFilePathPrefix="$CDCTI_HOME/substituted_header"
-# Make temporary directory to store scrambled file
-  mkdir -p "$substitutedFilePathPrefix/$file_path" && touch -f "$substitutedFilePathPrefix/$fpath"
-# Replace MSH Header and write into temporary directory
-  sed "1s/.*/$msh_header_replacement/" "$CDCTI_HOME/$fpath" > "$substitutedFilePathPrefix/$fpath"
-  fpath=$substitutedFilePathPrefix/$fpath
-  echo "By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. To toggle this, run with -p."
+    # Grab MSH Header
+    msh_header=$(head -n1 "$CDCTI_HOME/$fpath")
+    # Check message type
+    if [[ "$msh_header" = *"^R01"* ]]; then
+        msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-hospital-id^DNS|20230101010000-0000||ORU^R01^ORU_R01|111111|T|2.5.1||||||||||"
+    elif [[ "$msh_header" = *"^O01"* ]]; then
+        msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||ORM^O01^ORM_O01|111111|T|2.5.1||||||||||"
+    elif [[ "$msh_header" = *"^O21"* ]]; then
+        msh_header_replacement="MSH|^~\&|Sender Application^sender.test.com^DNS|Sender Facility^0.0.0.0.0.0.0.0^ISO|Receiver Application^0.0.0.0.0.0.0.0^ISO|Receiver Facility^simulated-lab-id^DNS|20230101010000-0000||OML^O21^OML_O21|111111|T|2.5.1||||||||||"
+    else
+        echo "File does not contain valid message type (MSH-9) values."
+        exit 1
+    fi
+    file_path=$(dirname "$fpath")
+    substitutedFilePathPrefix="$CDCTI_HOME/substituted_header"
+    # Make temporary directory to store scrambled file
+    mkdir -p "$substitutedFilePathPrefix/$file_path" && touch -f "$substitutedFilePathPrefix/$fpath"
+    # Replace MSH Header and write into temporary directory
+    sed "1s/.*/$msh_header_replacement/" "$CDCTI_HOME/$fpath" >"$substitutedFilePathPrefix/$fpath"
+    fpath=$substitutedFilePathPrefix/$fpath
+    echo "By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. To toggle this, run with -p."
 fi
 
 hurl \
@@ -159,5 +162,5 @@ hurl \
 
 # Remove temporary directory
 if [ "$allow_outbound" = false ]; then
-  rm -r "$substitutedFilePathPrefix"
+    rm -r "$substitutedFilePathPrefix"
 fi

--- a/scripts/hurl/rs/hrl
+++ b/scripts/hurl/rs/hrl
@@ -123,7 +123,7 @@ if [ -z "$secret" ]; then
     exit 1
 fi
 
-if [ "$allow_outbound" = false ]; then
+if [ "$allow_outbound" = false ] && [ -n "$fpath" ]; then
     # Grab MSH Header
     msh_header=$(head -n1 "$CDCTI_HOME/$fpath")
     # Check message type

--- a/scripts/hurl/rs/readme.md
+++ b/scripts/hurl/rs/readme.md
@@ -6,42 +6,47 @@
 Usage: ./hrl <HURL_FILE> [OPTIONS]
 
 Options:
-    -f <REL_PATH>         The path to the hl7/fhir file to submit, relative the root path (Required for waters API)
-    -r <ROOT_PATH>        The root path to the hl7/fhir files (Default: $CDCTI_HOME/examples/)
-    -t <CONTENT_TYPE>     The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: application/hl7-v2)
-    -e [local | staging]  The environment to run the test in (Default: local)
-    -c <CLIENT_ID>        The client id to use (Default: flexion)
-    -s <CLIENT_SENDER>    The client sender to use (Default: simulated-lab)
-    -x <KEY_PATH>         The path to the client private key for the environment
-    -i <SUBMISSION_ID>    The submissionId to call the history API with (Required for history API)
-    -v                    Verbose mode
-    -h                    Display this help and exit
-    -p                    By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced
+    -f <REL_PATH>                       The path to the hl7/fhir file to submit, relative the root path (Required for waters API)
+    -r <ROOT_PATH>                      The root path to the hl7/fhir files (Default: $CDCTI_HOME/examples/)
+    -t <CONTENT_TYPE>                   The content type for the message (e.g. 'application/hl7-v2' or 'application/fhir+ndjson') (Default: application/hl7-v2)
+    -e [local | staging | production ]  The environment to run the test in (Default: local)
+    -c <CLIENT_ID>                      The client id to use (Default: flexion)
+    -s <CLIENT_SENDER>                  The client sender to use (Default: simulated-hospital)
+    -x <KEY_PATH>                       The path to the client private key for the environment
+    -i <SUBMISSION_ID>                  The submissionId to call the history API with (Required for history API)
+    -v                                  Verbose mode
+    -h                                  Display this help and exit
+    -p                                  By default, the MSH segment is replaced to contain a Flexion receiver in order to avoid sending messages to partners inadvertently. When using this flag, the MSH segment will not be replaced
 ```
 
 ## Examples
 
 Sending an order to local environment
+
 ```
 ./hrl waters.hurl -f Test/Orders/003_AL_ORM_O01_NBS_Fully_Populated_0_initial_message.hl7
 ```
 
 Sending a result to local environment
+
 ```
 ./hrl waters.hurl -f Test/Results/002_AL_ORU_R01_NBS_Fully_Populated_0_initial_message.hl7
 ```
 
 Sending an order to staging
+
 ```
 ./hrl waters.hurl -f Test/Orders/003_AL_ORM_O01_NBS_Fully_Populated_0_initial_message.hl7 -e staging -x /path/to/staging/private/key
 ```
 
 Checking the history in local environment for a submission id
+
 ```
 ./hrl history.hurl -i 100
 ```
 
 Checking the history in staging for a submission id
+
 ```
 ./hrl history.hurl -i 100 -e staging -x /path/to/staging/private/key
 ```


### PR DESCRIPTION
# Hurl script updates

- Add prod env handling
- Fixed bug that was preventing use of the `./hrl history.hurl` command option