### PR TITLE
Make VPN Gen2

### DIFF
--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -34,7 +34,8 @@ resource "azurerm_virtual_network_gateway" "vpn" {
 
   active_active = false
   enable_bgp    = false
-  sku           = "VpnGw1AZ"
+  generation    = "Generation2"
+  sku           = "VpnGw2"
 
   ip_configuration {
     public_ip_address_id          = azurerm_public_ip.vpn_ip.id

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -7,6 +7,7 @@ resource "azurerm_public_ip" "vpn" {
   sku               = "Standard"
   #   below tags are managed by CDC
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [
       tags["business_steward"],
       tags["center"],

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -1,5 +1,5 @@
-resource "azurerm_public_ip" "vpn" {
-  name                = "vpn-public-ip"
+resource "azurerm_public_ip" "vpn_ip" {
+  name                = "vpn-ip"
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
 
@@ -7,7 +7,6 @@ resource "azurerm_public_ip" "vpn" {
   sku               = "Standard"
   #   below tags are managed by CDC
   lifecycle {
-    create_before_destroy = true
     ignore_changes = [
       tags["business_steward"],
       tags["center"],
@@ -38,7 +37,7 @@ resource "azurerm_virtual_network_gateway" "vpn" {
   sku           = "VpnGw1"
 
   ip_configuration {
-    public_ip_address_id          = azurerm_public_ip.vpn.id
+    public_ip_address_id          = azurerm_public_ip.vpn_ip.id
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.vpn.id
   }

--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -34,7 +34,7 @@ resource "azurerm_virtual_network_gateway" "vpn" {
 
   active_active = false
   enable_bgp    = false
-  sku           = "VpnGw1"
+  sku           = "VpnGw1AZ"
 
   ip_configuration {
     public_ip_address_id          = azurerm_public_ip.vpn_ip.id

--- a/operations/vpn/dev.ovpn
+++ b/operations/vpn/dev.ovpn
@@ -1,6 +1,6 @@
 client
-remote azuregateway-d84e0077-7de0-48f3-b087-b3759344ba44-7322fc20c350.vpn.azure.com 443
-verify-x509-name d84e0077-7de0-48f3-b087-b3759344ba44.vpn.azure.com name
+remote azuregateway-8afb0077-b033-4ea2-b44d-fc7fb6b286c3-a7d879b839d7.vpn.azure.com 443
+verify-x509-name 8afb0077-b033-4ea2-b44d-fc7fb6b286c3.vpn.azure.com name
 remote-cert-tls server
 
 dev tun


### PR DESCRIPTION
# Description
https://github.com/CDCgov/trusted-intermediary/pull/1499 didn't work in previously-existing environments because there is currently no way to replace the public IP on an existing VPN. Since we have to delete the VPNs to connect the new public IP setup, we are also upgrading them to gen2, which will be required in future

Prior to deploying to staging and prod, we'll need to manually delete the VPN in Azure. After that, we'll need to update each env's ovpn file and deploy again.

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1491

