### PR TITLE
Renovate Ignore `com.azure:azure-identity` 1.14.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
         },
         {
             "matchPackageNames": ["com.azure:azure-identity"],
-            "allowedVersions": "!/^1\\.14\\.0$/"
+            "allowedVersions": "!/^1\\.14\\.[0-1]$/"
         }],
     "pinDigests": false
 }


### PR DESCRIPTION
# Description

Told Renovate to ignore `com.azure:azure-identity` version 1.14.1 in addition to 1.14.0.  The [issue](https://github.com/Azure/azure-sdk-for-java/issues/42310) still hasn't been fixed.

## Issue

_None_.

## Checklist

- [x] I have added tests to cover my changes