### PR TITLE
Update local TI service URL to be reachable inside docker

### DIFF
--- a/scripts/.env.template
+++ b/scripts/.env.template
@@ -7,7 +7,7 @@ RS_HOME="/path/to/prime-reportstream"
 RS_LCL_API_URL="http://localhost:7071"
 RS_STG_API_URL="https://staging.prime.cdc.gov:443"
 RS_PRD_API_URL="https://prime.cdc.gov:443"
-TI_LCL_API_URL="http://localhost:8080"
+TI_LCL_API_URL="http://host.docker.internal:8080"
 TI_STG_API_URL="https://cdcti-stg-api.azurewebsites.net:443"
 TI_PRD_API_URL="https://cdcti-prd-api.azurewebsites.net:443"
 


### PR DESCRIPTION
Updated `TI_LCL_API_URL` env variable: `localhost` => `host.docker.internal`