### PR TITLE
Update story template for non-applicable DoD items

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -48,6 +48,8 @@ As a _, so that _, I need _.
   - [ ] Feature toggles created and/or deleted.  Document the feature toggle
   - [ ] Source code is merged to the main branch
 
+**Note**: Please remove any DoD items that are not applicable
+
 ## Research Questions
 - *Optional: Any initial questions for research*
 


### PR DESCRIPTION
# Description

- We added a note to the Story issue template for removing any non-applicable DoD items.
  - This is to be consistent between all engineers 

