### PR TITLE
Revert "Setup Azure Alert for Azure is down"

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -28,47 +28,6 @@ resource "azurerm_monitor_action_group" "notify_slack_email" {
   }
 }
 
-resource "azurerm_monitor_activity_log_alert" "azure_service_health_alert" {
-  count               = local.non_pr_environment ? 1 : 0
-  name                = "cdcti-${var.environment}-azure-status-alert"
-  location            = data.azurerm_resource_group.group.location
-  resource_group_name = data.azurerm_resource_group.group.name
-  scopes              = ["/subscriptions/${data.azurerm_client_config.current.subscription_id}"]
-
-  criteria {
-    category = "ServiceHealth"
-    levels   = ["Error"]
-    service_health {
-      locations = ["global"]
-      events    = ["Incident"]
-    }
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.notify_slack_email[count.index].id
-  }
-
-  description = "Alert service(s) appear to be down"
-  enabled     = true
-
-  lifecycle {
-    ignore_changes = [
-      tags["business_steward"],
-      tags["center"],
-      tags["environment"],
-      tags["escid"],
-      tags["funding_source"],
-      tags["pii_data"],
-      tags["security_compliance"],
-      tags["security_steward"],
-      tags["support_group"],
-      tags["system"],
-      tags["technical_steward"],
-      tags["zone"]
-    ]
-  }
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert" "database_token_expired_alert" {
   count               = local.non_pr_environment ? 1 : 0
   name                = "cdcti-${var.environment}-api-log-token-alert"


### PR DESCRIPTION
Reverts CDCgov/trusted-intermediary#1464

The changes from that PR is [failing in staging](https://github.com/CDCgov/trusted-intermediary/actions/runs/11462902938/job/31895798376).  It may be failing due to the change from my [PR comment](https://github.com/CDCgov/trusted-intermediary/pull/1464#discussion_r1809613510).  :`(  We don't know this for sure, though.

Normally, for this kind of issue, I'd favor "failing forward", but tomorrow we have the CA SME call.  I rather not have a failing staging deploy for that meeting.  So revert it is.