### PR TITLE
Set-up Terraform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           distribution: corretto
           cache: gradle
 
+      - uses: hashicorp/setup-terraform@v3
+
       - name: Code Formatting
         run: ./gradlew spotlessCheck
 

--- a/.github/workflows/db_rollback.yml
+++ b/.github/workflows/db_rollback.yml
@@ -41,6 +41,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: hashicorp/setup-terraform@v3
+
       - name: Terraform Init
         id: init
         run: |

--- a/.github/workflows/terraform-ci-destroy.yml
+++ b/.github/workflows/terraform-ci-destroy.yml
@@ -49,6 +49,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: hashicorp/setup-terraform@v3
+
       - name: Terraform Init
         run: terraform init -backend-config="key=pr_${{ github.event.number }}.tfstate"
 

--- a/.github/workflows/terraform-deploy_reusable.yml
+++ b/.github/workflows/terraform-deploy_reusable.yml
@@ -64,6 +64,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: hashicorp/setup-terraform@v3
+
       - name: Terraform Init
         id: init
         run: terraform init ${{ inputs.TERRAFORM_INIT_PARAMETERS }}


### PR DESCRIPTION
# Description

You may start noticing that `terraform` commands start failing in your GitHub Actions because `terraform` isn't found.  This is expected if you are using the `ubuntu-latest` runner.  The latest Ubuntu that `ubuntu-latest` points to was updated in December 2024 and is slowly rolling out across GitHub.  One of the changes is `terraform` is no longer installed by default.

This PR fixes this by installing Terraform.

## Issue

_None_.
