### PR TITLE
Downgrade `com.azure:azure-identity` to 1.13.3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,10 @@
                 "org.apache.httpcomponents.client5:httpclient5-fluent"
             ],
             "allowedVersions": "!/^5\\.3$/"
+        },
+        {
+            "matchPackageNames": ["com.azure:azure-identity"],
+            "allowedVersions": "!/^1\\.14\\.0$/"
         }],
     "pinDigests": false
 }

--- a/etor/build.gradle
+++ b/etor/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation testFixtures(project(':shared'))
 
     implementation 'com.azure:azure-storage-blob:12.28.1'
-    implementation 'com.azure:azure-identity:1.14.0'
+    implementation 'com.azure:azure-identity:1.13.3'
 
     testImplementation 'org.apache.groovy:groovy:4.0.23'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     // azure sdk
     implementation 'com.azure:azure-security-keyvault-secrets:4.9.0'
-    implementation 'com.azure:azure-identity:1.14.0'
+    implementation 'com.azure:azure-identity:1.13.3'
 
     testImplementation 'org.apache.groovy:groovy:4.0.23'
     testFixturesImplementation 'org.apache.groovy:groovy:4.0.23'


### PR DESCRIPTION
# Description

Our Staging environment started [generating alerts](https://flexion.slack.com/archives/C071LPLHXFW/p1729801283924049).  These weren't test alerts, they were legitimate.  :(  After looking at the logs, our Postgres server didn't like our password.  Did some [digging](https://flexion.slack.com/archives/C071LPLHXFW/p1729809715953989?thread_ts=1729801283.924049&cid=C071LPLHXFW), I found that it's due to the `com.azure:azure-identity` version 1.14.0.  I even found another person with the [exact same issue](https://github.com/Azure/azure-sdk-for-java/issues/42310).

So, we're downgrading and telling Renovate to ignore 1.14.0.  A [folow-up issue](https://github.com/CDCgov/trusted-intermediary/issues/1509) has been created to update the dependency when this issue is fixed.

## Issue

_None_.

## Checklist

- [x] Tested this in the Internal environment.  It works.
