### PR TITLE
Swap out deprecated values

### DIFF
--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -46,12 +46,12 @@ resource "azurerm_storage_account_customer_managed_key" "storage_storage_account
 
 resource "azurerm_storage_container" "metadata" {
   name                  = "metadata"
-  storage_account_name  = azurerm_storage_account.storage.name
+  storage_account_id    = azurerm_storage_account.storage.id
   container_access_type = "private"
 }
 
 resource "azurerm_role_assignment" "allow_api_read_write" {
-  scope                = azurerm_storage_container.metadata.resource_manager_id
+  scope                = azurerm_storage_container.metadata.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_linux_web_app.api.identity.0.principal_id
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -110,7 +110,7 @@ resource "azurerm_storage_container" "automated_container" {
 }
 
 resource "azurerm_role_assignment" "allow_automated_test_read_write" {
-  scope                = azurerm_storage_container.automated_container.resource_manager_id
+  scope                = azurerm_storage_container.automated_container.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = var.deployer_id
 }

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -105,7 +105,7 @@ resource "azurerm_storage_account_customer_managed_key" "automated_storage_stora
 
 resource "azurerm_storage_container" "automated_container" {
   name                  = "automated"
-  storage_account_name  = azurerm_storage_account.automated_storage.name
+  storage_account_id    = azurerm_storage_account.automated_storage.id
   container_access_type = "private"
 }
 


### PR DESCRIPTION
# Description

GitHub actions is showing warnings for soon-to-be deprecated terraform attributes. This PR will replace them, specifically `storage_account_name` and `resource_manager_id`.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1610

## Checklist


**Note**: You may remove items that are not applicable
