### PR TITLE
4XX and 5XX Alert Aggregation to Total Instead of Count

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -134,7 +134,7 @@ resource "azurerm_monitor_metric_alert" "azure_4XX_alert" {
   criteria {
     metric_namespace = "Microsoft.Web/sites"
     metric_name      = "Http4xx"
-    aggregation      = "Count"
+    aggregation      = "Total"
     operator         = "GreaterThanOrEqual"
     threshold        = 3
   }
@@ -174,7 +174,7 @@ resource "azurerm_monitor_metric_alert" "azure_5XX_alert" {
   criteria {
     metric_namespace = "Microsoft.Web/sites"
     metric_name      = "Http5xx"
-    aggregation      = "Count"
+    aggregation      = "Total"
     operator         = "GreaterThanOrEqual"
     threshold        = 1
   }


### PR DESCRIPTION
# Description

Based on @saquino0827's [finding](https://flexion.slack.com/archives/C06CP7E3NAF/p1729788774584409), updated the 4XX and 5XX alerts to use Total (Sum) instead of Count for their aggregation.

## Issue

#1396 and #1394.

## Checklist

- [x] Tested 4XX in the Internal environment.  Specifically, made sure that the 4XXs come in within a specific minute so that it would only work with Total (Sum) instead of also working with Count.