### PR TITLE
Eliminate warnings for missing fields (fix unsigned commits)

### DIFF
--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
@@ -28,11 +28,8 @@ public class CopyOrcOrderProviderToObrOrderProvider implements CustomFhirTransfo
             return;
         }
 
-        // Extract or create the OBR extension from the ServiceRequest
         Extension obrExtension =
                 HapiHelper.ensureExtensionExists(serviceRequest, HapiHelper.EXTENSION_OBR_URL);
-
-        // Set the ORC-12 Practitioner in the OBR-16 extension
         HapiHelper.setOBR16WithPractitioner(obrExtension, practitionerRole);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProvider.java
@@ -28,16 +28,11 @@ public class CopyOrcOrderProviderToObrOrderProvider implements CustomFhirTransfo
             return;
         }
 
-        // Extract or create the OBR-16 extension from the ServiceRequest
+        // Extract or create the OBR extension from the ServiceRequest
         Extension obrExtension =
                 HapiHelper.ensureExtensionExists(serviceRequest, HapiHelper.EXTENSION_OBR_URL);
 
-        // Extract or create the OBR-16 data type extension
-        Extension obr16Extension =
-                HapiHelper.ensureSubExtensionExists(
-                        obrExtension, HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString());
-
         // Set the ORC-12 Practitioner in the OBR-16 extension
-        HapiHelper.setOBR16WithPractitioner(obr16Extension, practitionerRole);
+        HapiHelper.setOBR16WithPractitioner(obrExtension, practitionerRole);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
@@ -5,7 +5,6 @@ import gov.hhs.cdc.trustedintermediary.external.hapi.HapiHelper;
 import gov.hhs.cdc.trustedintermediary.wrappers.HealthData;
 import java.util.Map;
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Identifier;
 
 /**
  * Removes Assigning Authority (PID-3.4) and Identifier Type Code (PID-3.5) from Patient Identifier
@@ -17,11 +16,7 @@ public class RemovePatientIdentifiers implements CustomFhirTransformation {
     public void transform(HealthData<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingData();
 
-        Identifier patientIdentifier = HapiHelper.getPID3Identifier(bundle);
-        if (patientIdentifier == null) {
-            return;
-        }
-        patientIdentifier.setAssigner(null);
-        HapiHelper.removePID3_5Value(patientIdentifier);
+        HapiHelper.setPID3_4Value(bundle, null);
+        HapiHelper.removePID3_5Value(bundle);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
@@ -22,6 +22,6 @@ public class RemovePatientIdentifiers implements CustomFhirTransformation {
             return;
         }
         patientIdentifier.setAssigner(null);
-        HapiHelper.removePID3_5Value(bundle);
+        HapiHelper.removePID3_5Value(patientIdentifier);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
@@ -5,6 +5,7 @@ import gov.hhs.cdc.trustedintermediary.external.hapi.HapiHelper;
 import gov.hhs.cdc.trustedintermediary.wrappers.HealthData;
 import java.util.Map;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Identifier;
 
 /**
  * Removes Assigning Authority (PID-3.4) and Identifier Type Code (PID-3.5) from Patient Identifier
@@ -15,7 +16,26 @@ public class RemovePatientIdentifiers implements CustomFhirTransformation {
     @Override
     public void transform(HealthData<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingData();
-        HapiHelper.setPID3_4Value(bundle, ""); // remove PID.3-4
-        HapiHelper.setPID3_5Value(bundle, ""); // remove PID.3-5
+
+        Identifier identifier = HapiHelper.getPID3Identifier(bundle);
+        if (identifier == null) {
+            return;
+        }
+        identifier.setAssigner(null);
+
+        if (identifier.hasExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)) {
+            identifier
+                    .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
+                    .removeExtension(HapiHelper.EXTENSION_CX5_URL);
+        }
+
+        if (identifier
+                .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
+                .getExtension()
+                .isEmpty()) {
+            identifier.removeExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
+        }
+
+        identifier.setType(null);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifiers.java
@@ -17,25 +17,11 @@ public class RemovePatientIdentifiers implements CustomFhirTransformation {
     public void transform(HealthData<?> resource, Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingData();
 
-        Identifier identifier = HapiHelper.getPID3Identifier(bundle);
-        if (identifier == null) {
+        Identifier patientIdentifier = HapiHelper.getPID3Identifier(bundle);
+        if (patientIdentifier == null) {
             return;
         }
-        identifier.setAssigner(null);
-
-        if (identifier.hasExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)) {
-            identifier
-                    .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
-                    .removeExtension(HapiHelper.EXTENSION_CX5_URL);
-        }
-
-        if (identifier
-                .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
-                .getExtension()
-                .isEmpty()) {
-            identifier.removeExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
-        }
-
-        identifier.setType(null);
+        patientIdentifier.setAssigner(null);
+        HapiHelper.removePID3_5Value(bundle);
     }
 }

--- a/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
+++ b/etor/src/main/java/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCode.java
@@ -12,8 +12,6 @@ public class RemovePatientNameTypeCode implements CustomFhirTransformation {
     @Override
     public void transform(final HealthData<?> resource, final Map<String, Object> args) {
         Bundle bundle = (Bundle) resource.getUnderlyingData();
-        // Need to set the value for extension to empty instead of removing the extension,
-        // otherwise RS will set its own value in its place
-        HapiHelper.setPID5_7ExtensionValue(bundle, null);
+        HapiHelper.removePID5_7Value(bundle);
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -244,16 +244,11 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
     }
 
     Practitioner getObr16ExtensionPractitioner (serviceRequest) {
-        def resource
-        try {
-            def obr16Extension = getObr16Extension(serviceRequest)
-            def value = obr16Extension.value
-            resource = value.getResource()
-            return resource
-        } catch(Exception ignored) {
-            resource = null
-            return resource
+        def obr16Extension = getObr16Extension(serviceRequest)
+        if (obr16Extension == null) {
+            return null
         }
+        return obr16Extension.value.getResource()
     }
 
     Practitioner getOrc12ExtensionPractitioner(Bundle bundle) {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -7,9 +7,6 @@ import gov.hhs.cdc.trustedintermediary.external.hapi.HapiHelper
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.DiagnosticReport
-import org.hl7.fhir.r4.model.Extension
-import org.hl7.fhir.r4.model.Practitioner
-import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.ServiceRequest
 import spock.lang.Specification
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -215,7 +215,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
     }
 
     void evaluateObr16IsNull(ServiceRequest serviceRequest) {
-        assert getObr16Extension(serviceRequest) == null
+        assert HapiHelper.getObr16Extension(serviceRequest) == null
         assert getObr16ExtensionPractitioner(serviceRequest) == null
     }
 
@@ -237,14 +237,8 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
         assert codingSystem == null || codingSystem[0]?.code == expectedIdentifierTypeCode
     }
 
-    Extension getObr16Extension(serviceRequest) {
-        def obrExtension =  serviceRequest.getExtensionByUrl(HapiHelper.EXTENSION_OBR_URL)
-        def obr16Extension = obrExtension.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
-        return obr16Extension
-    }
-
     Practitioner getObr16ExtensionPractitioner (serviceRequest) {
-        def obr16Extension = getObr16Extension(serviceRequest)
+        def obr16Extension = HapiHelper.getObr16Extension(serviceRequest)
         if (obr16Extension == null) {
             return null
         }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -192,7 +192,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
     }
 
     void evaluateOrc12IsNull(Bundle bundle) {
-        assert getOrc12ExtensionPractitioner(bundle) == null
+        assert HapiHelper.getOrc12ExtensionPractitioner(bundle) == null
     }
 
     void evaluateOrc12Values(
@@ -202,7 +202,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
             String expectedLastName,
             String expectedNameTypeCode,
             String expectedIdentifierTypeCode) {
-        def practitioner = getOrc12ExtensionPractitioner(bundle)
+        def practitioner = HapiHelper.getOrc12ExtensionPractitioner(bundle)
         def xcnExtension = practitioner.getExtensionByUrl(PRACTITIONER_EXTENSION_URL)
 
         assert practitioner.identifier[0]?.value == expectedNpi
@@ -235,27 +235,5 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
         assert xcnExtension.getExtensionByUrl("XCN.10")?.value?.toString() == expectedNameTypeCode
         def codingSystem = practitioner.identifier[0]?.type?.coding
         assert codingSystem == null || codingSystem[0]?.code == expectedIdentifierTypeCode
-    }
-
-    Practitioner getOrc12ExtensionPractitioner(Bundle bundle) {
-        def diagnosticReport = HapiHelper.getDiagnosticReport(bundle)
-        def serviceRequest = HapiHelper.getServiceRequest(diagnosticReport)
-
-        def orcExtension = serviceRequest.getExtensionByUrl(HapiHelper.EXTENSION_ORC_URL)
-        def orc12Extension = orcExtension.getExtensionByUrl(HapiHelper.EXTENSION_ORC12_URL)
-
-        if (orc12Extension == null) {
-            return null
-        }
-
-        def practitionerReference = (Reference) orc12Extension.getValue()
-        def practitionerUrl = practitionerReference.getReference()
-
-        for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
-            if (Objects.equals(entry.getFullUrl(), practitionerUrl) && entry.getResource() instanceof Practitioner)
-                return (Practitioner) entry.getResource()
-        }
-
-        return null
     }
 }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -7,6 +7,7 @@ import gov.hhs.cdc.trustedintermediary.external.hapi.HapiHelper
 import gov.hhs.cdc.trustedintermediary.wrappers.MetricMetadata
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.DiagnosticReport
+import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Practitioner
 import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.ServiceRequest
@@ -214,6 +215,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
     }
 
     void evaluateObr16IsNull(ServiceRequest serviceRequest) {
+        assert getObr16Extension(serviceRequest) == null
         assert getObr16ExtensionPractitioner(serviceRequest) == null
     }
 
@@ -235,12 +237,17 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
         assert codingSystem == null || codingSystem[0]?.code == expectedIdentifierTypeCode
     }
 
+    Extension getObr16Extension(serviceRequest) {
+        def obrExtension =  serviceRequest.getExtensionByUrl(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = obrExtension.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        return obr16Extension
+    }
+
     Practitioner getObr16ExtensionPractitioner (serviceRequest) {
         def resource
         try {
-            def extensionByUrl1 =  serviceRequest.getExtensionByUrl(HapiHelper.EXTENSION_OBR_URL)
-            def extensionByUrl2 = extensionByUrl1.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
-            def value = extensionByUrl2.value
+            def obr16Extension = getObr16Extension(serviceRequest)
+            def value = obr16Extension.value
             resource = value.getResource()
             return resource
         } catch(Exception ignored) {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/CopyOrcOrderProviderToObrOrderProviderTest.groovy
@@ -120,7 +120,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
         evaluateOrc12Values(bundle, EXPECTED_NPI, EXPECTED_FIRST_NAME, EXPECTED_LAST_NAME, EXPECTED_NAME_TYPE_CODE, EXPECTED_IDENTIFIER_TYPE_CODE)
 
         // OBR16 should not exist initially
-        def obr16Practitioner = getObr16ExtensionPractitioner(serviceRequest)
+        def obr16Practitioner = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
         obr16Practitioner == null
 
         when:
@@ -216,7 +216,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
 
     void evaluateObr16IsNull(ServiceRequest serviceRequest) {
         assert HapiHelper.getObr16Extension(serviceRequest) == null
-        assert getObr16ExtensionPractitioner(serviceRequest) == null
+        assert HapiHelper.getObr16ExtensionPractitioner(serviceRequest) == null
     }
 
     void evaluateObr16Values(
@@ -226,7 +226,7 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
             String expectedLastName,
             String expectedNameTypeCode,
             String expectedIdentifierTypeCode) {
-        def practitioner = getObr16ExtensionPractitioner(serviceRequest)
+        def practitioner = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
         def xcnExtension = practitioner.getExtensionByUrl(PRACTITIONER_EXTENSION_URL)
 
         assert practitioner.identifier[0]?.value == expectedNpi
@@ -235,14 +235,6 @@ class CopyOrcOrderProviderToObrOrderProviderTest extends Specification{
         assert xcnExtension.getExtensionByUrl("XCN.10")?.value?.toString() == expectedNameTypeCode
         def codingSystem = practitioner.identifier[0]?.type?.coding
         assert codingSystem == null || codingSystem[0]?.code == expectedIdentifierTypeCode
-    }
-
-    Practitioner getObr16ExtensionPractitioner (serviceRequest) {
-        def obr16Extension = HapiHelper.getObr16Extension(serviceRequest)
-        if (obr16Extension == null) {
-            return null
-        }
-        return obr16Extension.value.getResource()
     }
 
     Practitioner getOrc12ExtensionPractitioner(Bundle bundle) {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifierTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientIdentifierTest.groovy
@@ -33,10 +33,10 @@ class RemovePatientIdentifierTest extends Specification {
 
         when:
         transformClass.transform(fhirResource, null)
-        def actualPid3_4 = HapiFhirHelper.getPID3_4Value(bundle)
-        def actualPid3_5 = HapiFhirHelper.getPID3_5Value(bundle)
 
         then:
+        def actualPid3_4 = HapiFhirHelper.getPID3_4Value(bundle)
+        def actualPid3_5 = HapiFhirHelper.getPID3_5Value(bundle)
         actualPid3_4 == null || actualPid3_4.isEmpty()
         actualPid3_5 == null || actualPid3_5.isEmpty()
     }

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
@@ -24,23 +24,19 @@ class RemovePatientNameTypeCodeTest extends Specification {
         given:
         def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/007_CA_ORU_R01_CDPH_produced_UCSD2024-07-11-16-02-17-749_1_hl7_translation.fhir")
         def bundle = fhirResource.getUnderlyingData() as Bundle
-        def pid_5_initial = HapiHelper.getPID5Extension(bundle)
-        def xpn_7_initial = pid_5_initial.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)
+        def pid5Extension = HapiHelper.getPID5Extension(bundle)
         def patientName = HapiHelper.getPIDPatient(bundle).getNameFirstRep()
         def patientNameUse = patientName.getUse()
 
         expect:
-        xpn_7_initial != null
+        pid5Extension.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL) != null
         patientNameUse.toString() == "OFFICIAL"
 
         when:
         transformClass.transform(fhirResource, null)
 
         then:
-        def pid_5_transformed = HapiHelper.getPID5Extension(bundle)
-        def xpn_7_transformed = pid_5_transformed.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)
-        xpn_7_transformed == null
-
+        pid5Extension.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL) == null
         !patientName.hasUse()
     }
 

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
@@ -20,7 +20,7 @@ class RemovePatientNameTypeCodeTest extends Specification {
         transformClass = new RemovePatientNameTypeCode()
     }
 
-    def "remove PID.5-7 from Bundle"() {
+    def "remove PID.5-7 from Bundle - old"() {
         given:
         def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")
         def bundle = fhirResource.getUnderlyingData() as Bundle
@@ -34,6 +34,30 @@ class RemovePatientNameTypeCodeTest extends Specification {
 
         then:
         HapiFhirHelper.getPID5_7Value(bundle) == null
+    }
+
+    def "remove PID.5-7 from Bundle"() {
+        given:
+        def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")
+        def bundle = fhirResource.getUnderlyingData() as Bundle
+        def pid_5_initial = HapiHelper.getPID5Extension(bundle)
+        def xpn_7_initial = pid_5_initial.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)
+        def patientName = HapiHelper.getPIDPatient(bundle).getNameFirstRep()
+        def patientNameUse = patientName.getUse()
+
+        expect:
+        xpn_7_initial != null
+        patientNameUse.toString() == "OFFICIAL"
+
+        when:
+        transformClass.transform(fhirResource, null)
+
+        then:
+        def pid_5_transformed = HapiHelper.getPID5Extension(bundle)
+        def xpn_7_transformed = pid_5_transformed.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)
+        xpn_7_transformed == null
+
+        !patientName.hasUse()
     }
 
     def "don't throw exception if patient resource not present"() {

--- a/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
+++ b/etor/src/test/groovy/gov/hhs/cdc/trustedintermediary/etor/ruleengine/transformation/custom/RemovePatientNameTypeCodeTest.groovy
@@ -20,25 +20,9 @@ class RemovePatientNameTypeCodeTest extends Specification {
         transformClass = new RemovePatientNameTypeCode()
     }
 
-    def "remove PID.5-7 from Bundle - old"() {
-        given:
-        def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")
-        def bundle = fhirResource.getUnderlyingData() as Bundle
-        def pid5_7 = HapiFhirHelper.getPID5_7Value(bundle)
-
-        expect:
-        pid5_7 != null
-
-        when:
-        transformClass.transform(fhirResource, null)
-
-        then:
-        HapiFhirHelper.getPID5_7Value(bundle) == null
-    }
-
     def "remove PID.5-7 from Bundle"() {
         given:
-        def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/002_CA_ORU_R01_initial_translation.fhir")
+        def fhirResource = ExamplesHelper.getExampleFhirResource("../CA/007_CA_ORU_R01_CDPH_produced_UCSD2024-07-11-16-02-17-749_1_hl7_translation.fhir")
         def bundle = fhirResource.getUnderlyingData() as Bundle
         def pid_5_initial = HapiHelper.getPID5Extension(bundle)
         def xpn_7_initial = pid_5_initial.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL)

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -288,9 +288,7 @@ public class HapiHelper {
         setCX5Value(identifier, value);
     }
 
-    public static void removePID3_5Value(Bundle bundle) {
-        Identifier patientIdentifier = getPID3Identifier(bundle);
-
+    public static void removePID3_5Value(Identifier patientIdentifier) {
         if (patientIdentifier == null) {
             return;
         }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -333,6 +333,20 @@ public class HapiHelper {
         }
     }
 
+    public static void removePID5_7Value(Bundle bundle) {
+        Extension pid5Extension = HapiHelper.getPID5Extension(bundle);
+        if (pid5Extension == null) {
+            return;
+        }
+        Extension xpn7Extension = pid5Extension.getExtensionByUrl(HapiHelper.EXTENSION_XPN7_URL);
+        if (xpn7Extension != null) {
+            pid5Extension.removeExtension(HapiHelper.EXTENSION_XPN7_URL);
+        }
+
+        HumanName patientName = HapiHelper.getPIDPatient(bundle).getNameFirstRep();
+        patientName.setUse(null);
+    }
+
     // ORC - Common Order
 
     // Diagnostic Report

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -307,7 +307,7 @@ public class HapiHelper {
             patientIdentifier.removeExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
         }
 
-        // The PID-3.5 also appears in the type coding
+        // The PID-3.5 value also appears in the type coding
         patientIdentifier.setType(null);
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -296,22 +296,22 @@ public class HapiHelper {
             return;
         }
 
-        if (patientIdentifier.hasExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)) {
-            patientIdentifier
-                    .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
-                    .removeExtension(HapiHelper.EXTENSION_CX5_URL);
+        patientIdentifier.setType(null);
+
+        Extension cxExtension =
+                patientIdentifier.getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
+        if (cxExtension == null) {
+            return;
+        }
+
+        if (cxExtension.hasExtension(HapiHelper.EXTENSION_CX5_URL)) {
+            cxExtension.removeExtension(HapiHelper.EXTENSION_CX5_URL);
         }
 
         // The cx-identifier extension can be removed if it has no more sub-extensions
-        if (patientIdentifier
-                .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
-                .getExtension()
-                .isEmpty()) {
+        if (cxExtension.getExtension().isEmpty()) {
             patientIdentifier.removeExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
         }
-
-        // The PID-3.5 value also appears in the type coding
-        patientIdentifier.setType(null);
     }
 
     // PID-5 - Patient Name

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -275,11 +275,20 @@ public class HapiHelper {
     }
 
     public static void setPID3_4Value(Bundle bundle, String value) {
-        Identifier identifier = getPID3_4Identifier(bundle);
-        if (identifier == null) {
+        if (value == null) {
+            Identifier pid3Identifier = getPID3Identifier(bundle);
+            if (pid3Identifier == null) {
+                return;
+            }
+            pid3Identifier.setAssigner(null);
             return;
         }
-        identifier.setValue(value);
+
+        Identifier pid3_4Identifier = getPID3_4Identifier(bundle);
+        if (pid3_4Identifier == null) {
+            return;
+        }
+        pid3_4Identifier.setValue(value);
     }
 
     // PID-3.5 - Identifier Type Code
@@ -291,7 +300,8 @@ public class HapiHelper {
         setCX5Value(identifier, value);
     }
 
-    public static void removePID3_5Value(Identifier patientIdentifier) {
+    public static void removePID3_5Value(Bundle bundle) {
+        Identifier patientIdentifier = HapiHelper.getPID3Identifier(bundle);
         if (patientIdentifier == null) {
             return;
         }

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -288,6 +288,31 @@ public class HapiHelper {
         setCX5Value(identifier, value);
     }
 
+    public static void removePID3_5Value(Bundle bundle) {
+        Identifier patientIdentifier = getPID3Identifier(bundle);
+
+        if (patientIdentifier == null) {
+            return;
+        }
+
+        if (patientIdentifier.hasExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)) {
+            patientIdentifier
+                    .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
+                    .removeExtension(HapiHelper.EXTENSION_CX5_URL);
+        }
+
+        // The cx-identifier extension can be removed if it has no more sub-extensions
+        if (patientIdentifier
+                .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
+                .getExtension()
+                .isEmpty()) {
+            patientIdentifier.removeExtension(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
+        }
+
+        // The PID-3.5 also appears in the type coding
+        patientIdentifier.setType(null);
+    }
+
     // PID-5 - Patient Name
     public static Extension getPID5Extension(Bundle bundle) {
         Patient patient = getPIDPatient(bundle);

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -567,6 +567,14 @@ public class HapiHelper {
         obr16Extension.setValue(practitionerRole.getPractitioner());
     }
 
+    public static Extension getObr16Extension(ServiceRequest serviceRequest) {
+        Extension obrExtension = serviceRequest.getExtensionByUrl(HapiHelper.EXTENSION_OBR_URL);
+        if (obrExtension == null) {
+            return null;
+        }
+        return obrExtension.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString());
+    }
+
     /**
      * Ensures that the extension exists for a given serviceRequest. If the extension does not
      * exist, it will create it.

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -551,7 +551,7 @@ public class HapiHelper {
         return getCWE1Value(cc.getCoding().get(0));
     }
 
-    // OBR16 - Ordering Provider
+    // OBR-16 - Ordering Provider
     public static void setOBR16WithPractitioner(
             Extension obrExtension, PractitionerRole practitionerRole) {
         if (practitionerRole == null || !practitionerRole.getPractitioner().hasReference()) {
@@ -578,11 +578,39 @@ public class HapiHelper {
             return null;
         }
 
-        if (obr16Extension.getValue() instanceof Reference reference) {
-            if (reference.getResource() instanceof Practitioner practitioner) {
-                return practitioner;
-            }
+        if (obr16Extension.getValue() instanceof Reference reference
+                && reference.getResource() instanceof Practitioner practitioner) {
+            return practitioner;
         }
+        return null;
+    }
+
+    // ORC-12 - Ordering Provider
+    public static Practitioner getOrc12ExtensionPractitioner(Bundle bundle) {
+        DiagnosticReport diagnosticReport = getDiagnosticReport(bundle);
+        if (diagnosticReport == null) return null;
+
+        ServiceRequest serviceRequest = getServiceRequest(diagnosticReport);
+        if (serviceRequest == null) return null;
+
+        Extension orcExtension = serviceRequest.getExtensionByUrl(EXTENSION_ORC_URL);
+        if (orcExtension == null) return null;
+
+        Extension orc12Extension = orcExtension.getExtensionByUrl(EXTENSION_ORC12_URL);
+        if (orc12Extension == null) return null;
+
+        Reference practitionerReference = (Reference) orc12Extension.getValue();
+        if (practitionerReference == null) return null;
+
+        String practitionerUrl = practitionerReference.getReference();
+        if (practitionerUrl == null) return null;
+
+        for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+            if (Objects.equals(entry.getFullUrl(), practitionerUrl)
+                    && entry.getResource() instanceof Practitioner practitioner)
+                return practitioner;
+        }
+
         return null;
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -268,6 +268,9 @@ public class HapiHelper {
             return null;
         }
         Organization organization = (Organization) identifier.getAssigner().getResource();
+        if (organization == null) {
+            return null;
+        }
         return organization.getIdentifierFirstRep();
     }
 
@@ -523,13 +526,16 @@ public class HapiHelper {
     }
 
     // OBR16 - Ordering Provider
-
-    // OBR16 -
     public static void setOBR16WithPractitioner(
-            Extension obr16Extension, PractitionerRole practitionerRole) {
-        if (practitionerRole == null) {
+            Extension obrExtension, PractitionerRole practitionerRole) {
+        if (practitionerRole == null || !practitionerRole.getPractitioner().hasReference()) {
             return;
         }
+
+        Extension obr16Extension =
+                HapiHelper.ensureSubExtensionExists(
+                        obrExtension, HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString());
+
         obr16Extension.setValue(practitionerRole.getPractitioner());
     }
 

--- a/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
+++ b/shared/src/main/java/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelper.java
@@ -334,6 +334,13 @@ public class HapiHelper {
     }
 
     public static void removePID5_7Value(Bundle bundle) {
+        Patient patient = HapiHelper.getPIDPatient(bundle);
+        if (patient == null) {
+            return;
+        }
+        HumanName patientName = patient.getNameFirstRep();
+        patientName.setUse(null);
+
         Extension pid5Extension = HapiHelper.getPID5Extension(bundle);
         if (pid5Extension == null) {
             return;
@@ -342,9 +349,6 @@ public class HapiHelper {
         if (xpn7Extension != null) {
             pid5Extension.removeExtension(HapiHelper.EXTENSION_XPN7_URL);
         }
-
-        HumanName patientName = HapiHelper.getPIDPatient(bundle).getNameFirstRep();
-        patientName.setUse(null);
     }
 
     // ORC - Common Order

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -477,6 +477,36 @@ class HapiHelperTest extends Specification {
         HapiFhirHelper.getPID3_5Value(bundle) == pid3_5
     }
 
+    // PID-3.5 - Removing Identifier Type Code
+    def "null patientIdentifier remains null"() {
+        when:
+        Identifier patientIdentfier = null
+        HapiHelper.removePID3_5Value(patientIdentfier)
+
+        then:
+        patientIdentifier == null
+    }
+
+    def "removing of the patient assigning identifier clears extensions and type coding"() {
+        given:
+        def pid3_5 = "pid3_5"
+        def bundle = new Bundle()
+        def patientIdentifier = new Identifier()
+
+        HapiFhirHelper.createPIDPatient(bundle)
+        HapiFhirHelper.setPID3Identifier(bundle, patientIdentifier)
+        HapiHelper.setPID3_5Value(bundle, pid3_5)
+
+        patientIdentifier.type.addCoding(new Coding(code: pid3_5))
+
+        when:
+        HapiHelper.removePID3_5Value(patientIdentifier)
+
+        then:
+        patientIdentifier.extension.isEmpty()
+        patientIdentifier.type.isEmpty()
+    }
+
     // PID-5 - Patient Name
     def "patient name methods work as expected"() {
         given:

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -523,6 +523,27 @@ class HapiHelperTest extends Specification {
         patientIdentifier.type.isEmpty()
     }
 
+    def "removing patient identifier with non-cx5 url extension doesnt clears extensions"() {
+        given:
+        def bundle = new Bundle()
+        def patientIdentifier = new Identifier()
+
+        HapiFhirHelper.createPIDPatient(bundle)
+        HapiFhirHelper.setPID3Identifier(bundle, patientIdentifier)
+        patientIdentifier.addExtension().setUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
+        patientIdentifier
+                .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
+                .addExtension()
+                .setUrl(HapiHelper.EXTENSION_XON10_URL);
+
+        when:
+        HapiHelper.removePID3_5Value(patientIdentifier)
+
+        then:
+        patientIdentifier.hasExtension()
+    }
+
+
     // PID-5 - Patient Name
     def "patient name methods work as expected"() {
         given:

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -479,12 +479,28 @@ class HapiHelperTest extends Specification {
 
     // PID-3.5 - Removing Identifier Type Code
     def "null patientIdentifier remains null"() {
-        when:
+        given:
         Identifier patientIdentifier = null
+
+        when:
         HapiHelper.removePID3_5Value(patientIdentifier)
 
         then:
         patientIdentifier == null
+    }
+
+    def "patientIdentifier with no extensions leaves extensions as-is"() {
+        given:
+        Identifier patientIdentifier = new Identifier()
+
+        expect:
+        !patientIdentifier.hasExtension()
+
+        when:
+        HapiHelper.removePID3_5Value(patientIdentifier)
+
+        then:
+        !patientIdentifier.hasExtension()
     }
 
     def "removing of the patient assigning identifier clears extensions and type coding"() {
@@ -560,6 +576,45 @@ class HapiHelperTest extends Specification {
         HapiHelper.getPID5Extension(bundle) != null
         HapiFhirHelper.getPID5_7Value(bundle) == null
     }
+
+    // PID-5.7 - Removing Name Type Code
+    def "bundle without patient remains empty"() {
+        given:
+        def bundle = new Bundle()
+
+        when:
+        HapiHelper.removePID5_7Value(bundle)
+
+        then:
+        bundle.getEntry().size() == 0
+    }
+
+    def "bundle with patient but no extensions remains empty"() {
+        given:
+        def bundle = new Bundle()
+        HapiFhirHelper.createPIDPatient(bundle)
+
+        when:
+        HapiHelper.removePID5_7Value(bundle)
+
+        then:
+        HapiHelper.getPID5Extension(bundle) == null
+    }
+
+    def "bundle with patient and pid5 extensions but no xpn7 extension remains empty"() {
+        given:
+        def bundle = new Bundle()
+        HapiFhirHelper.createPIDPatient(bundle)
+        HapiFhirHelper.setPID5Extension(bundle)
+
+        when:
+        HapiHelper.removePID5_7Value(bundle)
+
+        then:
+        Extension pid5Extension = HapiHelper.getPID5Extension(bundle)
+        !pid5Extension.hasExtension()
+    }
+
 
     // ORC-2 - Placer Order Number
     def "orc-2.1 methods work as expected"() {

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -430,30 +430,58 @@ class HapiHelperTest extends Specification {
     }
 
     // PID-3.4 - Assigning Authority
-    def "patient assigning authority methods work as expected"() {
+    def "getPID3_4Identifier returns null when bundle is empty"() {
         given:
-        def pid3_4 = "pid3_4"
-
-        when:
         def bundle = new Bundle()
 
-        then:
+        expect:
         HapiHelper.getPID3_4Identifier(bundle) == null
+    }
+
+    def "setPID3_4Value does not modify bundle without PID-3 identifier"() {
+        given:
+        def pid3_4Value = "pid3_4"
+        def bundle = new Bundle()
 
         when:
-        HapiHelper.setPID3_4Value(bundle, pid3_4)
+        HapiHelper.setPID3_4Value(bundle, pid3_4Value)
 
         then:
         HapiFhirHelper.getPID3_4Value(bundle) == null
+    }
 
-        when:
+    def "setPID3_4Value updates correctly when patient has a PID-3 identifier"() {
+        given:
+        def pid3_4Value = "pid3_4"
+        def bundle = new Bundle()
         HapiFhirHelper.createPIDPatient(bundle)
         HapiFhirHelper.setPID3Identifier(bundle, new Identifier())
         HapiFhirHelper.setPID3_4Identifier(bundle, new Identifier())
-        HapiHelper.setPID3_4Value(bundle, pid3_4)
+
+        when:
+        HapiHelper.setPID3_4Value(bundle, pid3_4Value)
 
         then:
-        HapiFhirHelper.getPID3_4Value(bundle) == pid3_4
+        HapiFhirHelper.getPID3_4Value(bundle) == pid3_4Value
+    }
+
+    def "setPID3_4Value updates correctly when patient has a PID-3 identifier and the new value is null"() {
+        given:
+        def bundle = new Bundle()
+        HapiFhirHelper.createPIDPatient(bundle)
+
+        def pid3Identifier = new Identifier()
+        HapiFhirHelper.setPID3Identifier(bundle, pid3Identifier)
+
+        def pid3_4Value = "pid3_4"
+        HapiFhirHelper.setPID3_4Identifier(bundle, new Identifier())
+        HapiHelper.setPID3_4Value(bundle, pid3_4Value)
+
+        when:
+        HapiHelper.setPID3_4Value(bundle, null)
+
+        then:
+        !pid3Identifier.hasAssigner()
     }
 
     // PID-3.5 - Assigning Identifier Type Code
@@ -478,26 +506,28 @@ class HapiHelperTest extends Specification {
     }
 
     // PID-3.5 - Removing Identifier Type Code
-    def "null patientIdentifier remains null"() {
+    def "Bundle with no patient identifier does not change"() {
         given:
-        Identifier patientIdentifier = null
+        Bundle bundle = new Bundle()
 
         when:
-        HapiHelper.removePID3_5Value(patientIdentifier)
+        HapiHelper.removePID3_5Value(bundle)
 
         then:
-        patientIdentifier == null
+        !bundle.hasEntry()
     }
 
     def "patientIdentifier with no extensions leaves extensions as-is"() {
         given:
+        Bundle bundle = new Bundle()
         Identifier patientIdentifier = new Identifier()
+        HapiFhirHelper.setPID3Identifier(bundle, patientIdentifier)
 
         expect:
         !patientIdentifier.hasExtension()
 
         when:
-        HapiHelper.removePID3_5Value(patientIdentifier)
+        HapiHelper.removePID3_5Value(bundle)
 
         then:
         !patientIdentifier.hasExtension()
@@ -516,14 +546,14 @@ class HapiHelperTest extends Specification {
         patientIdentifier.type.addCoding(new Coding(code: pid3_5))
 
         when:
-        HapiHelper.removePID3_5Value(patientIdentifier)
+        HapiHelper.removePID3_5Value(bundle)
 
         then:
         patientIdentifier.extension.isEmpty()
         patientIdentifier.type.isEmpty()
     }
 
-    def "removing patient identifier with non-cx5 url extension doesnt clears extensions"() {
+    def "removing patient identifier with non-cx5 url extension does not clear extensions"() {
         given:
         def bundle = new Bundle()
         def patientIdentifier = new Identifier()
@@ -537,7 +567,7 @@ class HapiHelperTest extends Specification {
                 .setUrl(HapiHelper.EXTENSION_XON10_URL);
 
         when:
-        HapiHelper.removePID3_5Value(patientIdentifier)
+        HapiHelper.removePID3_5Value(bundle)
 
         then:
         patientIdentifier.hasExtension()

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -561,11 +561,11 @@ class HapiHelperTest extends Specification {
 
         HapiFhirHelper.createPIDPatient(bundle)
         HapiFhirHelper.setPID3Identifier(bundle, patientIdentifier)
-        patientIdentifier.addExtension().setUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL);
+        patientIdentifier.addExtension().setUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
         patientIdentifier
                 .getExtensionByUrl(HapiHelper.EXTENSION_CX_IDENTIFIER_URL)
                 .addExtension()
-                .setUrl(HapiHelper.EXTENSION_XON10_URL);
+                .setUrl(HapiHelper.EXTENSION_XON10_URL)
 
         when:
         HapiHelper.removePID3_5Value(bundle)

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -879,6 +879,86 @@ class HapiHelperTest extends Specification {
         result == null
     }
 
+    def "getObr16ExtensionPractitioner should return null when ServiceRequest has no OBR-16 extension"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+
+        when:
+        def result = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
+
+        then:
+        result == null
+    }
+
+    def "getObr16ExtensionPractitioner should return null when OBR-16 extension value is null"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = new Extension(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obrExtension.addExtension(obr16Extension)
+        serviceRequest.addExtension(obrExtension)
+
+        when:
+        def result = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
+
+        then:
+        result == null
+    }
+
+    def "getObr16ExtensionPractitioner should return null when OBR16 extension value is not a Reference"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = new Extension(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obr16Extension.setValue(new StringType("Not a Reference"))
+        obrExtension.addExtension(obr16Extension)
+        serviceRequest.addExtension(obrExtension)
+
+        when:
+        def result = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
+
+        then:
+        result == null
+    }
+
+    def "getObr16ExtensionPractitioner should return null when Reference does not contain Practitioner"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def reference = new Reference()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = new Extension(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obr16Extension.setValue(reference)
+        obrExtension.addExtension(obr16Extension)
+        serviceRequest.addExtension(obrExtension)
+
+        when:
+        def result = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
+
+        then:
+        result == null
+    }
+
+    def "getObr16ExtensionPractitioner should return Practitioner when Reference contains Practitioner"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = new Extension(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obrExtension.addExtension(obr16Extension)
+        serviceRequest.addExtension(obrExtension)
+
+        def practitioner = new Practitioner()
+        def practitionerRole = new PractitionerRole()
+        practitionerRole.setPractitioner(new Reference("Practitioner/123").setResource(practitioner) as Reference)
+
+        HapiHelper.setOBR16WithPractitioner(obrExtension, practitionerRole)
+
+        when:
+        def result = HapiHelper.getObr16ExtensionPractitioner(serviceRequest)
+
+        then:
+        result == practitioner
+    }
+
     def "ensureExtensionExists returns extension if it exists"() {
         given:
         def serviceRequest = new ServiceRequest()

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -839,6 +839,46 @@ class HapiHelperTest extends Specification {
         HapiHelper.getOBR4_1Value(sr) == null
     }
 
+    // OBR-16 - Ordering Provider
+    def "getObr16Extension returns the extension if present"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        def obr16Extension = new Extension(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obrExtension.addExtension(obr16Extension)
+        serviceRequest.addExtension(obrExtension)
+
+        when:
+        def result = HapiHelper.getObr16Extension(serviceRequest)
+
+        then:
+        result == obr16Extension
+    }
+
+    def "getObr16Extension returns null when no OBR extension is present"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+
+        when:
+        def result = HapiHelper.getObr16Extension(serviceRequest)
+
+        then:
+        result == null
+    }
+
+    def "getObr16Extension returns null when OBR extension does not contain OBR-16"() {
+        given:
+        def serviceRequest = new ServiceRequest()
+        def obrExtension = new Extension(HapiHelper.EXTENSION_OBR_URL)
+        serviceRequest.addExtension(obrExtension)
+
+        when:
+        def result = HapiHelper.getObr16Extension(serviceRequest)
+
+        then:
+        result == null
+    }
+
     def "ensureExtensionExists returns extension if it exists"() {
         given:
         def serviceRequest = new ServiceRequest()

--- a/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
+++ b/shared/src/test/groovy/gov/hhs/cdc/trustedintermediary/external/hapi/HapiHelperTest.groovy
@@ -480,8 +480,8 @@ class HapiHelperTest extends Specification {
     // PID-3.5 - Removing Identifier Type Code
     def "null patientIdentifier remains null"() {
         when:
-        Identifier patientIdentfier = null
-        HapiHelper.removePID3_5Value(patientIdentfier)
+        Identifier patientIdentifier = null
+        HapiHelper.removePID3_5Value(patientIdentifier)
 
         then:
         patientIdentifier == null
@@ -893,21 +893,19 @@ class HapiHelperTest extends Specification {
 
     def "setOBR16WithPractitioner sets the expected value on an extension"() {
         given:
-        def ext = new Extension()
+        Extension obrExtension = new Extension()
         def role = new PractitionerRole()
         def practitioner = new Practitioner()
         practitioner.setId("test123")
         def ref = new Reference(practitioner.getId())
         role.setPractitioner(ref)
 
-        expect:
-        ext.getValue() == null
-
         when:
-        HapiHelper.setOBR16WithPractitioner(ext, role)
+        HapiHelper.setOBR16WithPractitioner(obrExtension, role)
 
         then:
-        ext.getValue().getReference() == "test123"
+        def obr16Extension = obrExtension.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obr16Extension.getValue().getReference() == "test123"
     }
 
     def "setOBR16WithPractitioner does nothing if the provided PractitionerRole is null"() {
@@ -922,7 +920,8 @@ class HapiHelperTest extends Specification {
         HapiHelper.setOBR16WithPractitioner(ext, role)
 
         then:
-        ext.getValue() == null
+        def obr16Extension = ext.getExtensionByUrl(HapiHelper.EXTENSION_OBR16_DATA_TYPE.toString())
+        obr16Extension == null
     }
 
     def "urlForCodeType should return expected values"() {


### PR DESCRIPTION
# Description

This PR updates and/or removes unnecessary fields in our FHIR mappings that were causing warnings when sending messages.

_Note: this is a replacement of PR #1656, which had unsigned commits in the branch._

## Issue
#940 

When an extension contains a URL but no value of any type, the message "Resource is missing required element: value" is printed in the log.

There were 3 "value-less" extensions remaining that were producing these warnings.

1. Patient identifier type code `CX-5` (`PID-3.5` in the v2 message) - transform: `RemovePatientIdentifiers`
2. Patient name type code `XPN-7` (`PID-5.7` in the v2 message) - transform: `RemovePatientNameTypeCode`
3. Observation request `OBR-16` (occurs only when `ORC-12` is blank - transform: `CopyOrcOrderProviderToObrOrderProvider`

This PR ensures that the "value-less" extensions do not get added during the TI transforms and does some additional cleanup of the transform output to ensure that the values being cleared by the transforms no longer exist in other places in the affected resource.

See the [Areas of Concern comment in the issue](https://github.com/CDCgov/trusted-intermediary/issues/940#issuecomment-2518611083) for more details.

## Testing instructions

- Run a sample CA message with empty `ORC-12` and `OBR-16` through RS and TI end to end (such as CA examples 7, 19, or 20). Review the transformed fhir and final HL7.
- The transformed fhir should have no extensions without a value (specifically `CX.5`, `XPN.7`, and `OBR.16`)
- There should be no change in the final HL7



## Checklist

- [x] I have added tests to cover my changes
