### PR TITLE
revert keyvault upgrade

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     // azure sdk
-    implementation 'com.azure:azure-security-keyvault-secrets:4.8.7'
+    implementation 'com.azure:azure-security-keyvault-secrets:4.8.6'
     implementation 'com.azure:azure-identity:1.14.0'
 
     testImplementation 'org.apache.groovy:groovy:4.0.23'


### PR DESCRIPTION
# Add a PR title
Reverting https://github.com/CDCgov/trusted-intermediary/pull/1369 - we started seeing errors retrieving secrets from keyvault after this change. 

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1386

