### PR TITLE
Sleep 2 minutes before swapping slots to see if this reduces swap timeouts

### DIFF
--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -105,6 +105,9 @@ jobs:
         slot-name: pre-live
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'
 
+    - name: Sleep 2 minutes
+      run: sleep 2m
+
     - name: Azure Swap Slots
       uses: azure/CLI@v2
       with:


### PR DESCRIPTION
# Description
We've been getting intermittent timeouts when swapping slots. When this happens, there are no other errors in logs and the pre-live instances appear healthy. This PR adds a brief sleep between deploying to the pre-live slot and swapping slots in case there's some poorly-managed latency on the Azure side

