### PR TITLE
Fix DORA metrics workflow

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -42,7 +42,7 @@ jobs:
             [[repositories]]
             owner = "CDCgov"
             repo = "trusted-intermediary"
-            id = "42635194"
+            workflow_filename = "metrics.yaml"
             deployment-frequency = "df"
             change-fail-rate = "cf"
             mean-time-to-recover = "mttrs"

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -42,7 +42,7 @@ jobs:
             [[repositories]]
             owner = "CDCgov"
             repo = "trusted-intermediary"
-            workflow_filename = "metrics.yaml"
+            workflow_filename = "metrics.yml"
             deployment-frequency = "df"
             change-fail-rate = "cf"
             mean-time-to-recover = "mttrs"


### PR DESCRIPTION
# Description
Updated the `metrics.yml` to use workflow filename instead of ID based on [changes](https://github.com/flexion/devops-deployment-metrics/commit/e6139b51656be25e4e34154acc3d1642088b8fdf#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91) in the `devops-deployment-metrics` tool

It runs without error after this update: https://github.com/CDCgov/trusted-intermediary/actions/runs/11114976169/job/30882538891
