### PR TITLE
High CPU alerts for TI app and DB

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -383,7 +383,7 @@ resource "azurerm_monitor_metric_alert" "cpu_alert" {
 
 resource "azurerm_monitor_metric_alert" "database_cpu_alert" {
   count               = local.non_pr_environment ? 1 : 0
-  name                = "cdcti-${var.environment}-db-cpu-alert"
+  name                = "cdcti-${var.environment}-database-cpu-alert"
   resource_group_name = data.azurerm_resource_group.group.name
   scopes              = [azurerm_postgresql_flexible_server.database.id]
   description         = "Alerts when the average CPU usage for the DB is high"

--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -348,7 +348,7 @@ resource "azurerm_monitor_metric_alert" "cpu_alert" {
   description         = "Alerts when the average CPU usage across the service plan is high"
   severity            = 2
   frequency           = "PT1M"
-  window_size         = "PT10M"
+  window_size         = "PT15M"
 
   criteria {
     metric_name      = "CpuPercentage"

--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -340,6 +340,47 @@ resource "azurerm_monitor_metric_alert" "memory_alert" {
   }
 }
 
+resource "azurerm_monitor_metric_alert" "cpu_alert" {
+  count               = local.non_pr_environment ? 1 : 0
+  name                = "cdcti-${var.environment}-cpu-alert"
+  resource_group_name = data.azurerm_resource_group.group.name
+  scopes              = [azurerm_service_plan.plan.id]
+  description         = "Alerts when the average CPU usage across the service plan is high"
+  severity            = 2
+  frequency           = "PT1M"
+  window_size         = "PT10M"
+
+  criteria {
+    metric_name      = "CpuPercentage"
+    metric_namespace = "microsoft.web/serverfarms"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 80 # We autoscale at 75%, so CPU over that means either we've hit the scaling limit or something is wrong with scaling
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.notify_slack_email[count.index].id
+  }
+
+  lifecycle {
+    # Ignore changes to tags because the CDC sets these automagically
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "low_instance_count_alert" {
   count               = local.non_pr_environment ? 1 : 0
   name                = "cdcti-${var.environment}-azure-low-instance-count-alert"

--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -381,6 +381,47 @@ resource "azurerm_monitor_metric_alert" "cpu_alert" {
   }
 }
 
+resource "azurerm_monitor_metric_alert" "database_cpu_alert" {
+  count               = local.non_pr_environment ? 1 : 0
+  name                = "cdcti-${var.environment}-db-cpu-alert"
+  resource_group_name = data.azurerm_resource_group.group.name
+  scopes              = [azurerm_postgresql_flexible_server.database.id]
+  description         = "Alerts when the average CPU usage for the DB is high"
+  severity            = 2
+  frequency           = "PT1M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_name      = "cpu_percent"
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 50
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.notify_slack_email[count.index].id
+  }
+
+  lifecycle {
+    # Ignore changes to tags because the CDC sets these automagically
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
+}
+
 resource "azurerm_monitor_metric_alert" "low_instance_count_alert" {
   count               = local.non_pr_environment ? 1 : 0
   name                = "cdcti-${var.environment}-azure-low-instance-count-alert"


### PR DESCRIPTION
# Description
Add Azure alerts when CDC TI app CPU usage is above 80% (we autoscale before that) and when DB CPU usage is above 50%

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1399

