### PR TITLE
Azure db memory alert

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -270,7 +270,7 @@ resource "azurerm_monitor_metric_alert" "database_memory_alert" {
 
   criteria {
     metric_name      = "memory_percent"
-    metric_namespace = "microsoft.dbforpostresql/flexibleservers"
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
     aggregation      = "Average"
     operator         = "GreaterThan"
     threshold        = local.higher_environment_level ? 50 : 80


### PR DESCRIPTION
# DB Memory Alert
Adding a static threshold for the database memory usage.  This will alert the team in slack

## Issue

#1401


