### PR TITLE
Update env variable name for automated test sender

### DIFF
--- a/.github/workflows/automated-staging-test-submit.yml
+++ b/.github/workflows/automated-staging-test-submit.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * 2-6"  # Tuesday to Saturday at Midnight UTC
   workflow_dispatch:
+  pull_request:
 
 jobs:
   send_files:

--- a/.github/workflows/automated-staging-test-submit.yml
+++ b/.github/workflows/automated-staging-test-submit.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Write private key to file
         run: |
-          echo "${{ secrets.SIMULATED_SENDER_PRIVATE_KEY }}" > /tmp/staging_private_key.pem
+          echo "${{ secrets.SIMULATED_SENDER_STAGING_PRIVATE_KEY }}" > /tmp/staging_private_key.pem
           chmod 600 /tmp/staging_private_key.pem
 
       - name: Send HL7 sample messages to staging RS

--- a/.github/workflows/automated-staging-test-submit.yml
+++ b/.github/workflows/automated-staging-test-submit.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * 2-6"  # Tuesday to Saturday at Midnight UTC
   workflow_dispatch:
-  pull_request:
 
 jobs:
   send_files:

--- a/.github/workflows/automated-staging-test-submit.yml
+++ b/.github/workflows/automated-staging-test-submit.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Write private key to file
         run: |
-          echo "${{ secrets.AUTOMATED_STAGING_RS_INTEGRATION_PRIVATE_KEY }}" > /tmp/staging_private_key.pem
+          echo "${{ secrets.SIMULATED_SENDER_PRIVATE_KEY }}" > /tmp/staging_private_key.pem
           chmod 600 /tmp/staging_private_key.pem
 
       - name: Send HL7 sample messages to staging RS


### PR DESCRIPTION
Now that we are using `simulated-sender` for the automated test task, updated to use the corresponding key stored in a new github env variable