### PR TITLE
Avoid ignoring exceptions in automated tests

### DIFF
--- a/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcher.java
+++ b/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcher.java
@@ -44,8 +44,8 @@ public class HapiHL7FileMatcher {
         Set<String> inputKeys = inputMap.keySet();
         Set<String> outputKeys = outputMap.keySet();
         Set<String> unmatchedKeys = new HashSet<>();
-        unmatchedKeys.addAll(Sets.difference(inputKeys, outputKeys)); // in input but not output
-        unmatchedKeys.addAll(Sets.difference(outputKeys, inputKeys)); // in output but not input
+        unmatchedKeys.addAll(Sets.difference(inputKeys, outputKeys));
+        unmatchedKeys.addAll(Sets.difference(outputKeys, inputKeys));
 
         if (!unmatchedKeys.isEmpty()) {
             throw new NoSuchElementException(

--- a/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherException.java
+++ b/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherException.java
@@ -1,5 +1,9 @@
 package gov.hhs.cdc.trustedintermediary.rse2e.external.hapi;
 
+/**
+ * The HapiHL7FileMatcherException class is responsible for handling exceptions that occur in the
+ * HapiHL7FileMatcher class.
+ */
 public class HapiHL7FileMatcherException extends Exception {
 
     public HapiHL7FileMatcherException(String message, Throwable cause) {

--- a/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherException.java
+++ b/rs-e2e/src/main/java/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherException.java
@@ -1,0 +1,12 @@
+package gov.hhs.cdc.trustedintermediary.rse2e.external.hapi;
+
+public class HapiHL7FileMatcherException extends Exception {
+
+    public HapiHL7FileMatcherException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HapiHL7FileMatcherException(String message) {
+        super(message);
+    }
+}

--- a/rs-e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherExceptionTest.groovy
+++ b/rs-e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherExceptionTest.groovy
@@ -1,0 +1,30 @@
+package gov.hhs.cdc.trustedintermediary.rse2e.external.hapi
+
+import spock.lang.Specification
+
+class HapiHL7FileMatcherExceptionTest  extends Specification {
+
+    def "two param constructor works"() {
+        given:
+        def message = "something blew up!"
+        def cause = new NullPointerException()
+
+        when:
+        def exception = new HapiHL7FileMatcherException(message, cause)
+
+        then:
+        exception.getMessage() == message
+        exception.getCause() == cause
+    }
+
+    def "single param constructor works"() {
+        given:
+        def message = "something blew up!"
+
+        when:
+        def exception = new HapiHL7FileMatcherException(message)
+
+        then:
+        exception.getMessage() == message
+    }
+}

--- a/rs-e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherTest.groovy
+++ b/rs-e2e/src/test/groovy/gov/hhs/cdc/trustedintermediary/rse2e/external/hapi/HapiHL7FileMatcherTest.groovy
@@ -35,12 +35,15 @@ class HapiHL7FileMatcherTest extends Specification {
         spyFileMatcher.mapMessageByControlId(mockOutputFiles) >> [ "2": mockOutputMessage2, "3": Mock(Message) ]
 
         when:
-        def result = spyFileMatcher.matchFiles(mockOutputFiles, mockInputFiles)
+        spyFileMatcher.matchFiles(mockOutputFiles, mockInputFiles)
 
         then:
-        result.size() == 1
-        result == Map.of(mockInputMessage2, mockOutputMessage2)
-        1 * mockLogger.logError({ it.contains("Found no match") && it.contains("1") && it.contains("3") })
+        def exception = thrown(NoSuchElementException)
+        with(exception.getMessage()) {
+            contains("Found no match")
+            contains("1")
+            contains("3")
+        }
     }
 
     def "should map message by control ID"() {


### PR DESCRIPTION
# Avoid ignoring exceptions in automated tests

- Bubble up exceptions, add context, and let automated test fail
- Throw exception if failed to find matching input or output
- Refactored to simplify logic in `matchFiles`
- Added custom exception `HapiHL7FileMatcherException`

## Issue

#1536 

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added JavaDocs where required
- [x] I have updated the documentation accordingly
