### PR TITLE
Rename sent/received submission id to inbound/outbound message id variables

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
@@ -12,10 +12,10 @@ public interface MessageRequestHandler<T> {
     /**
      * Parses the request, converts and sends the message
      *
-     * @param receivedSubmissionId the ID for the submission returned from ReportStream
+     * @param outboundMessageId the ID for the submission returned from ReportStream
      * @return the response
      * @throws FhirParseException if there is an error parsing the FHIR data
      * @throws UnableToSendMessageException if there is an error sending the message
      */
-    T handle(String receivedSubmissionId) throws FhirParseException, UnableToSendMessageException;
+    T handle(String outboundMessageId) throws FhirParseException, UnableToSendMessageException;
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/MessageRequestHandler.java
@@ -12,7 +12,7 @@ public interface MessageRequestHandler<T> {
     /**
      * Parses the request, converts and sends the message
      *
-     * @param outboundMessageId the ID for the submission returned from ReportStream
+     * @param outboundMessageId the ID for the outbound message returned from ReportStream
      * @return the response
      * @throws FhirParseException if there is an error parsing the FHIR data
      * @throws UnableToSendMessageException if there is an error sending the message

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
@@ -21,14 +21,14 @@ public class SendMessageHelper {
 
     private SendMessageHelper() {}
 
-    public void savePartnerMetadataForReceivedMessage(PartnerMetadata partnerMetadata) {
+    public void savePartnerMetadataForOutboundMessage(PartnerMetadata partnerMetadata) {
         if (partnerMetadata.outboundMessageId() == null) {
             logger.logWarning(
-                    "Received submissionId is null so not saving metadata for received message");
+                    "Outbound messageId is null so not saving metadata for outbound message");
             return;
         }
         try {
-            partnerMetadataOrchestrator.updateMetadataForReceivedMessage(partnerMetadata);
+            partnerMetadataOrchestrator.updateMetadataForOutboundMessage(partnerMetadata);
         } catch (PartnerMetadataException e) {
             logger.logError(
                     "Unable to save metadata for outboundMessageId "
@@ -37,15 +37,15 @@ public class SendMessageHelper {
         }
     }
 
-    public void saveSentMessageSubmissionId(String outboundMessageId, String inboundMessageId) {
+    public void saveInboundMessageId(String outboundMessageId, String inboundMessageId) {
         if (inboundMessageId == null || outboundMessageId == null) {
             logger.logWarning(
-                    "Received and/or sent submissionId is null so not saving metadata for sent result");
+                    "Outbound and/or inbound messageId is null so not saving metadata for sent result");
             return;
         }
 
         try {
-            partnerMetadataOrchestrator.updateMetadataForSentMessage(
+            partnerMetadataOrchestrator.updateMetadataForInboundMessage(
                     outboundMessageId, inboundMessageId);
         } catch (PartnerMetadataException e) {
             logger.logError(
@@ -59,7 +59,7 @@ public class SendMessageHelper {
 
     public void linkMessage(String outboundMessageId) {
         if (outboundMessageId == null) {
-            logger.logWarning("Received submissionId is null so not linking messages");
+            logger.logWarning("Outbound messageId is null so not linking messages");
             return;
         }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
@@ -49,9 +49,9 @@ public class SendMessageHelper {
                     outboundMessageId, inboundMessageId);
         } catch (PartnerMetadataException e) {
             logger.logError(
-                    "Unable to update metadata for received submissionId "
+                    "Unable to update metadata for outbound messageId "
                             + outboundMessageId
-                            + " and sent submissionId "
+                            + " and inbound messageId "
                             + inboundMessageId,
                     e);
         }
@@ -81,7 +81,7 @@ public class SendMessageHelper {
             partnerMetadataOrchestrator.linkMessages(messageIdsToLink);
         } catch (PartnerMetadataException | MessageLinkException e) {
             logger.logError(
-                    "Unable to link messages for received submissionId " + outboundMessageId, e);
+                    "Unable to link messages for outbound messageId " + outboundMessageId, e);
         }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
@@ -22,7 +22,7 @@ public class SendMessageHelper {
     private SendMessageHelper() {}
 
     public void savePartnerMetadataForReceivedMessage(PartnerMetadata partnerMetadata) {
-        if (partnerMetadata.receivedSubmissionId() == null) {
+        if (partnerMetadata.outboundMessageId() == null) {
             logger.logWarning(
                     "Received submissionId is null so not saving metadata for received message");
             return;
@@ -31,14 +31,14 @@ public class SendMessageHelper {
             partnerMetadataOrchestrator.updateMetadataForReceivedMessage(partnerMetadata);
         } catch (PartnerMetadataException e) {
             logger.logError(
-                    "Unable to save metadata for receivedSubmissionId "
-                            + partnerMetadata.receivedSubmissionId(),
+                    "Unable to save metadata for outboundMessageId "
+                            + partnerMetadata.outboundMessageId(),
                     e);
         }
     }
 
-    public void saveSentMessageSubmissionId(String receivedSubmissionId, String inboundMessageId) {
-        if (inboundMessageId == null || receivedSubmissionId == null) {
+    public void saveSentMessageSubmissionId(String outboundMessageId, String inboundMessageId) {
+        if (inboundMessageId == null || outboundMessageId == null) {
             logger.logWarning(
                     "Received and/or sent submissionId is null so not saving metadata for sent result");
             return;
@@ -46,42 +46,42 @@ public class SendMessageHelper {
 
         try {
             partnerMetadataOrchestrator.updateMetadataForSentMessage(
-                    receivedSubmissionId, inboundMessageId);
+                    outboundMessageId, inboundMessageId);
         } catch (PartnerMetadataException e) {
             logger.logError(
                     "Unable to update metadata for received submissionId "
-                            + receivedSubmissionId
+                            + outboundMessageId
                             + " and sent submissionId "
                             + inboundMessageId,
                     e);
         }
     }
 
-    public void linkMessage(String receivedSubmissionId) {
-        if (receivedSubmissionId == null) {
+    public void linkMessage(String outboundMessageId) {
+        if (outboundMessageId == null) {
             logger.logWarning("Received submissionId is null so not linking messages");
             return;
         }
 
         try {
             Set<String> messageIdsToLink =
-                    partnerMetadataOrchestrator.findMessagesIdsToLink(receivedSubmissionId);
+                    partnerMetadataOrchestrator.findMessagesIdsToLink(outboundMessageId);
 
             if (messageIdsToLink == null || messageIdsToLink.isEmpty()) {
                 return;
             }
 
-            // Add receivedSubmissionId to complete the list of messageIds to link
-            messageIdsToLink.add(receivedSubmissionId);
+            // Add outboundMessageId to complete the list of messageIds to link
+            messageIdsToLink.add(outboundMessageId);
 
             logger.logInfo(
-                    "Found messages to link for receivedSubmissionId {}: {}",
-                    receivedSubmissionId,
+                    "Found messages to link for outboundMessageId {}: {}",
+                    outboundMessageId,
                     messageIdsToLink);
             partnerMetadataOrchestrator.linkMessages(messageIdsToLink);
         } catch (PartnerMetadataException | MessageLinkException e) {
             logger.logError(
-                    "Unable to link messages for received submissionId " + receivedSubmissionId, e);
+                    "Unable to link messages for received submissionId " + outboundMessageId, e);
         }
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelper.java
@@ -37,8 +37,8 @@ public class SendMessageHelper {
         }
     }
 
-    public void saveSentMessageSubmissionId(String receivedSubmissionId, String sentSubmissionId) {
-        if (sentSubmissionId == null || receivedSubmissionId == null) {
+    public void saveSentMessageSubmissionId(String receivedSubmissionId, String inboundMessageId) {
+        if (inboundMessageId == null || receivedSubmissionId == null) {
             logger.logWarning(
                     "Received and/or sent submissionId is null so not saving metadata for sent result");
             return;
@@ -46,13 +46,13 @@ public class SendMessageHelper {
 
         try {
             partnerMetadataOrchestrator.updateMetadataForSentMessage(
-                    receivedSubmissionId, sentSubmissionId);
+                    receivedSubmissionId, inboundMessageId);
         } catch (PartnerMetadataException e) {
             logger.logError(
                     "Unable to update metadata for received submissionId "
                             + receivedSubmissionId
                             + " and sent submissionId "
-                            + sentSubmissionId,
+                            + inboundMessageId,
                     e);
         }
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  * The partner-facing metadata.
  *
  * @param receivedSubmissionId The received submission ID.
- * @param sentSubmissionId The sent submission ID.
+ * @param inboundMessageId The outbound submission ID.
  * @param timeReceived The time the message was received.
  * @param timeDelivered The time the message was delivered.
  * @param hash The hash of the message.
@@ -15,7 +15,7 @@ import java.time.Instant;
  */
 public record PartnerMetadata(
         String receivedSubmissionId,
-        String sentSubmissionId,
+        String inboundMessageId,
         Instant timeReceived,
         Instant timeDelivered,
         String hash,
@@ -77,10 +77,10 @@ public record PartnerMetadata(
                 null);
     }
 
-    public PartnerMetadata withSentSubmissionId(String sentSubmissionId) {
+    public PartnerMetadata withInboundMessageId(String inboundMessageId) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
-                sentSubmissionId,
+                inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -97,7 +97,7 @@ public record PartnerMetadata(
     public PartnerMetadata withTimeReceived(Instant timeReceived) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
-                this.sentSubmissionId,
+                this.inboundMessageId,
                 timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -114,7 +114,7 @@ public record PartnerMetadata(
     public PartnerMetadata withTimeDelivered(Instant timeDelivered) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
-                this.sentSubmissionId,
+                this.inboundMessageId,
                 this.timeReceived,
                 timeDelivered,
                 this.hash,
@@ -131,7 +131,7 @@ public record PartnerMetadata(
     public PartnerMetadata withDeliveryStatus(PartnerMetadataStatus deliveryStatus) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
-                this.sentSubmissionId,
+                this.inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,
@@ -148,7 +148,7 @@ public record PartnerMetadata(
     public PartnerMetadata withFailureMessage(String failureMessage) {
         return new PartnerMetadata(
                 this.receivedSubmissionId,
-                this.sentSubmissionId,
+                this.inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,
                 this.hash,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 /**
  * The partner-facing metadata.
  *
- * @param receivedSubmissionId The received submission ID.
+ * @param outboundMessageId The received submission ID.
  * @param inboundMessageId The inbound submission ID.
  * @param timeReceived The time the message was received.
  * @param timeDelivered The time the message was delivered.
@@ -14,7 +14,7 @@ import java.time.Instant;
  * @param deliveryStatus the status of the message based on an enum
  */
 public record PartnerMetadata(
-        String receivedSubmissionId,
+        String outboundMessageId,
         String inboundMessageId,
         Instant timeReceived,
         Instant timeDelivered,
@@ -36,7 +36,7 @@ public record PartnerMetadata(
     }
 
     public PartnerMetadata(
-            String receivedSubmissionId,
+            String outboundMessageId,
             String hash,
             PartnerMetadataMessageType messageType,
             MessageHdDataType sendingApplicationDetails,
@@ -45,7 +45,7 @@ public record PartnerMetadata(
             MessageHdDataType receivingFacilityDetails,
             String placerOrderNumber) {
         this(
-                receivedSubmissionId,
+                outboundMessageId,
                 null,
                 null,
                 null,
@@ -60,9 +60,9 @@ public record PartnerMetadata(
                 placerOrderNumber);
     }
 
-    public PartnerMetadata(String receivedSubmissionId, PartnerMetadataStatus deliveryStatus) {
+    public PartnerMetadata(String outboundMessageId, PartnerMetadataStatus deliveryStatus) {
         this(
-                receivedSubmissionId,
+                outboundMessageId,
                 null,
                 null,
                 null,
@@ -79,7 +79,7 @@ public record PartnerMetadata(
 
     public PartnerMetadata withInboundMessageId(String inboundMessageId) {
         return new PartnerMetadata(
-                this.receivedSubmissionId,
+                this.outboundMessageId,
                 inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,
@@ -96,7 +96,7 @@ public record PartnerMetadata(
 
     public PartnerMetadata withTimeReceived(Instant timeReceived) {
         return new PartnerMetadata(
-                this.receivedSubmissionId,
+                this.outboundMessageId,
                 this.inboundMessageId,
                 timeReceived,
                 this.timeDelivered,
@@ -113,7 +113,7 @@ public record PartnerMetadata(
 
     public PartnerMetadata withTimeDelivered(Instant timeDelivered) {
         return new PartnerMetadata(
-                this.receivedSubmissionId,
+                this.outboundMessageId,
                 this.inboundMessageId,
                 this.timeReceived,
                 timeDelivered,
@@ -130,7 +130,7 @@ public record PartnerMetadata(
 
     public PartnerMetadata withDeliveryStatus(PartnerMetadataStatus deliveryStatus) {
         return new PartnerMetadata(
-                this.receivedSubmissionId,
+                this.outboundMessageId,
                 this.inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,
@@ -147,7 +147,7 @@ public record PartnerMetadata(
 
     public PartnerMetadata withFailureMessage(String failureMessage) {
         return new PartnerMetadata(
-                this.receivedSubmissionId,
+                this.outboundMessageId,
                 this.inboundMessageId,
                 this.timeReceived,
                 this.timeDelivered,

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -6,8 +6,8 @@ import java.time.Instant;
 /**
  * The partner-facing metadata.
  *
- * @param outboundMessageId The received submission ID.
- * @param inboundMessageId The inbound submission ID.
+ * @param outboundMessageId The outbound message ID.
+ * @param inboundMessageId The inbound message ID.
  * @param timeReceived The time the message was received.
  * @param timeDelivered The time the message was delivered.
  * @param hash The hash of the message.

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadata.java
@@ -7,7 +7,7 @@ import java.time.Instant;
  * The partner-facing metadata.
  *
  * @param receivedSubmissionId The received submission ID.
- * @param inboundMessageId The outbound submission ID.
+ * @param inboundMessageId The inbound submission ID.
  * @param timeReceived The time the message was received.
  * @param timeDelivered The time the message was delivered.
  * @param hash The hash of the message.

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -80,7 +80,7 @@ public class PartnerMetadataOrchestrator {
             // write the received submission ID so that the rest of the metadata flow works even if
             // some data is missing
             logger.logWarning(
-                    "Unable to retrieve metadata from RS delivery API, but writing basic metadata entry anyway for received submission ID {}",
+                    "Unable to retrieve metadata from RS delivery API, but writing basic metadata entry anyway for outbound message ID {}",
                     partnerMetadata.outboundMessageId());
             partnerMetadataStorage.saveMetadata(partnerMetadata);
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -45,15 +45,15 @@ public class PartnerMetadataOrchestrator {
             throws PartnerMetadataException {
 
         logger.logInfo(
-                "Looking up sender name and timeReceived from RS delivery API for receivedSubmissionId: {}",
-                partnerMetadata.receivedSubmissionId());
+                "Looking up sender name and timeReceived from RS delivery API for outboundMessageId: {}",
+                partnerMetadata.outboundMessageId());
 
         Instant timeReceived;
         try {
             String bearerToken = rsclient.getRsToken();
             String responseBody =
                     rsclient.requestDeliveryEndpoint(
-                            partnerMetadata.receivedSubmissionId(), bearerToken);
+                            partnerMetadata.outboundMessageId(), bearerToken);
             Map<String, Object> responseObject =
                     formatter.convertJsonToObject(responseBody, new TypeReference<>() {});
 
@@ -81,7 +81,7 @@ public class PartnerMetadataOrchestrator {
             // some data is missing
             logger.logWarning(
                     "Unable to retrieve metadata from RS delivery API, but writing basic metadata entry anyway for received submission ID {}",
-                    partnerMetadata.receivedSubmissionId());
+                    partnerMetadata.outboundMessageId());
             partnerMetadataStorage.saveMetadata(partnerMetadata);
 
             throw new PartnerMetadataException(
@@ -93,7 +93,7 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(updatedPartnerMetadata);
     }
 
-    public void updateMetadataForSentMessage(String receivedSubmissionId, String inboundMessageId)
+    public void updateMetadataForSentMessage(String outboundMessageId, String inboundMessageId)
             throws PartnerMetadataException {
 
         if (inboundMessageId == null) {
@@ -101,10 +101,9 @@ public class PartnerMetadataOrchestrator {
         }
 
         Optional<PartnerMetadata> optionalPartnerMetadata =
-                partnerMetadataStorage.readMetadata(receivedSubmissionId);
+                partnerMetadataStorage.readMetadata(outboundMessageId);
         if (optionalPartnerMetadata.isEmpty()) {
-            logger.logWarning(
-                    "Metadata not found for receivedSubmissionId: {}", receivedSubmissionId);
+            logger.logWarning("Metadata not found for outboundMessageId: {}", outboundMessageId);
             return;
         }
 
@@ -119,12 +118,12 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
-    public Optional<PartnerMetadata> getMetadata(String receivedSubmissionId)
+    public Optional<PartnerMetadata> getMetadata(String outboundMessageId)
             throws PartnerMetadataException {
         Optional<PartnerMetadata> optionalPartnerMetadata =
-                partnerMetadataStorage.readMetadata(receivedSubmissionId);
+                partnerMetadataStorage.readMetadata(outboundMessageId);
         if (optionalPartnerMetadata.isEmpty()) {
-            logger.logInfo("Metadata not found for receivedSubmissionId: {}", receivedSubmissionId);
+            logger.logInfo("Metadata not found for outboundMessageId: {}", outboundMessageId);
             return Optional.empty();
         }
 
@@ -206,7 +205,7 @@ public class PartnerMetadataOrchestrator {
         return metadataSet.stream()
                 .collect(
                         Collectors.toMap(
-                                PartnerMetadata::receivedSubmissionId,
+                                PartnerMetadata::outboundMessageId,
                                 metadata -> {
                                     var status = String.valueOf(metadata.deliveryStatus());
                                     var stale = metadataIsStale(metadata);
@@ -221,10 +220,10 @@ public class PartnerMetadataOrchestrator {
                                 }));
     }
 
-    public Set<String> findMessagesIdsToLink(String receivedSubmissionId)
+    public Set<String> findMessagesIdsToLink(String outboundMessageId)
             throws PartnerMetadataException {
 
-        return partnerMetadataStorage.readMetadataForMessageLinking(receivedSubmissionId);
+        return partnerMetadataStorage.readMetadataForMessageLinking(outboundMessageId);
     }
 
     public void linkMessages(Set<String> messageIds) throws MessageLinkException {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -93,10 +93,10 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(updatedPartnerMetadata);
     }
 
-    public void updateMetadataForSentMessage(String receivedSubmissionId, String sentSubmissionId)
+    public void updateMetadataForSentMessage(String receivedSubmissionId, String inboundMessageId)
             throws PartnerMetadataException {
 
-        if (sentSubmissionId == null) {
+        if (inboundMessageId == null) {
             return;
         }
 
@@ -110,12 +110,12 @@ public class PartnerMetadataOrchestrator {
 
         PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();
 
-        if (sentSubmissionId.equals(partnerMetadata.sentSubmissionId())) {
+        if (inboundMessageId.equals(partnerMetadata.inboundMessageId())) {
             return;
         }
 
-        logger.logInfo("Updating metadata with sentSubmissionId: {}", sentSubmissionId);
-        partnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId);
+        logger.logInfo("Updating metadata with inboundMessageId: {}", inboundMessageId);
+        partnerMetadata = partnerMetadata.withInboundMessageId(inboundMessageId);
         partnerMetadataStorage.saveMetadata(partnerMetadata);
     }
 
@@ -129,11 +129,11 @@ public class PartnerMetadataOrchestrator {
         }
 
         PartnerMetadata partnerMetadata = optionalPartnerMetadata.get();
-        var sentSubmissionId = partnerMetadata.sentSubmissionId();
-        if (metadataIsStale(partnerMetadata) && sentSubmissionId != null) {
+        var inboundMessageId = partnerMetadata.inboundMessageId();
+        if (metadataIsStale(partnerMetadata) && inboundMessageId != null) {
             logger.logInfo(
                     "Receiver name not found in metadata or delivery status still pending, looking up {} from RS history API",
-                    sentSubmissionId);
+                    inboundMessageId);
 
             String rsStatus;
             String rsMessage = "";
@@ -141,7 +141,7 @@ public class PartnerMetadataOrchestrator {
             try {
                 String bearerToken = rsclient.getRsToken();
                 String responseBody =
-                        rsclient.requestHistoryEndpoint(sentSubmissionId, bearerToken);
+                        rsclient.requestHistoryEndpoint(inboundMessageId, bearerToken);
                 var parsedResponseBody = getDataFromReportStream(responseBody);
                 rsStatus = parsedResponseBody[0];
                 rsMessage = parsedResponseBody[1];

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestrator.java
@@ -41,7 +41,7 @@ public class PartnerMetadataOrchestrator {
 
     private PartnerMetadataOrchestrator() {}
 
-    public void updateMetadataForReceivedMessage(PartnerMetadata partnerMetadata)
+    public void updateMetadataForOutboundMessage(PartnerMetadata partnerMetadata)
             throws PartnerMetadataException {
 
         logger.logInfo(
@@ -93,7 +93,7 @@ public class PartnerMetadataOrchestrator {
         partnerMetadataStorage.saveMetadata(updatedPartnerMetadata);
     }
 
-    public void updateMetadataForSentMessage(String outboundMessageId, String inboundMessageId)
+    public void updateMetadataForInboundMessage(String outboundMessageId, String inboundMessageId)
             throws PartnerMetadataException {
 
         if (inboundMessageId == null) {

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataStorage.java
@@ -9,10 +9,10 @@ public interface PartnerMetadataStorage {
     /**
      * This method will retrieve and return the metadata for the given submissionId, if it exists.
      *
-     * @param receivedSubmissionId The submission Id to read the metadata for.
+     * @param outboundMessageId The outbound id to read the metadata for.
      * @return The metadata, if it exists. Otherwise, an empty Optional.
      */
-    Optional<PartnerMetadata> readMetadata(String receivedSubmissionId)
+    Optional<PartnerMetadata> readMetadata(String outboundMessageId)
             throws PartnerMetadataException;
 
     /**

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -40,7 +40,7 @@ public class SendOrderUseCase implements SendMessageUseCase<Order<?>> {
                         order.getReceivingFacilityDetails(),
                         order.getPlacerOrderNumber());
 
-        sendMessageHelper.savePartnerMetadataForReceivedMessage(partnerMetadata);
+        sendMessageHelper.savePartnerMetadataForOutboundMessage(partnerMetadata);
 
         transformationEngine.runRules(order);
 
@@ -49,6 +49,6 @@ public class SendOrderUseCase implements SendMessageUseCase<Order<?>> {
 
         sendMessageHelper.linkMessage(outboundMessageId);
 
-        sendMessageHelper.saveSentMessageSubmissionId(outboundMessageId, outboundReportId);
+        sendMessageHelper.saveInboundMessageId(outboundMessageId, outboundReportId);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCase.java
@@ -26,12 +26,12 @@ public class SendOrderUseCase implements SendMessageUseCase<Order<?>> {
     }
 
     @Override
-    public void convertAndSend(final Order<?> order, String receivedSubmissionId)
+    public void convertAndSend(final Order<?> order, String outboundMessageId)
             throws UnableToSendMessageException {
 
         PartnerMetadata partnerMetadata =
                 new PartnerMetadata(
-                        receivedSubmissionId,
+                        outboundMessageId,
                         String.valueOf(order.hashCode()),
                         PartnerMetadataMessageType.ORDER,
                         order.getSendingApplicationDetails(),
@@ -47,8 +47,8 @@ public class SendOrderUseCase implements SendMessageUseCase<Order<?>> {
         String outboundReportId = sender.send(order).orElse(null);
         logger.logInfo("Sent order reportId: {}", outboundReportId);
 
-        sendMessageHelper.linkMessage(receivedSubmissionId);
+        sendMessageHelper.linkMessage(outboundMessageId);
 
-        sendMessageHelper.saveSentMessageSubmissionId(receivedSubmissionId, outboundReportId);
+        sendMessageHelper.saveSentMessageSubmissionId(outboundMessageId, outboundReportId);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
@@ -27,12 +27,12 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
     }
 
     @Override
-    public void convertAndSend(Result<?> result, String receivedSubmissionId)
+    public void convertAndSend(Result<?> result, String outboundMessageId)
             throws UnableToSendMessageException {
 
         PartnerMetadata partnerMetadata =
                 new PartnerMetadata(
-                        receivedSubmissionId,
+                        outboundMessageId,
                         String.valueOf(result.hashCode()),
                         PartnerMetadataMessageType.RESULT,
                         result.getSendingApplicationDetails(),
@@ -48,8 +48,8 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
         String outboundReportId = sender.send(result).orElse(null);
         logger.logInfo("Sent result reportId: {}", outboundReportId);
 
-        sendMessageHelper.linkMessage(receivedSubmissionId);
+        sendMessageHelper.linkMessage(outboundMessageId);
 
-        sendMessageHelper.saveSentMessageSubmissionId(receivedSubmissionId, outboundReportId);
+        sendMessageHelper.saveSentMessageSubmissionId(outboundMessageId, outboundReportId);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCase.java
@@ -41,7 +41,7 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
                         result.getReceivingFacilityDetails(),
                         result.getPlacerOrderNumber());
 
-        sendMessageHelper.savePartnerMetadataForReceivedMessage(partnerMetadata);
+        sendMessageHelper.savePartnerMetadataForOutboundMessage(partnerMetadata);
 
         transformationEngine.runRules(result);
 
@@ -50,6 +50,6 @@ public class SendResultUseCase implements SendMessageUseCase<Result<?>> {
 
         sendMessageHelper.linkMessage(outboundMessageId);
 
-        sendMessageHelper.saveSentMessageSubmissionId(outboundMessageId, outboundReportId);
+        sendMessageHelper.saveInboundMessageId(outboundMessageId, outboundReportId);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -203,7 +203,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
         return List.of(
                 new DbColumn(
                         METADATA_TABLE_RECEIVED_MESSAGE_ID,
-                        metadata.receivedSubmissionId(),
+                        metadata.outboundMessageId(),
                         false,
                         Types.VARCHAR),
                 new DbColumn("sent_message_id", metadata.inboundMessageId(), true, Types.VARCHAR),

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorage.java
@@ -206,7 +206,7 @@ public class DatabasePartnerMetadataStorage implements PartnerMetadataStorage {
                         metadata.receivedSubmissionId(),
                         false,
                         Types.VARCHAR),
-                new DbColumn("sent_message_id", metadata.sentSubmissionId(), true, Types.VARCHAR),
+                new DbColumn("sent_message_id", metadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", metadata.hash(), false, Types.VARCHAR),
                 new DbColumn(
                         "time_received",

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
@@ -76,7 +76,7 @@ public class HapiPartnerMetadataConverter implements PartnerMetadataConverter {
                 .getIssue()
                 .add(
                         createInformationIssueComponent(
-                                "outbound submission id", metadata.sentSubmissionId()));
+                                "outbound submission id", metadata.inboundMessageId()));
 
         operation
                 .getIssue()

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiPartnerMetadataConverter.java
@@ -82,7 +82,7 @@ public class HapiPartnerMetadataConverter implements PartnerMetadataConverter {
                 .getIssue()
                 .add(
                         createInformationIssueComponent(
-                                "inbound submission id", metadata.receivedSubmissionId()));
+                                "inbound submission id", metadata.outboundMessageId()));
 
         return new HapiFhirMetadata(operation);
     }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -139,7 +139,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
                     .collect(Collectors.toSet());
         } catch (Exception e) {
             throw new PartnerMetadataException(
-                    "Failed reading metadata for submissionId: " + outboundMessageId, e);
+                    "Failed reading metadata for messageId: " + outboundMessageId, e);
         }
     }
 

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorage.java
@@ -76,7 +76,7 @@ public class FilePartnerMetadataStorage implements PartnerMetadataStorage {
         }
 
         Path metadataFilePath =
-                getFilePath(metadata.receivedSubmissionId() + "-" + metadata.sentSubmissionId());
+                getFilePath(metadata.receivedSubmissionId() + "-" + metadata.inboundMessageId());
         try {
             String content = formatter.convertToJsonString(metadata);
             Files.writeString(metadataFilePath, content);

--- a/etor/src/main/resources/openapi_etor.yaml
+++ b/etor/src/main/resources/openapi_etor.yaml
@@ -149,7 +149,7 @@ components:
     ConsolidatedMetadata:
       type: map<string, map<string, object>>
       properties:
-        receivedSubmissionId:
+        outboundMessageId:
           type: string
           properties:
             value:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -171,15 +171,15 @@ class EtorDomainRegistrationTest extends Specification {
     def "metadata endpoint happy path"() {
         given:
         def expectedStatusCode = 200
-        def receivedSubmissionId = "receivedSubmissionId"
-        def metadata = new PartnerMetadata("receivedSubmissionId", "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
-        def linkedMessageIds = Set.of(receivedSubmissionId, "Test1", "Test2")
+        def outboundMessageId = "outboundMessageId"
+        def metadata = new PartnerMetadata("outboundMessageId", "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
+        def linkedMessageIds = Set.of(outboundMessageId, "Test1", "Test2")
 
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
 
         def request = new DomainRequest()
-        request.setPathParams(["id": receivedSubmissionId])
+        request.setPathParams(["id": outboundMessageId])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
@@ -202,8 +202,8 @@ class EtorDomainRegistrationTest extends Specification {
 
         then:
         actualStatusCode == expectedStatusCode
-        1 * mockPartnerMetadataOrchestrator.getMetadata(receivedSubmissionId) >> Optional.ofNullable(metadata)
-        1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> linkedMessageIds
+        1 * mockPartnerMetadataOrchestrator.getMetadata(outboundMessageId) >> Optional.ofNullable(metadata)
+        1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(outboundMessageId) >> linkedMessageIds
         1 * mockPartnerMetadataConverter.extractPublicMetadataToOperationOutcome(_ as PartnerMetadata, _ as String, linkedMessageIds) >> Mock(FhirMetadata)
         1 * mockResponseHelper.constructOkResponseFromString(_ as String) >> new DomainResponse(expectedStatusCode)
     }
@@ -211,10 +211,10 @@ class EtorDomainRegistrationTest extends Specification {
     def "metadata endpoint returns metadata even when the submitted ID is different from ID used for linking"() {
         given:
         def expectedStatusCode = 200
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def inboundMessageId = "inboundMessageId"
-        def metadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number").withInboundMessageId(inboundMessageId)
-        def linkedMessageIds = Set.of(receivedSubmissionId, "Test1", "Test2")
+        def metadata = new PartnerMetadata(outboundMessageId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number").withInboundMessageId(inboundMessageId)
+        def linkedMessageIds = Set.of(outboundMessageId, "Test1", "Test2")
 
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
@@ -244,7 +244,7 @@ class EtorDomainRegistrationTest extends Specification {
         then:
         actualStatusCode == expectedStatusCode
         1 * mockPartnerMetadataOrchestrator.getMetadata(inboundMessageId) >> Optional.ofNullable(metadata)
-        1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> linkedMessageIds
+        1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(outboundMessageId) >> linkedMessageIds
         1 * mockPartnerMetadataConverter.extractPublicMetadataToOperationOutcome(_ as PartnerMetadata, _ as String, linkedMessageIds) >> Mock(FhirMetadata)
         1 * mockResponseHelper.constructOkResponseFromString(_ as String) >> new DomainResponse(expectedStatusCode)
     }
@@ -430,7 +430,7 @@ class EtorDomainRegistrationTest extends Specification {
         2 * mockLogger.logError(_ as String, _ as Exception)
     }
 
-    def "handleMessageRequest logs an error and continues when the receivedSubmissionId is missing or empty because we want to know when our integration with RS is broken"() {
+    def "handleMessageRequest logs an error and continues when the outboundMessageId is missing or empty because we want to know when our integration with RS is broken"() {
         given:
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/EtorDomainRegistrationTest.groovy
@@ -212,15 +212,15 @@ class EtorDomainRegistrationTest extends Specification {
         given:
         def expectedStatusCode = 200
         def receivedSubmissionId = "receivedSubmissionId"
-        def sentSubmissionId = "sentSubmissionId"
-        def metadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number").withSentSubmissionId(sentSubmissionId)
+        def inboundMessageId = "inboundMessageId"
+        def metadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number").withInboundMessageId(inboundMessageId)
         def linkedMessageIds = Set.of(receivedSubmissionId, "Test1", "Test2")
 
         def connector = new EtorDomainRegistration()
         TestApplicationContext.register(EtorDomainRegistration, connector)
 
         def request = new DomainRequest()
-        request.setPathParams(["id": sentSubmissionId])
+        request.setPathParams(["id": inboundMessageId])
 
         def mockPartnerMetadataOrchestrator = Mock(PartnerMetadataOrchestrator)
         TestApplicationContext.register(PartnerMetadataOrchestrator, mockPartnerMetadataOrchestrator)
@@ -243,7 +243,7 @@ class EtorDomainRegistrationTest extends Specification {
 
         then:
         actualStatusCode == expectedStatusCode
-        1 * mockPartnerMetadataOrchestrator.getMetadata(sentSubmissionId) >> Optional.ofNullable(metadata)
+        1 * mockPartnerMetadataOrchestrator.getMetadata(inboundMessageId) >> Optional.ofNullable(metadata)
         1 * mockPartnerMetadataOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> linkedMessageIds
         1 * mockPartnerMetadataConverter.extractPublicMetadataToOperationOutcome(_ as PartnerMetadata, _ as String, linkedMessageIds) >> Mock(FhirMetadata)
         1 * mockResponseHelper.constructOkResponseFromString(_ as String) >> new DomainResponse(expectedStatusCode)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
@@ -44,7 +44,7 @@ class SendMessageHelperTest extends Specification {
         1 * mockOrchestrator.updateMetadataForReceivedMessage(_)
     }
 
-    def "savePartnerMetadataForReceivedMessage should log warnings for null receivedSubmissionId"() {
+    def "savePartnerMetadataForReceivedMessage should log warnings for null outboundMessageId"() {
         when:
         PartnerMetadata warningPartnerMetadata = new PartnerMetadata(
                 null,
@@ -77,22 +77,22 @@ class SendMessageHelperTest extends Specification {
     def "saveSentMessageSubmissionId works"() {
         given:
         def inboundMessageId = "sentId" // TODO - figure out if this value matters
-        def receivedSubmissionId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def outboundMessageId = "receivedId"
+        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, inboundMessageId)
+        SendMessageHelper.getInstance().saveSentMessageSubmissionId(outboundMessageId, inboundMessageId)
 
         then:
         1 * mockOrchestrator.updateMetadataForSentMessage(_, _)
     }
 
-    def "saveSentMessageSubmissionId should log warnings for null receivedSubmissionId"() {
+    def "saveSentMessageSubmissionId should log warnings for null outboundMessageId"() {
         given:
-        def receivedSubmissionId = "receivedId"
+        def outboundMessageId = "receivedId"
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(null, receivedSubmissionId)
+        SendMessageHelper.getInstance().saveSentMessageSubmissionId(null, outboundMessageId)
 
         then:
         1 * mockLogger.logWarning(_)
@@ -101,11 +101,11 @@ class SendMessageHelperTest extends Specification {
     def "saveSentMessageSubmissionId should log error and continues when updateMetadataForSentMessage throws error"() {
         given:
         def inboundMessageId = "sentId" // TODO - figure out if this value matters
-        def receivedSubmissionId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def outboundMessageId = "receivedId"
+        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, inboundMessageId)
+        SendMessageHelper.getInstance().saveSentMessageSubmissionId(outboundMessageId, inboundMessageId)
 
         then:
         1 * mockLogger.logError(_, _)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
@@ -76,12 +76,12 @@ class SendMessageHelperTest extends Specification {
 
     def "saveSentMessageSubmissionId works"() {
         given:
-        def sentSubmissionId = "sentId"
+        def inboundMessageId = "sentId" // TODO - figure out if this value matters
         def receivedSubmissionId = "receivedId"
         mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, sentSubmissionId)
+        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, inboundMessageId)
 
         then:
         1 * mockOrchestrator.updateMetadataForSentMessage(_, _)
@@ -100,12 +100,12 @@ class SendMessageHelperTest extends Specification {
 
     def "saveSentMessageSubmissionId should log error and continues when updateMetadataForSentMessage throws error"() {
         given:
-        def sentSubmissionId = "sentId"
+        def inboundMessageId = "sentId" // TODO - figure out if this value matters
         def receivedSubmissionId = "receivedId"
         mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, sentSubmissionId)
+        SendMessageHelper.getInstance().saveSentMessageSubmissionId(receivedSubmissionId, inboundMessageId)
 
         then:
         1 * mockLogger.logError(_, _)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/messages/SendMessageHelperTest.groovy
@@ -27,7 +27,7 @@ class SendMessageHelperTest extends Specification {
         TestApplicationContext.register(Logger, mockLogger)
         TestApplicationContext.injectRegisteredImplementations()
         partnerMetadata = new PartnerMetadata(
-                "receivedId",
+                "outboundId",
                 new Random().nextInt().toString(),
                 PartnerMetadataMessageType.RESULT,
                 sendingApp,
@@ -36,15 +36,15 @@ class SendMessageHelperTest extends Specification {
                 receivingFacility,
                 placerOrderNumber)
     }
-    def "savePartnerMetadataForReceivedMessage works"() {
+    def "savePartnerMetadataForOutboundMessage works"() {
         when:
-        SendMessageHelper.getInstance().savePartnerMetadataForReceivedMessage(partnerMetadata)
+        SendMessageHelper.getInstance().savePartnerMetadataForOutboundMessage(partnerMetadata)
 
         then:
-        1 * mockOrchestrator.updateMetadataForReceivedMessage(_)
+        1 * mockOrchestrator.updateMetadataForOutboundMessage(_)
     }
 
-    def "savePartnerMetadataForReceivedMessage should log warnings for null outboundMessageId"() {
+    def "savePartnerMetadataForOutboundMessage should log warnings for null outboundMessageId"() {
         when:
         PartnerMetadata warningPartnerMetadata = new PartnerMetadata(
                 null,
@@ -55,57 +55,57 @@ class SendMessageHelperTest extends Specification {
                 receivingApp,
                 receivingFacility,
                 placerOrderNumber)
-        SendMessageHelper.getInstance().savePartnerMetadataForReceivedMessage(warningPartnerMetadata)
+        SendMessageHelper.getInstance().savePartnerMetadataForOutboundMessage(warningPartnerMetadata)
 
         then:
         1 * mockLogger.logWarning(_)
     }
 
-    def "savePartnerMetadataForReceivedMessage logs error and continues when updateMetadataForReceivedMessage throws error"() {
+    def "savePartnerMetadataForOutboundMessage logs error and continues when updateMetadataForOutboundMessage throws error"() {
         given:
         def hashCode = new Random().nextInt()
         def messageType = PartnerMetadataMessageType.RESULT
-        mockOrchestrator.updateMetadataForReceivedMessage(partnerMetadata) >> { throw new PartnerMetadataException("Error") }
+        mockOrchestrator.updateMetadataForOutboundMessage(partnerMetadata) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().savePartnerMetadataForReceivedMessage(partnerMetadata)
+        SendMessageHelper.getInstance().savePartnerMetadataForOutboundMessage(partnerMetadata)
 
         then:
         1 * mockLogger.logError(_, _)
     }
 
-    def "saveSentMessageSubmissionId works"() {
+    def "saveInboundMessageId works"() {
         given:
-        def inboundMessageId = "sentId" // TODO - figure out if this value matters
-        def outboundMessageId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def inboundMessageId = "inboundId"
+        def outboundMessageId = "outboundId"
+        mockOrchestrator.updateMetadataForInboundMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(outboundMessageId, inboundMessageId)
+        SendMessageHelper.getInstance().saveInboundMessageId(outboundMessageId, inboundMessageId)
 
         then:
-        1 * mockOrchestrator.updateMetadataForSentMessage(_, _)
+        1 * mockOrchestrator.updateMetadataForInboundMessage(_, _)
     }
 
-    def "saveSentMessageSubmissionId should log warnings for null outboundMessageId"() {
+    def "saveInboundMessageId should log warnings for null outboundMessageId"() {
         given:
-        def outboundMessageId = "receivedId"
+        def outboundMessageId = "outboundId"
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(null, outboundMessageId)
+        SendMessageHelper.getInstance().saveInboundMessageId(null, outboundMessageId)
 
         then:
         1 * mockLogger.logWarning(_)
     }
 
-    def "saveSentMessageSubmissionId should log error and continues when updateMetadataForSentMessage throws error"() {
+    def "saveInboundMessageId should log error and continues when updateMetadataForInboundMessage throws error"() {
         given:
-        def inboundMessageId = "sentId" // TODO - figure out if this value matters
-        def outboundMessageId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def inboundMessageId = "inboundId"
+        def outboundMessageId = "outboundId"
+        mockOrchestrator.updateMetadataForInboundMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
 
         when:
-        SendMessageHelper.getInstance().saveSentMessageSubmissionId(outboundMessageId, inboundMessageId)
+        SendMessageHelper.getInstance().saveInboundMessageId(outboundMessageId, inboundMessageId)
 
         then:
         1 * mockLogger.logError(_, _)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -19,7 +19,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def mockMessageLinkStorage
     def mockClient
     def mockFormatter
-    def receivedSubmissionId = "receivedSubmissionId"
+    def outboundMessageId = "outboundMessageId"
     def inboundMessageId = "inboundMessageId"
     def hashCode = "hash"
     def bearerToken = "token"
@@ -48,7 +48,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         receivingApp = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         receivingFacility = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
-        testMetadata = new PartnerMetadata(receivedSubmissionId,
+        testMetadata = new PartnerMetadata(outboundMessageId,
                 inboundMessageId,
                 timeReceived,
                 timeDelivered,
@@ -109,7 +109,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         """
 
         def expectedMetadata = new PartnerMetadata(
-                receivedSubmissionId,
+                outboundMessageId,
                 inboundMessageId,
                 Instant.parse(timestamp),
                 timeDelivered,
@@ -129,25 +129,25 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         then:
         1 * mockClient.getRsToken() >> bearerToken
-        1 * mockClient.requestDeliveryEndpoint(receivedSubmissionId, bearerToken) >> rsDeliveryApiResponse
+        1 * mockClient.requestDeliveryEndpoint(outboundMessageId, bearerToken) >> rsDeliveryApiResponse
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
     def "updateMetadataForSentMessage test case when inboundMessageId is null"() {
         when:
         def inboundMessageId = null
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(outboundMessageId, inboundMessageId)
 
         then:
-        0 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId)
+        0 * mockPartnerMetadataStorage.readMetadata(outboundMessageId)
     }
 
     def "updateMetadataForSentMessage test case when PartnerMetadata returns no data"() {
         given:
-        mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.empty()
+        mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.empty()
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(outboundMessageId, inboundMessageId)
 
         then:
         0 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata)
@@ -155,11 +155,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentMessage ends when inboundMessageId matches the one provided by PartnerMetadata"() {
         given:
-        def optional = Optional.of(new PartnerMetadata(receivedSubmissionId, inboundMessageId, Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
-        mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> optional
+        def optional = Optional.of(new PartnerMetadata(outboundMessageId, inboundMessageId, Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
+        mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> optional
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(outboundMessageId, inboundMessageId)
 
         then:
         0 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata)
@@ -167,15 +167,15 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata returns empty Optional when data is not found"() {
         given:
-        String receivedSubmissionId = "receivedSubmissionId"
+        String outboundMessageId = "outboundMessageId"
         def mockMetadata = Optional.empty()
 
         when:
-        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         !result.isPresent()
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> mockMetadata
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> mockMetadata
     }
 
     def "updateMetadataForReceivedMessage throws PartnerMetadataException on client error"() {
@@ -188,7 +188,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         then:
         1 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata) >> { PartnerMetadata metadata ->
-            assert metadata.receivedSubmissionId() == receivedSubmissionId
+            assert metadata.outboundMessageId() == outboundMessageId
         }
         thrown(PartnerMetadataException)
     }
@@ -270,27 +270,27 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(outboundMessageId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
         def updatedPartnerMetadata = partnerMetadata.withInboundMessageId(inboundMessageId)
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(outboundMessageId, inboundMessageId)
 
         then:
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(partnerMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(updatedPartnerMetadata)
     }
 
     def "getMetadata throws PartnerMetadataException on client error"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(outboundMessageId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
-        mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
         mockClient.requestDeliveryEndpoint(_ as String, _ as String) >> { throw new ReportStreamEndpointClientException("Client error", new Exception()) }
 
         when:
-        PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         thrown(PartnerMetadataException)
@@ -299,15 +299,15 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata throws PartnerMetadataException on formatter error"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(outboundMessageId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
-        mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
+        mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
         mockClient.requestHistoryEndpoint(_ as String, _ as String) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> { throw new FormatterProcessingException("Formatter error", new Exception()) }
 
         when:
-        PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         thrown(PartnerMetadataException)
@@ -315,42 +315,42 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata retrieves metadata successfully with the sender already filled"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def metadata = new PartnerMetadata(outboundMessageId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         when:
-        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == metadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(metadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(metadata)
         0 * mockClient.requestHistoryEndpoint(_, _)
     }
 
     def "getMetadata skips lookup with stale metadata and missing inboundMessageId"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
+        def metadata = new PartnerMetadata(outboundMessageId, null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
 
         when:
-        PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(metadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(metadata)
         0 * mockClient.requestHistoryEndpoint(_, _)
         notThrown(PartnerMetadataException)
     }
 
     def "getMetadata retrieves metadata successfully when receiver is present and inboundMessageId is missing"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def metadata = new PartnerMetadata(outboundMessageId, null, Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         when:
-        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        def result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == metadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(metadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(metadata)
     }
 
     def "getMetadata gets receiver if missing from metadata"() {
@@ -358,8 +358,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "{\"actualCompletionAt\": \"2023-10-24T19:48:26.921Z\",\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
         def receivingFacilityWithMissingUniversalId = new MessageHdDataType("receiving_app_name", null, "receiving_app_type")
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
@@ -373,20 +373,20 @@ class PartnerMetadataOrchestratorTest extends Specification {
         ]
 
         when:
-        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == expectedMetadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(missingReceiverMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(missingReceiverMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
     def "getMetadata gets status if still pending in metadata"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
@@ -399,12 +399,12 @@ class PartnerMetadataOrchestratorTest extends Specification {
         ]
 
         when:
-        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == expectedMetadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(missingReceiverMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(missingReceiverMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
@@ -412,8 +412,8 @@ class PartnerMetadataOrchestratorTest extends Specification {
         given:
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
@@ -431,19 +431,19 @@ class PartnerMetadataOrchestratorTest extends Specification {
         ]
 
         when:
-        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == expectedMetadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(missingReceiverMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(missingReceiverMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
     def "getMetadata saves pending without delivery time if nobody has delivery times"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
@@ -461,20 +461,20 @@ class PartnerMetadataOrchestratorTest extends Specification {
         ]
 
         when:
-        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == missingReceiverMetadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(missingReceiverMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(missingReceiverMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(missingReceiverMetadata)
     }
 
     def "getMetadata saves loaded delivered metadata if found"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
         mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
@@ -492,12 +492,12 @@ class PartnerMetadataOrchestratorTest extends Specification {
         ]
 
         when:
-        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
+        Optional<PartnerMetadata> result = PartnerMetadataOrchestrator.getInstance().getMetadata(outboundMessageId)
 
         then:
         result.isPresent()
         result.get() == expectedMetadata
-        1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(missingReceiverMetadata)
+        1 * mockPartnerMetadataStorage.readMetadata(outboundMessageId) >> Optional.of(missingReceiverMetadata)
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
@@ -540,7 +540,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         then:
         1 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata) >> { PartnerMetadata partnerMetadata ->
             assert partnerMetadata.deliveryStatus() == PartnerMetadataStatus.FAILED
-            assert partnerMetadata.receivedSubmissionId() == submissionId
+            assert partnerMetadata.outboundMessageId() == submissionId
         }
     }
 
@@ -714,22 +714,22 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "findMessagesIdsToLink returns a list of message ids"() {
         given:
         def placerOrderNumber = "placerOrderNumber"
-        def receivedSubmissionId1 = "1"
-        def receivedSubmissionId2 = "2"
+        def outboundMessageId1 = "1"
+        def outboundMessageId2 = "2"
         def sendingAppDetails = new MessageHdDataType("sending_app_name", "sending_app_id", "sending_app_type")
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def partnerMetadata1 = new PartnerMetadata(receivedSubmissionId1, "hash1", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
-        def partnerMetadata2 = new PartnerMetadata(receivedSubmissionId2, "hash2", PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
-        def metadataSetForMessageLinking = Set.of(receivedSubmissionId1, receivedSubmissionId2)
-        mockPartnerMetadataStorage.readMetadataForMessageLinking(receivedSubmissionId) >> metadataSetForMessageLinking
+        def partnerMetadata1 = new PartnerMetadata(outboundMessageId1, "hash1", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def partnerMetadata2 = new PartnerMetadata(outboundMessageId2, "hash2", PartnerMetadataMessageType.RESULT, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def metadataSetForMessageLinking = Set.of(outboundMessageId1, outboundMessageId2)
+        mockPartnerMetadataStorage.readMetadataForMessageLinking(outboundMessageId) >> metadataSetForMessageLinking
 
         when:
-        def result = PartnerMetadataOrchestrator.getInstance().findMessagesIdsToLink(receivedSubmissionId)
+        def result = PartnerMetadataOrchestrator.getInstance().findMessagesIdsToLink(outboundMessageId)
 
         then:
-        result == Set.of(receivedSubmissionId1, receivedSubmissionId2)
+        result == Set.of(outboundMessageId1, outboundMessageId2)
     }
 
     def "linkMessages links messages successfully"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataOrchestratorTest.groovy
@@ -20,7 +20,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def mockClient
     def mockFormatter
     def receivedSubmissionId = "receivedSubmissionId"
-    def sentSubmissionId = "sentSubmissionId"
+    def inboundMessageId = "inboundMessageId"
     def hashCode = "hash"
     def bearerToken = "token"
     def placerOrderNumber = "placer_order_number"
@@ -49,7 +49,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         receivingFacility = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         testMetadata = new PartnerMetadata(receivedSubmissionId,
-                sentSubmissionId,
+                inboundMessageId,
                 timeReceived,
                 timeDelivered,
                 hashCode,
@@ -110,7 +110,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
         def expectedMetadata = new PartnerMetadata(
                 receivedSubmissionId,
-                sentSubmissionId,
+                inboundMessageId,
                 Instant.parse(timestamp),
                 timeDelivered,
                 hashCode,
@@ -133,10 +133,10 @@ class PartnerMetadataOrchestratorTest extends Specification {
         1 * mockPartnerMetadataStorage.saveMetadata(expectedMetadata)
     }
 
-    def "updateMetadataForSentMessage test case when sentSubmissionId is null"() {
+    def "updateMetadataForSentMessage test case when inboundMessageId is null"() {
         when:
-        def sentSubmissionId = null
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
+        def inboundMessageId = null
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
 
         then:
         0 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId)
@@ -147,19 +147,19 @@ class PartnerMetadataOrchestratorTest extends Specification {
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.empty()
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
 
         then:
         0 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata)
     }
 
-    def "updateMetadataForSentMessage ends when sentSubmissionId matches the one provided by PartnerMetadata"() {
+    def "updateMetadataForSentMessage ends when inboundMessageId matches the one provided by PartnerMetadata"() {
         given:
-        def optional = Optional.of(new PartnerMetadata(receivedSubmissionId, sentSubmissionId, Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
+        def optional = Optional.of(new PartnerMetadata(receivedSubmissionId, inboundMessageId, Instant.now(), null, "", PartnerMetadataStatus.FAILED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber))
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> optional
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
 
         then:
         0 * mockPartnerMetadataStorage.saveMetadata(_ as PartnerMetadata)
@@ -271,10 +271,10 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "updateMetadataForSentMessage updates metadata successfully"() {
         given:
         def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "hash", PartnerMetadataMessageType.ORDER, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def updatedPartnerMetadata = partnerMetadata.withSentSubmissionId(sentSubmissionId)
+        def updatedPartnerMetadata = partnerMetadata.withInboundMessageId(inboundMessageId)
 
         when:
-        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
+        PartnerMetadataOrchestrator.getInstance().updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
 
         then:
         1 * mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
@@ -283,7 +283,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata throws PartnerMetadataException on client error"() {
         given:
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
@@ -299,7 +299,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata throws PartnerMetadataException on formatter error"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def partnerMetadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, "failureReason", PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockPartnerMetadataStorage.readMetadata(receivedSubmissionId) >> Optional.of(partnerMetadata)
         mockClient.getRsToken() >> "token"
@@ -315,7 +315,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
 
     def "getMetadata retrieves metadata successfully with the sender already filled"() {
         given:
-        def metadata = new PartnerMetadata(receivedSubmissionId, "sentSubmissionId", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def metadata = new PartnerMetadata(receivedSubmissionId, "inboundMessageId", Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         when:
         def result = PartnerMetadataOrchestrator.getInstance().getMetadata(receivedSubmissionId)
@@ -327,7 +327,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         0 * mockClient.requestHistoryEndpoint(_, _)
     }
 
-    def "getMetadata skips lookup with stale metadata and missing sentSubmissionId"() {
+    def "getMetadata skips lookup with stale metadata and missing inboundMessageId"() {
         given:
         def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.PENDING, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, "placer_order_number")
 
@@ -340,7 +340,7 @@ class PartnerMetadataOrchestratorTest extends Specification {
         notThrown(PartnerMetadataException)
     }
 
-    def "getMetadata retrieves metadata successfully when receiver is present and sentSubmissionId is missing"() {
+    def "getMetadata retrieves metadata successfully when receiver is present and inboundMessageId is missing"() {
         given:
         def metadata = new PartnerMetadata(receivedSubmissionId, null, Instant.now(), null, "hash", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.RESULT, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
@@ -358,11 +358,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "{\"actualCompletionAt\": \"2023-10-24T19:48:26.921Z\",\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
         def receivingFacilityWithMissingUniversalId = new MessageHdDataType("receiving_app_name", null, "receiving_app_type")
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacilityWithMissingUniversalId, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
-        mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
             overallStatus: "Delivered",
             actualCompletionAt: timeDelivered.toString(),
@@ -385,11 +385,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata gets status if still pending in metadata"() {
         given:
         def rsHistoryApiResponse = "{\"destinations\": [{\"organization_id\": \"org\", \"service\": \"service\"}]}"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.FAILED, "", messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
-        mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
             overallStatus: "Not Delivering",
             destinations: [
@@ -412,11 +412,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
         given:
         def timeDelivered = Instant.now()
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
-        mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
             overallStatus: "Delivered",
             actualCompletionAt: timeDelivered.toString(),
@@ -443,10 +443,10 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata saves pending without delivery time if nobody has delivery times"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
-        mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
             overallStatus: "Pending",
             actualCompletionAt: null,
@@ -473,11 +473,11 @@ class PartnerMetadataOrchestratorTest extends Specification {
     def "getMetadata saves loaded delivered metadata if found"() {
         given:
         def rsHistoryApiResponse = "whatever"
-        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
-        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def missingReceiverMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.PENDING, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
+        def expectedMetadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hashCode, PartnerMetadataStatus.DELIVERED, null, messageType, sendingApp, sendingFacility, receivingApp, receivingFacility, placerOrderNumber)
 
         mockClient.getRsToken() >> bearerToken
-        mockClient.requestHistoryEndpoint(sentSubmissionId, bearerToken) >> rsHistoryApiResponse
+        mockClient.requestHistoryEndpoint(inboundMessageId, bearerToken) >> rsHistoryApiResponse
         mockFormatter.convertJsonToObject(rsHistoryApiResponse, _ as TypeReference) >> [
             overallStatus: "Delivered",
             actualCompletionAt: null,

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
@@ -17,7 +17,7 @@ class PartnerMetadataTest extends Specification {
 
     def "test constructor"() {
         given:
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
@@ -31,10 +31,10 @@ class PartnerMetadataTest extends Specification {
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         then:
-        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.outboundMessageId() == outboundMessageId
         metadata.inboundMessageId() == inboundMessageId
         metadata.timeDelivered() == timeDelivered
         metadata.timeReceived() == timeReceived
@@ -49,14 +49,14 @@ class PartnerMetadataTest extends Specification {
 
     def "test constructor with only received submission ID and status"() {
         given:
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def deliverStatus = PartnerMetadataStatus.DELIVERED
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, deliverStatus)
+        def metadata = new PartnerMetadata(outboundMessageId, deliverStatus)
 
         then:
-        metadata.receivedSubmissionId() == receivedSubmissionId
+        metadata.outboundMessageId() == outboundMessageId
         metadata.inboundMessageId() == null
         metadata.timeReceived() == null
         metadata.timeDelivered() == null
@@ -66,7 +66,7 @@ class PartnerMetadataTest extends Specification {
 
     def "test withInboundMessageId to update PartnerMetadata"() {
         given:
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def inboundMessageId = "inboundMessageId"
         def messageType = PartnerMetadataMessageType.RESULT
         def timeReceived = Instant.now()
@@ -78,13 +78,13 @@ class PartnerMetadataTest extends Specification {
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
-        def metadata = new PartnerMetadata(receivedSubmissionId, null, timeReceived, null, hash, status, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(outboundMessageId, null, timeReceived, null, hash, status, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def updatedMetadata = metadata.withInboundMessageId(inboundMessageId)
 
         then:
-        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.outboundMessageId() == outboundMessageId
         updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.hash() == hash
@@ -97,7 +97,7 @@ class PartnerMetadataTest extends Specification {
 
     def "test withDeliveryStatus to update PartnerMetadata"() {
         given:
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = null
@@ -108,14 +108,14 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def newStatus = PartnerMetadataStatus.DELIVERED
         def updatedMetadata = metadata.withInboundMessageId(inboundMessageId).withDeliveryStatus(newStatus)
 
         then:
-        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.outboundMessageId() == outboundMessageId
         updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == null
@@ -130,7 +130,7 @@ class PartnerMetadataTest extends Specification {
 
     def "test withTimeDelivered to update PartnerMetadata"() {
         given:
-        def receivedSubmissionId = "receivedSubmissionId"
+        def outboundMessageId = "outboundMessageId"
         def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
@@ -141,13 +141,13 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def updatedMetadata = metadata.withTimeDelivered(timeDelivered)
 
         then:
-        updatedMetadata.receivedSubmissionId() == receivedSubmissionId
+        updatedMetadata.outboundMessageId() == outboundMessageId
         updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == timeDelivered

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/metadata/partner/PartnerMetadataTest.groovy
@@ -18,7 +18,7 @@ class PartnerMetadataTest extends Specification {
     def "test constructor"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def sentSubmissionId = "sentSubmissionId"
+        def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
         def hash = "abcd"
@@ -31,11 +31,11 @@ class PartnerMetadataTest extends Specification {
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
 
         when:
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
-        metadata.sentSubmissionId() == sentSubmissionId
+        metadata.inboundMessageId() == inboundMessageId
         metadata.timeDelivered() == timeDelivered
         metadata.timeReceived() == timeReceived
         metadata.hash() == hash
@@ -57,17 +57,17 @@ class PartnerMetadataTest extends Specification {
 
         then:
         metadata.receivedSubmissionId() == receivedSubmissionId
-        metadata.sentSubmissionId() == null
+        metadata.inboundMessageId() == null
         metadata.timeReceived() == null
         metadata.timeDelivered() == null
         metadata.hash() == null
         metadata.deliveryStatus() == deliverStatus
     }
 
-    def "test withSentSubmissionId to update PartnerMetadata"() {
+    def "test withInboundMessageId to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def sentSubmissionId = "sentSubmissionId"
+        def inboundMessageId = "inboundMessageId"
         def messageType = PartnerMetadataMessageType.RESULT
         def timeReceived = Instant.now()
         def hash = "abcd"
@@ -81,11 +81,11 @@ class PartnerMetadataTest extends Specification {
         def metadata = new PartnerMetadata(receivedSubmissionId, null, timeReceived, null, hash, status, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
-        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId)
+        def updatedMetadata = metadata.withInboundMessageId(inboundMessageId)
 
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
-        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.hash() == hash
         updatedMetadata.deliveryStatus() == status
@@ -98,7 +98,7 @@ class PartnerMetadataTest extends Specification {
     def "test withDeliveryStatus to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def sentSubmissionId = "sentSubmissionId"
+        def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = null
         def messageType = PartnerMetadataMessageType.RESULT
@@ -108,15 +108,15 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, timeDelivered, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def newStatus = PartnerMetadataStatus.DELIVERED
-        def updatedMetadata = metadata.withSentSubmissionId(sentSubmissionId).withDeliveryStatus(newStatus)
+        def updatedMetadata = metadata.withInboundMessageId(inboundMessageId).withDeliveryStatus(newStatus)
 
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
-        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == null
         updatedMetadata.hash() == hash
@@ -131,7 +131,7 @@ class PartnerMetadataTest extends Specification {
     def "test withTimeDelivered to update PartnerMetadata"() {
         given:
         def receivedSubmissionId = "receivedSubmissionId"
-        def sentSubmissionId = "sentSubmissionId"
+        def inboundMessageId = "inboundMessageId"
         def timeReceived = Instant.now()
         def timeDelivered = Instant.now()
         def messageType = PartnerMetadataMessageType.RESULT
@@ -141,14 +141,14 @@ class PartnerMetadataTest extends Specification {
         def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
         def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
         def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-        def metadata = new PartnerMetadata(receivedSubmissionId, sentSubmissionId, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def metadata = new PartnerMetadata(receivedSubmissionId, inboundMessageId, timeReceived, null, hash, PartnerMetadataStatus.PENDING, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def updatedMetadata = metadata.withTimeDelivered(timeDelivered)
 
         then:
         updatedMetadata.receivedSubmissionId() == receivedSubmissionId
-        updatedMetadata.sentSubmissionId() == sentSubmissionId
+        updatedMetadata.inboundMessageId() == inboundMessageId
         updatedMetadata.timeReceived() == timeReceived
         updatedMetadata.timeDelivered() == timeDelivered
         updatedMetadata.hash() == hash

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/orders/SendOrderUseCaseTest.groovy
@@ -35,7 +35,7 @@ class SendOrderUseCaseTest extends Specification {
     def "send sends successfully"() {
         given:
         def receivedSubmissionId = "receivedId"
-        def sentSubmissionId = "sentId"
+        def inboundMessageId = "sentId"
         def messagesIdsToLink = new HashSet<>(Set.of("messageId1", "messageId2"))
         def mockOrder = new OrderMock(null, null, null, null, null, null, null, null)
 
@@ -46,9 +46,9 @@ class SendOrderUseCaseTest extends Specification {
 
         then:
         1 * mockEngine.runRules(mockOrder)
-        1 * mockSender.send(mockOrder) >> Optional.of(sentSubmissionId)
+        1 * mockSender.send(mockOrder) >> Optional.of(inboundMessageId)
         1 * mockOrchestrator.updateMetadataForReceivedMessage(_ as PartnerMetadata)
-        1 * mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, sentSubmissionId)
+        1 * mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, inboundMessageId)
         1 * mockOrchestrator.findMessagesIdsToLink(receivedSubmissionId) >> messagesIdsToLink
         1 * mockOrchestrator.linkMessages(messagesIdsToLink + receivedSubmissionId)
     }
@@ -67,7 +67,7 @@ class SendOrderUseCaseTest extends Specification {
 
     def "convertAndSend should log warnings for null receivedSubmissionId"() {
         given:
-        mockSender.send(_) >> Optional.of("sentSubmissionId")
+        mockSender.send(_) >> Optional.of("inboundMessageId")
         TestApplicationContext.injectRegisteredImplementations()
 
         when:

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
@@ -36,7 +36,7 @@ class SendResultUseCaseTest extends Specification {
     def "convertAndSend works"() {
         given:
         def mockResult = new ResultMock(null, "Mock result", null, null, null, null, null)
-        def outboundMessageId = "receivedId"
+        def outboundMessageId = "outboundId"
 
         when:
         SendResultUseCase.getInstance().convertAndSend(mockResult, outboundMessageId)
@@ -48,7 +48,7 @@ class SendResultUseCaseTest extends Specification {
 
     def "convertAndSend throws exception when send fails"() {
         given:
-        def outboundMessageId = "receivedId"
+        def outboundMessageId = "outboundId"
         mockSender.send(_) >> { throw new UnableToSendMessageException("DogCow", new NullPointerException()) }
 
         when:
@@ -58,11 +58,11 @@ class SendResultUseCaseTest extends Specification {
         thrown(UnableToSendMessageException)
     }
 
-    def "convertAndSend logs error and continues when updateMetadataForReceivedMessage throws exception"() {
+    def "convertAndSend logs error and continues when updateMetadataForOutboundMessage throws exception"() {
         given:
         def result = Mock(Result)
-        def outboundMessageId = "receivedId"
-        mockOrchestrator.updateMetadataForReceivedMessage(_ as PartnerMetadata) >> { throw new PartnerMetadataException("Error") }
+        def outboundMessageId = "outboundId"
+        mockOrchestrator.updateMetadataForOutboundMessage(_ as PartnerMetadata) >> { throw new PartnerMetadataException("Error") }
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
@@ -71,14 +71,14 @@ class SendResultUseCaseTest extends Specification {
         then:
         1 * mockLogger.logError(_, _)
         1 * mockEngine.runRules(result)
-        1 * mockSender.send(result) >> Optional.of("sentId")
+        1 * mockSender.send(result) >> Optional.of("inboundId")
     }
 
-    def "convertAndSend logs error and continues when updateMetadataForSentMessage throws exception"() {
+    def "convertAndSend logs error and continues when updateMetadataForInboundMessage throws exception"() {
         given:
         def result = Mock(Result)
-        def outboundMessageId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def outboundMessageId = "outboundId"
+        mockOrchestrator.updateMetadataForInboundMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
@@ -86,7 +86,7 @@ class SendResultUseCaseTest extends Specification {
 
         then:
         1 * mockEngine.runRules(result)
-        1 * mockSender.send(result) >> Optional.of("sentId")
+        1 * mockSender.send(result) >> Optional.of("inboundId")
         1 * mockLogger.logError(_, _)
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
@@ -43,7 +43,7 @@ class SendResultUseCaseTest extends Specification {
 
         then:
         1 * mockEngine.runRules(mockResult)
-        1 * mockSender.send(mockResult) >> Optional.of("sentSubmissionId")
+        1 * mockSender.send(mockResult) >> Optional.of("inboundMessageId")
     }
 
     def "convertAndSend throws exception when send fails"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/results/SendResultUseCaseTest.groovy
@@ -36,10 +36,10 @@ class SendResultUseCaseTest extends Specification {
     def "convertAndSend works"() {
         given:
         def mockResult = new ResultMock(null, "Mock result", null, null, null, null, null)
-        def receivedSubmissionId = "receivedId"
+        def outboundMessageId = "receivedId"
 
         when:
-        SendResultUseCase.getInstance().convertAndSend(mockResult, receivedSubmissionId)
+        SendResultUseCase.getInstance().convertAndSend(mockResult, outboundMessageId)
 
         then:
         1 * mockEngine.runRules(mockResult)
@@ -48,11 +48,11 @@ class SendResultUseCaseTest extends Specification {
 
     def "convertAndSend throws exception when send fails"() {
         given:
-        def receivedSubmissionId = "receivedId"
+        def outboundMessageId = "receivedId"
         mockSender.send(_) >> { throw new UnableToSendMessageException("DogCow", new NullPointerException()) }
 
         when:
-        SendResultUseCase.getInstance().convertAndSend(Mock(Result), receivedSubmissionId)
+        SendResultUseCase.getInstance().convertAndSend(Mock(Result), outboundMessageId)
 
         then:
         thrown(UnableToSendMessageException)
@@ -61,12 +61,12 @@ class SendResultUseCaseTest extends Specification {
     def "convertAndSend logs error and continues when updateMetadataForReceivedMessage throws exception"() {
         given:
         def result = Mock(Result)
-        def receivedSubmissionId = "receivedId"
+        def outboundMessageId = "receivedId"
         mockOrchestrator.updateMetadataForReceivedMessage(_ as PartnerMetadata) >> { throw new PartnerMetadataException("Error") }
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendResultUseCase.getInstance().convertAndSend(result, receivedSubmissionId)
+        SendResultUseCase.getInstance().convertAndSend(result, outboundMessageId)
 
         then:
         1 * mockLogger.logError(_, _)
@@ -77,12 +77,12 @@ class SendResultUseCaseTest extends Specification {
     def "convertAndSend logs error and continues when updateMetadataForSentMessage throws exception"() {
         given:
         def result = Mock(Result)
-        def receivedSubmissionId = "receivedId"
-        mockOrchestrator.updateMetadataForSentMessage(receivedSubmissionId, _ as String) >> { throw new PartnerMetadataException("Error") }
+        def outboundMessageId = "receivedId"
+        mockOrchestrator.updateMetadataForSentMessage(outboundMessageId, _ as String) >> { throw new PartnerMetadataException("Error") }
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        SendResultUseCase.getInstance().convertAndSend(result, receivedSubmissionId)
+        SendResultUseCase.getInstance().convertAndSend(result, outboundMessageId)
 
         then:
         1 * mockEngine.runRules(result)

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -103,8 +103,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def testMapper = new ObjectMapper()
         List<DbColumn> columns =
                 List.of(
-                new DbColumn("received_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
-                new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
+                new DbColumn("outbound_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
+                new DbColumn("inbound_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", Timestamp.from(mockMetadata.timeReceived()),false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", Timestamp.from(mockMetadata.timeDelivered()),true, Types.TIMESTAMP),
@@ -124,7 +124,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         DatabasePartnerMetadataStorage.getInstance().saveMetadata(mockMetadata)
 
         then:
-        1 * mockDao.upsertData("metadata", columns, "(received_message_id)")
+        1 * mockDao.upsertData("metadata", columns, "(outbound_message_id)")
     }
 
     def "saveMetadata unhappy path works"() {
@@ -217,8 +217,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
 
         List<DbColumn> columns =
                 List.of(
-                new DbColumn("received_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
-                new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
+                new DbColumn("outbound_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
+                new DbColumn("inbound_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", null, false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", null,true, Types.TIMESTAMP),
@@ -238,7 +238,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         DatabasePartnerMetadataStorage.getInstance().saveMetadata(mockMetadata)
 
         then:
-        1 * mockDao.upsertData("metadata", columns, "(received_message_id)")
+        1 * mockDao.upsertData("metadata", columns, "(outbound_message_id)")
     }
 
     def "readMetadataForMessageLinking happy path works"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -31,7 +31,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
     def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
     def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
     def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-    def mockMetadata = new PartnerMetadata("receivedSubmissionId", "inboundMessageId", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+    def mockMetadata = new PartnerMetadata("outboundMessageId", "inboundMessageId", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
     def setup() {
         TestApplicationContext.reset()
@@ -52,7 +52,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         mockDao.fetchFirstData(_ as Function<Connection, PreparedStatement>, _ as Function<ResultSet, PartnerMetadata>) >> mockMetadata
 
         when:
-        def actualResult = DatabasePartnerMetadataStorage.getInstance().readMetadata(mockMetadata.receivedSubmissionId())
+        def actualResult = DatabasePartnerMetadataStorage.getInstance().readMetadata(mockMetadata.outboundMessageId())
 
         then:
         actualResult == expectedResult
@@ -63,7 +63,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         mockDao.fetchFirstData(_ as Function<Connection, PreparedStatement>, _ as Function<ResultSet, PartnerMetadata>) >> { throw new SQLException("Something went wrong!") }
 
         when:
-        DatabasePartnerMetadataStorage.getInstance().readMetadata("receivedSubmissionId")
+        DatabasePartnerMetadataStorage.getInstance().readMetadata("outboundMessageId")
 
         then:
         thrown(PartnerMetadataException)
@@ -103,7 +103,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def testMapper = new ObjectMapper()
         List<DbColumn> columns =
                 List.of(
-                new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
+                new DbColumn("received_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", Timestamp.from(mockMetadata.timeReceived()),false, Types.TIMESTAMP),
@@ -200,7 +200,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         given:
         def testMapper = new ObjectMapper()
         def mockMetadata = new PartnerMetadata(
-                "receivedSubmissionId",
+                "outboundMessageId",
                 "inboundMessageId",
                 null,
                 null,
@@ -217,7 +217,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
 
         List<DbColumn> columns =
                 List.of(
-                new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
+                new DbColumn("received_message_id", mockMetadata.outboundMessageId(), false, Types.VARCHAR),
                 new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", null, false, Types.TIMESTAMP),
@@ -248,7 +248,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         mockDao.fetchManyData(_ as Function<Connection, PreparedStatement>, _ as Function<ResultSet, PartnerMetadata>, _) >> expectedResult
 
         when:
-        def actualResult = DatabasePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(mockMetadata.receivedSubmissionId())
+        def actualResult = DatabasePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(mockMetadata.outboundMessageId())
 
         then:
         actualResult == expectedResult
@@ -259,7 +259,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         mockDao.fetchManyData(_ as Function<Connection, PreparedStatement>, _ as Function<ResultSet, PartnerMetadata>, _) >> { throw new SQLException("Something went wrong!") }
 
         when:
-        DatabasePartnerMetadataStorage.getInstance().readMetadataForMessageLinking("receivedSubmissionId")
+        DatabasePartnerMetadataStorage.getInstance().readMetadataForMessageLinking("outboundMessageId")
 
         then:
         thrown(PartnerMetadataException)
@@ -300,8 +300,8 @@ class DatabasePartnerMetadataStorageTest extends Specification {
 
     def "partnerMetadataFromResultSet returns partner metadata"() {
         given:
-        def receivedMessageId = "12345"
-        def sentMessageId = "7890"
+        def outboundMessageId = "12345"
+        def inboundMessageId = "7890"
         def sender = "DogCow"
         def receiver = "You'll get your just reward"
         Timestamp timestampForMock = Timestamp.from(Instant.parse("2024-01-03T15:45:33.30Z"))
@@ -313,12 +313,12 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def reason = "It done Goofed"
         def messageType = PartnerMetadataMessageType.RESULT
         def placerOrderNumber = "placer_order_number"
-        def expected = new PartnerMetadata(receivedMessageId, sentMessageId, timeReceived, timeDelivered, hash, status, reason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
+        def expected = new PartnerMetadata(outboundMessageId, inboundMessageId, timeReceived, timeDelivered, hash, status, reason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, placerOrderNumber)
 
         def mockResultSet = Mock(ResultSet)
         mockResultSet.next() >> true
-        mockResultSet.getString("received_message_id") >> receivedMessageId
-        mockResultSet.getString("sent_message_id") >> sentMessageId
+        mockResultSet.getString("outbound_message_id") >> outboundMessageId
+        mockResultSet.getString("inbound_message_id") >> inboundMessageId
         mockResultSet.getString("sender") >> sender
         mockResultSet.getString("receiver") >> receiver
         mockResultSet.getTimestamp("time_received") >> timestampForMock

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/database/DatabasePartnerMetadataStorageTest.groovy
@@ -31,7 +31,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
     def sendingFacilityDetails = new MessageHdDataType("sending_facility_name", "sending_facility_id", "sending_facility_type")
     def receivingAppDetails = new MessageHdDataType("receiving_app_name", "receiving_app_id", "receiving_app_type")
     def receivingFacilityDetails = new MessageHdDataType("receiving_facility_name", "receiving_facility_id", "receiving_facility_type")
-    def mockMetadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+    def mockMetadata = new PartnerMetadata("receivedSubmissionId", "inboundMessageId", Instant.now(), Instant.now(), "hash", PartnerMetadataStatus.DELIVERED, "failure reason", PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
     def setup() {
         TestApplicationContext.reset()
@@ -104,7 +104,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         List<DbColumn> columns =
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
-                new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
+                new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", Timestamp.from(mockMetadata.timeReceived()),false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", Timestamp.from(mockMetadata.timeDelivered()),true, Types.TIMESTAMP),
@@ -201,7 +201,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         def testMapper = new ObjectMapper()
         def mockMetadata = new PartnerMetadata(
                 "receivedSubmissionId",
-                "sentSubmissionId",
+                "inboundMessageId",
                 null,
                 null,
                 "hash",
@@ -218,7 +218,7 @@ class DatabasePartnerMetadataStorageTest extends Specification {
         List<DbColumn> columns =
                 List.of(
                 new DbColumn("received_message_id", mockMetadata.receivedSubmissionId(), false, Types.VARCHAR),
-                new DbColumn("sent_message_id", mockMetadata.sentSubmissionId(), true, Types.VARCHAR),
+                new DbColumn("sent_message_id", mockMetadata.inboundMessageId(), true, Types.VARCHAR),
                 new DbColumn("hash_of_message", mockMetadata.hash(), false, Types.VARCHAR),
                 new DbColumn("time_received", null, false, Types.TIMESTAMP),
                 new DbColumn("time_delivered", null,true, Types.TIMESTAMP),

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
@@ -36,13 +36,13 @@ class HapiMetadataConverterTest extends Specification {
         def messageType =  PartnerMetadataMessageType.ORDER
         def messageIds = Set.of("TestId")
         PartnerMetadata metadata = new PartnerMetadata(
-                "receivedSubmissionId", "inboundMessageId", time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+                "outboundMessageId", "inboundMessageId", time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
-        def result = HapiPartnerMetadataConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata, "receivedSubmissionId", messageIds).getUnderlyingOutcome() as OperationOutcome
+        def result = HapiPartnerMetadataConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata, "outboundMessageId", messageIds).getUnderlyingOutcome() as OperationOutcome
 
         then:
-        result.getId() == "receivedSubmissionId"
+        result.getId() == "outboundMessageId"
         result.getIssue().get(0).diagnostics == messageIds.toString()
         result.getIssue().get(1).diagnostics == sendingFacilityId
         result.getIssue().get(2).diagnostics == receivingFacilityId
@@ -53,6 +53,6 @@ class HapiMetadataConverterTest extends Specification {
         result.getIssue().get(7).diagnostics == failureReason
         result.getIssue().get(8).diagnostics == messageType.toString()
         result.getIssue().get(9).diagnostics == "inboundMessageId"
-        result.getIssue().get(10).diagnostics == "receivedSubmissionId"
+        result.getIssue().get(10).diagnostics == "outboundMessageId"
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiMetadataConverterTest.groovy
@@ -36,7 +36,7 @@ class HapiMetadataConverterTest extends Specification {
         def messageType =  PartnerMetadataMessageType.ORDER
         def messageIds = Set.of("TestId")
         PartnerMetadata metadata = new PartnerMetadata(
-                "receivedSubmissionId", "sentSubmissionId", time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+                "receivedSubmissionId", "inboundMessageId", time, time, hash, PartnerMetadataStatus.DELIVERED, failureReason, messageType, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         when:
         def result = HapiPartnerMetadataConverter.getInstance().extractPublicMetadataToOperationOutcome(metadata, "receivedSubmissionId", messageIds).getUnderlyingOutcome() as OperationOutcome
@@ -52,7 +52,7 @@ class HapiMetadataConverterTest extends Specification {
         result.getIssue().get(6).diagnostics == PartnerMetadataStatus.DELIVERED.toString()
         result.getIssue().get(7).diagnostics == failureReason
         result.getIssue().get(8).diagnostics == messageType.toString()
-        result.getIssue().get(9).diagnostics == "sentSubmissionId"
+        result.getIssue().get(9).diagnostics == "inboundMessageId"
         result.getIssue().get(10).diagnostics == "receivedSubmissionId"
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -32,8 +32,8 @@ class FilePartnerMetadataStorageTest extends Specification {
     def "save and read metadata successfully"() {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
-        def expectedSentSubmissionId = "receivedSubmissionId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def expectedInboundMessageId = "receivedSubmissionId"
+        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
@@ -48,7 +48,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "sentSubmissionId", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "inboundMessageId", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}
@@ -66,8 +66,8 @@ class FilePartnerMetadataStorageTest extends Specification {
     def "saveMetadata overwrites a file if it had been saved before"() {
         given:
         def expectedReceivedSubmissionId = "receivedSubmissionId"
-        def expectedSentSubmissionId = "sentSubmissionId"
-        PartnerMetadata metadata1 = new PartnerMetadata(expectedReceivedSubmissionId, expectedSentSubmissionId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def expectedInboundMessageId = "inboundMessageId"
+        PartnerMetadata metadata1 = new PartnerMetadata(expectedReceivedSubmissionId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
         PartnerMetadata metadata2 = new PartnerMetadata(expectedReceivedSubmissionId, PartnerMetadataStatus.DELIVERED)
 
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/localfile/FilePartnerMetadataStorageTest.groovy
@@ -31,16 +31,16 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "save and read metadata successfully"() {
         given:
-        def expectedReceivedSubmissionId = "receivedSubmissionId"
-        def expectedInboundMessageId = "receivedSubmissionId"
-        PartnerMetadata metadata = new PartnerMetadata(expectedReceivedSubmissionId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        def expectedOutboundMessageId = "outboundMessageId"
+        def expectedInboundMessageId = "outboundMessageId"
+        PartnerMetadata metadata = new PartnerMetadata(expectedOutboundMessageId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata)
-        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedReceivedSubmissionId)
+        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedOutboundMessageId)
 
         then:
         actualMetadata.get() == metadata
@@ -48,7 +48,7 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata throws PartnerMetadataException when unable to save file"() {
         given:
-        PartnerMetadata metadata = new PartnerMetadata("receivedSubmissionId", "inboundMessageId", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata = new PartnerMetadata("outboundMessageId", "inboundMessageId", Instant.now(), Instant.now(), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
 
         def mockFormatter = Mock(Formatter)
         mockFormatter.convertToJsonString(_ as PartnerMetadata) >> {throw new FormatterProcessingException("error", new Exception())}
@@ -65,10 +65,10 @@ class FilePartnerMetadataStorageTest extends Specification {
 
     def "saveMetadata overwrites a file if it had been saved before"() {
         given:
-        def expectedReceivedSubmissionId = "receivedSubmissionId"
+        def expectedOutboundMessageId = "outboundMessageId"
         def expectedInboundMessageId = "inboundMessageId"
-        PartnerMetadata metadata1 = new PartnerMetadata(expectedReceivedSubmissionId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
-        PartnerMetadata metadata2 = new PartnerMetadata(expectedReceivedSubmissionId, PartnerMetadataStatus.DELIVERED)
+        PartnerMetadata metadata1 = new PartnerMetadata(expectedOutboundMessageId, expectedInboundMessageId, Instant.parse("2023-12-04T18:51:48.941875Z"), Instant.parse("2023-12-04T18:51:48.941875Z"), "abcd", PartnerMetadataStatus.DELIVERED, null, PartnerMetadataMessageType.ORDER, sendingAppDetails, sendingFacilityDetails, receivingAppDetails, receivingFacilityDetails, "placer_order_number")
+        PartnerMetadata metadata2 = new PartnerMetadata(expectedOutboundMessageId, PartnerMetadataStatus.DELIVERED)
 
 
         TestApplicationContext.register(Formatter, Jackson.getInstance())
@@ -77,7 +77,7 @@ class FilePartnerMetadataStorageTest extends Specification {
         when:
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(metadata2)
-        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedReceivedSubmissionId)
+        def actualMetadata = FilePartnerMetadataStorage.getInstance().readMetadata(expectedOutboundMessageId)
 
         then:
         actualMetadata.get() == metadata2
@@ -134,32 +134,32 @@ class FilePartnerMetadataStorageTest extends Specification {
         TestApplicationContext.injectRegisteredImplementations()
 
         when:
-        def receivedSubmissionId1 = "receivedSubmissionId1"
+        def outboundMessageId1 = "outboundMessageId1"
         def matchingPlacerOrderNumber1 = "placerOrderNumber1"
         def matchingSendingFacilityDetails1 = new MessageHdDataType("sending_facility_name1", "sending_facility_id1", "sending_facility_type1")
-        def matchingSendingFacilityDetailsMetadata1 = new PartnerMetadata(receivedSubmissionId1, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
+        def matchingSendingFacilityDetailsMetadata1 = new PartnerMetadata(outboundMessageId1, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
         def otherMatchingSendingFacilityDetailsMetadata1 = new PartnerMetadata("1", null, null, null, null, null, null, null, null, matchingSendingFacilityDetails1, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingSendingFacilityDetailsMetadata1)
         FilePartnerMetadataStorage.getInstance().saveMetadata(otherMatchingSendingFacilityDetailsMetadata1)
-        def metadataSetWithMatchingSendingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId1)
+        def metadataSetWithMatchingSendingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(outboundMessageId1)
 
         then:
-        metadataSetWithMatchingSendingFacilityDetails.contains(otherMatchingSendingFacilityDetailsMetadata1.receivedSubmissionId())
-        !metadataSetWithMatchingSendingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata1.receivedSubmissionId())
+        metadataSetWithMatchingSendingFacilityDetails.contains(otherMatchingSendingFacilityDetailsMetadata1.outboundMessageId())
+        !metadataSetWithMatchingSendingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata1.outboundMessageId())
 
         when:
-        def receivedSubmissionId2 = "receivedSubmissionId2"
+        def outboundMessageId2 = "outboundMessageId2"
         def matchingPlacerOrderNumber2 = "placerOrderNumber2"
         def matchingSendingFacilityDetails2 = new MessageHdDataType("sending_facility_name2", "sending_facility_id2", "sending_facility_type2")
-        def matchingSendingFacilityDetailsMetadata2 = new PartnerMetadata(receivedSubmissionId2, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails2, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber2)
+        def matchingSendingFacilityDetailsMetadata2 = new PartnerMetadata(outboundMessageId2, null, null, null, null, null, null, null, null, matchingSendingFacilityDetails2, null, new MessageHdDataType(null, null, null), matchingPlacerOrderNumber2)
         def matchingReceivingFacilityDetailsMetadata2 = new PartnerMetadata("2", null, null, null, null, null, null, null, null, new MessageHdDataType(null, null, null), null, matchingSendingFacilityDetails2, matchingPlacerOrderNumber2)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingSendingFacilityDetailsMetadata2)
         FilePartnerMetadataStorage.getInstance().saveMetadata(matchingReceivingFacilityDetailsMetadata2)
-        def metadataSetWithMatchingSendingAndReceivingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(receivedSubmissionId2)
+        def metadataSetWithMatchingSendingAndReceivingFacilityDetails = FilePartnerMetadataStorage.getInstance().readMetadataForMessageLinking(outboundMessageId2)
 
         then:
-        metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingReceivingFacilityDetailsMetadata2.receivedSubmissionId())
-        !metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata2.receivedSubmissionId())
+        metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingReceivingFacilityDetailsMetadata2.outboundMessageId())
+        !metadataSetWithMatchingSendingAndReceivingFacilityDetails.contains(matchingSendingFacilityDetailsMetadata2.outboundMessageId())
     }
 
     def "readMetadataForMessageLinking returns an empty set when no metadata is found"() {


### PR DESCRIPTION
# Description

Renamed sentSubmissionId and receivedSubmissionId to inboundMessageId and outboundMessageId. Renamed sentMessageId and receivedMessageId to inboundMessageId and outboundMessageId. The rename is from the perspective of TI who is receiving and sending to ReportStream.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1404

## Checklist

- [ ] I have added logging where useful (with appropriate log level)
- [ ] I have added JavaDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
