### PR TITLE
Fix for ZAP scan warning: `Insufficient Site Isolation Against Spectre Vulnerability`

### DIFF
--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -33,7 +33,6 @@ import gov.hhs.cdc.trustedintermediary.wrappers.database.ConnectionPool;
 import gov.hhs.cdc.trustedintermediary.wrappers.database.DatabaseCredentialsProvider;
 import gov.hhs.cdc.trustedintermediary.wrappers.formatter.Formatter;
 import io.javalin.Javalin;
-import io.javalin.plugin.bundled.CorsPluginConfig;
 import java.util.Set;
 
 /** Creates the starting point of our API. Handles the registration of the domains. */
@@ -50,7 +49,11 @@ public class App {
                                     config.http.maxRequestSize = MAX_REQUEST_SIZE;
                                     config.bundledPlugins.enableCors(
                                             cors -> {
-                                                cors.addRule(CorsPluginConfig.CorsRule::anyHost);
+                                                cors.addRule(
+                                                        it -> {
+                                                            it.allowCredentials = true;
+                                                            it.anyHost();
+                                                        });
                                             });
                                 })
                         .start(PORT);

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -53,6 +53,7 @@ public class App {
                     ctx.header("X-Content-Type-Options", "nosniff");
                     // Fix for https://www.zaproxy.org/docs/alerts/90004
                     ctx.header("Cross-Origin-Opener-Policy", "same-origin");
+                    ctx.header("Cross-Origin-Embedder-Policy", "require-corp");
                 });
 
         try {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -52,8 +52,7 @@ public class App {
                 ctx -> {
                     ctx.header("X-Content-Type-Options", "nosniff");
                     // Fix for https://www.zaproxy.org/docs/alerts/90004
-                    ctx.header("Cross-Origin-Opener-Policy", "same-origin");
-                    ctx.header("Cross-Origin-Embedder-Policy", "require-corp");
+                    ctx.header("Cross-Origin-Resource-Policy", "cross-origin");
                 });
 
         try {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -52,6 +52,7 @@ public class App {
                 ctx -> {
                     ctx.header("X-Content-Type-Options", "nosniff");
                     // Fix for https://www.zaproxy.org/docs/alerts/90004
+                    ctx.header("Cross-Origin-Resource-Policy", "same-origin");
                 });
 
         try {

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -44,22 +44,16 @@ public class App {
 
     public static void main(String[] args) {
         var app =
-                Javalin.create(
-                                config -> {
-                                    config.http.maxRequestSize = MAX_REQUEST_SIZE;
-                                    config.bundledPlugins.enableCors(
-                                            cors -> {
-                                                cors.addRule(
-                                                        it -> {
-                                                            it.allowHost("localhost");
-                                                        });
-                                            });
-                                })
-                        .start(PORT);
+                Javalin.create(config -> config.http.maxRequestSize = MAX_REQUEST_SIZE).start(PORT);
 
         // apply this security header to all responses, but allow it to be overwritten by a specific
         // endpoint by using `before` if needed
-        app.before(ctx -> ctx.header("X-Content-Type-Options", "nosniff"));
+        app.before(
+                ctx -> {
+                    ctx.header("X-Content-Type-Options", "nosniff");
+                    // Fix for https://www.zaproxy.org/docs/alerts/90004
+                    ctx.header("Cross-Origin-Opener-Policy", "same-origin");
+                });
 
         try {
             app.get(HEALTH_API_ENDPOINT, ctx -> ctx.result("Operational"));

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -48,7 +48,14 @@ public class App {
 
         // apply this security header to all responses, but allow it to be overwritten by a specific
         // endpoint by using `before` if needed
-        app.before(ctx -> ctx.header("X-Content-Type-Options", "nosniff"));
+        app.before(
+                ctx -> {
+                    ctx.header("X-Content-Type-Options", "nosniff");
+                    // Fix for https://www.zaproxy.org/docs/alerts/90004
+                    ctx.header("Cross-Origin-Resource-Policy", "same-origin");
+                    ctx.header("Cross-Origin-Opener-Policy", "same-origin");
+                    ctx.header("Cross-Origin-Embedder-Policy", "require-corp");
+                });
 
         try {
             app.get(HEALTH_API_ENDPOINT, ctx -> ctx.result("Operational"));

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -52,7 +52,9 @@ public class App {
                                                 cors.addRule(
                                                         it -> {
                                                             it.allowCredentials = true;
-                                                            it.anyHost();
+                                                            it.allowHost("http://localhost:8080");
+                                                            it.allowHost("http://127.0.0.1:8080");
+                                                            it.allowHost("http://172.17.0.1:8080");
                                                         });
                                             });
                                 })

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -51,10 +51,7 @@ public class App {
                                             cors -> {
                                                 cors.addRule(
                                                         it -> {
-                                                            it.allowCredentials = true;
-                                                            it.allowHost("http://localhost:8080");
-                                                            it.allowHost("http://127.0.0.1:8080");
-                                                            it.allowHost("http://172.17.0.1:8080");
+                                                            it.allowHost("localhost");
                                                         });
                                             });
                                 })

--- a/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
+++ b/app/src/main/java/gov/hhs/cdc/trustedintermediary/external/javalin/App.java
@@ -52,9 +52,6 @@ public class App {
                 ctx -> {
                     ctx.header("X-Content-Type-Options", "nosniff");
                     // Fix for https://www.zaproxy.org/docs/alerts/90004
-                    ctx.header("Cross-Origin-Resource-Policy", "same-origin");
-                    ctx.header("Cross-Origin-Opener-Policy", "same-origin");
-                    ctx.header("Cross-Origin-Embedder-Policy", "require-corp");
                 });
 
         try {


### PR DESCRIPTION
# Description

This is a fix for the following ZAP scan warning:
```
WARN-NEW: Insufficient Site Isolation Against Spectre Vulnerability [90004] x 1 
```

We've been getting this warning consistently for the past few days, which is making the ZAP Api Scan action fail and blocking PRs from being merged
