### PR TITLE
Load Testing Doesn't Like Spaces

### DIFF
--- a/.github/workflows/azure-load-tests.yml
+++ b/.github/workflows/azure-load-tests.yml
@@ -42,5 +42,5 @@ jobs:
             --resource-group "csels-rsti-internal-moderate-rg" \
             --load-test-resource "load-testing-internal" \
             --test-id "47a5e722-d63b-4ec9-8b05-17372866f00a" \
-            --test-run-id "run_"`date +"%Y%m%d%_H%M%S"` \
+            --test-run-id "run_"`date +"%Y%m%d%H%M%S"` \
             --description "Run by Github Action"

--- a/.github/workflows/azure-load-tests.yml
+++ b/.github/workflows/azure-load-tests.yml
@@ -42,5 +42,5 @@ jobs:
             --resource-group "csels-rsti-internal-moderate-rg" \
             --load-test-resource "load-testing-internal" \
             --test-id "47a5e722-d63b-4ec9-8b05-17372866f00a" \
-            --test-run-id "run_"`date +"%Y%m%d%H%M%S"` \
+            --test-run-id "run_"`date +"%Y%m%d_%H%M%S"` \
             --description "Run by Github Action"


### PR DESCRIPTION
# Description

The `test-run-id` argument when running the load tests could sometimes have spaces before the hour if the hour was less than 10.  This extra space made the `az` CLI command think there was an extra argument that it didn't know what to do with, so it failed.

The `test-run-id` will now always have an underscore between the date and time and no spaces as padding if the hour is less than 10.

## Issue

#1122.

## Checklist

- [x] [Tested](https://github.com/CDCgov/trusted-intermediary/actions/runs/12773916942) that this works with an underscore.