### PR TITLE
remove platform from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,3 @@ services:
     ports:
       - "8080:8080" # default api endpoint port
       - "6006:6006" # Java debug port
-    platform: linux/amd64


### PR DESCRIPTION
# Description
The platform attribute in docker-compose doesn't work with Podman, and doesn't appear necessary with other platforms, so we're removing it

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1608