### PR TITLE
Revert "Update VPN IP allocation"

### DIFF
--- a/operations/template/vpn.tf
+++ b/operations/template/vpn.tf
@@ -3,8 +3,8 @@ resource "azurerm_public_ip" "vpn" {
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
 
-  allocation_method = "Static"
-  sku               = "Standard"
+  allocation_method = "Dynamic"
+  sku               = "Basic"
   #   below tags are managed by CDC
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
Reverts CDCgov/trusted-intermediary#1499

This is causing issues in already-existing environments