### PR TITLE
Improve Slot Swapping

### DIFF
--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -105,9 +105,6 @@ jobs:
         slot-name: pre-live
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'
 
-    - name: Sleep 2 minutes
-      run: sleep 2m
-
     - name: Azure Swap Slots
       uses: azure/CLI@v2
       with:

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -38,7 +38,8 @@ import java.util.Set;
 public class App {
     private static final long MAX_REQUEST_SIZE = 2 * 1024 * 1024L; // 2 MB in bytes
     private static final int PORT = 8080;
-    static final String HEALTH_API_ENDPOINT = "/health";
+    private static final String HEALTH_API_ENDPOINT = "/health";
+    private static final String ROOT_API_ENDPOINT = "/";
 
     public static void main(String[] args) {
         var app =
@@ -50,6 +51,7 @@ public class App {
 
         try {
             app.get(HEALTH_API_ENDPOINT, ctx -> ctx.result("Operational"));
+            app.get(ROOT_API_ENDPOINT, ctx -> ctx.result("Operational"));
 
             registerClasses();
             registerDomains(app);


### PR DESCRIPTION
# Improve Slot Swapping

TI is having issues with its slot swapping whenever deploying to any environment.  It fails a lot.  What's worse is that it takes 20+ minutes to fail.  RS SFTP Ingest doesn't have nearly the same failure rate.  It succeeds much more often.

One difference between RS SFTP Ingest and TI is us responding with an HTTP `200` status code from the `/` path.  So I tried adding this to TI, and that change is this PR.  I [tested this multiple times](https://github.com/CDCgov/trusted-intermediary/actions/runs/11181877789) in the Internal environment, and the tests always succeeded when previously they would easily fail.

Now, you may be wondering, why do we need to respond to `/` at all?  Our health check points to `/health`, for goodness sake.  And... I have no idea why.  Even with the health check pointing to `/health`, the health check seems to want to hit `/` anyway according to the app service's HTTP logs.  I looked for some other setting that would tell Azure "I mean it, actually use /health dang it", but I couldn't find it.  So instead I made `/` respond to health checks and it seems to work.

## Issue

_None_.

## Checklist

- [x] [Tested four times](https://github.com/CDCgov/trusted-intermediary/actions/runs/11181877789) in the Internal environment.