### PR TITLE
Enabled ask and reflect

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -21,7 +21,7 @@ inline_code_comments = true # If set to true, the tool will publish the code sug
 ask_and_reflect=true
 persistent_comment=false
 #automatic_review=true
-extra_instructions = "Please be mean using Spongebob language" # Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
+extra_instructions = "" # Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
 final_update_message = true # If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is false.
 # review labels
 enable_review_labels_security=false # If set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -18,10 +18,10 @@ pr_actions = ["opened", "reopened", "ready_for_review", "review_requested"]
 # general options
 num_code_suggestions=3 # Number of code suggestions provided by the 'review' tool. Default is 0, meaning no code suggestions will be provided by the `review` tool.
 inline_code_comments = true # If set to true, the tool will publish the code suggestions as comments on the code diff. Default is false. Note that you need to set `num_code_suggestions`>0 to get code suggestions
-ask_and_reflect=false
+ask_and_reflect=true
 persistent_comment=false
 #automatic_review=true
-extra_instructions = "" # Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
+extra_instructions = "Please be mean using Spongebob language" # Optional extra instructions to the tool. For example: "focus on the changes in the file X. Ignore change in ...".
 final_update_message = true # If set to true, it will add a comment message [`PR Description updated to latest commit...`](https://github.com/Codium-ai/pr-agent/pull/499#issuecomment-1837412176) after finishing calling `/describe`. Default is false.
 # review labels
 enable_review_labels_security=false # If set to true, the tool will publish a 'possible security issue' label if it detects a security issue. Default is true.


### PR DESCRIPTION
Enabled Ask and Reflect for our AI PR Agent. 

This will enable the agent to reflect on it's suggestions after a new commit is pushed. 