### PR TITLE
Remove `azure-identity` package rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,10 +33,7 @@
                 "org.apache.httpcomponents.client5:httpclient5-fluent"
             ],
             "allowedVersions": "!/^5\\.3$/"
-        },
-        {
-            "matchPackageNames": ["com.azure:azure-identity"],
-            "allowedVersions": "!/^1\\.14\\.[0-1]$/"
-        }],
+        }
+    ],
     "pinDigests": false
 }


### PR DESCRIPTION
# Description

Removed the unnecessary package rule that ignores 1.14.0. for `com.azure:azure-identity`.  The rule was in place because there was a bug with 1.14.0 but the updated version fixes this. 

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1509

## Checklist


**Note**: You may remove items that are not applicable
