### PR TITLE
Specify Maintenance Window for the Database

### DIFF
--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -24,7 +24,7 @@ resource "azurerm_postgresql_flexible_server" "database" {
 
   maintenance_window { # Sunday at 12:00 UTC which is 7:00 AM EST or 8:00 AM EDT (around the time of our SLA's maintenance window)
     day_of_week  = 0
-    start_hour   = 5
+    start_hour   = 12
     start_minute = 0
   }
 

--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -22,6 +22,12 @@ resource "azurerm_postgresql_flexible_server" "database" {
     tenant_id                     = data.azurerm_client_config.current.tenant_id
   }
 
+  maintenance_window { # Sunday at 5:00 AM UTC which is 0:00 AM EST or 1:00 AM EDT
+    day_of_week  = 0
+    start_hour   = 5
+    start_minute = 0
+  }
+
   depends_on = [azurerm_private_dns_zone_virtual_network_link.db_network_link]
 
   lifecycle {

--- a/operations/template/db.tf
+++ b/operations/template/db.tf
@@ -22,7 +22,7 @@ resource "azurerm_postgresql_flexible_server" "database" {
     tenant_id                     = data.azurerm_client_config.current.tenant_id
   }
 
-  maintenance_window { # Sunday at 5:00 AM UTC which is 0:00 AM EST or 1:00 AM EDT
+  maintenance_window { # Sunday at 12:00 UTC which is 7:00 AM EST or 8:00 AM EDT (around the time of our SLA's maintenance window)
     day_of_week  = 0
     start_hour   = 5
     start_minute = 0


### PR DESCRIPTION
# Description

Our database has maintenance windows.  [Azure recommends](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-maintenance) setting a specific one, and specifying one reduces the randomness of when the maintenance window will occur.  I set the maintenance to our SLA's maintenance window.  Not that our SLA is actually set, but our draft is better than nothing.

## Issue

_None_.