### PR TITLE
Bug - Javalin Security Vulnerabilities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     // Import the Jetty BOM to pull consistent Jetty versions
     implementation 'org.eclipse.jetty:jetty-bom:12.0.14'
 
+    // Version 6.3.0 has jetty vulnerabilities. We are pulling the jetty directly to by pass this.
     implementation 'io.javalin:javalin:6.3.0'
 
     testImplementation 'org.apache.groovy:groovy:4.0.23'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,12 @@ dependencies {
     implementation project(':etor')
     testImplementation testFixtures(project(':shared'))
 
+    // Patch: Add the fixed Jetty version
+    implementation('org.eclipse.jetty:jetty-server:12.0.12') {
+        // Exclude the vulnerable version brought by Javalin
+        exclude group: 'org.eclipse.jetty', module: 'jetty-server'
+    }
+
     implementation 'io.javalin:javalin:6.3.0'
 
     testImplementation 'org.apache.groovy:groovy:4.0.23'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,10 +24,8 @@ dependencies {
     testImplementation testFixtures(project(':shared'))
 
     // Patch: Add the fixed Jetty version
-    implementation('org.eclipse.jetty:jetty-server:12.0.12') {
-        // Exclude the vulnerable version brought by Javalin
-        exclude group: 'org.eclipse.jetty', module: 'jetty-server'
-    }
+    // Import the Jetty BOM to pull consistent Jetty versions
+    implementation 'org.eclipse.jetty:jetty-bom:12.0.14'
 
     implementation 'io.javalin:javalin:6.3.0'
 


### PR DESCRIPTION
# Javalin Vulnerabilities

Javalin uses Jetty-server and Snyk notified us of vulnerabilities related to the jetty-server verstion. The dependencies flagged were:
jetty-server and jetty-http

## Issue
#1437 

## Checklist

- [x] All tests pass



